### PR TITLE
Switch macro engine to AutoHotKey

### DIFF
--- a/Borealis.ps1
+++ b/Borealis.ps1
@@ -418,6 +418,9 @@ switch ($choice) {
                 New-Item -Path $agentDestinationFolder -ItemType Directory -Force | Out-Null
                 Copy-Item $agentSourcePath $agentDestinationFile -Force
                 Copy-Item "Data\Agent\Python_API_Endpoints" $agentDestinationFolder -Recurse
+                if (Test-Path "Dependencies\AutoHotKey") {
+                    Copy-Item "Dependencies\AutoHotKey" $agentDestinationFolder -Recurse
+                }
             }
             . "$venvFolder\Scripts\Activate"
         }

--- a/Borealis.sh
+++ b/Borealis.sh
@@ -169,6 +169,10 @@ launch_agent() {
     run_step "Copy Agent Script" bash -c "
         mkdir -p '${agentDestinationFolder}'
         cp '${agentSourcePath}' '${agentDestinationFolder}/'
+        cp -r 'Data/Agent/Python_API_Endpoints' '${agentDestinationFolder}/'
+        if [ -d 'Dependencies/AutoHotKey' ]; then
+            cp -r 'Dependencies/AutoHotKey' '${agentDestinationFolder}/'
+        fi
     "
 
     echo -e "\n${GREEN}Launching Borealis Agent...${RESET}"

--- a/Data/Agent/Python_API_Endpoints/macro_engines.py
+++ b/Data/Agent/Python_API_Endpoints/macro_engines.py
@@ -1,55 +1,66 @@
 #////////// PROJECT FILE SEPARATION LINE ////////// CODE AFTER THIS LINE ARE FROM: <ProjectRoot>/Data/Agent/Python_API_Endpoints/macro_engines.py
+import os
 import platform
 
-if platform.system().lower().startswith('win'):
-    # pywinauto is only available/supported on Windows
+if platform.system().lower().startswith("win"):
     try:
-        from pywinauto import Desktop, Application
-    except ImportError:
-        Desktop = None
-        Application = None
-        print("[macro_engines] pywinauto not installed!")
+        from ahk import AHK
+    except Exception:
+        AHK = None
+        ahk = None
+    else:
+        _script_dir = os.path.dirname(os.path.abspath(__file__))
+        _ahk_exe = os.path.join(_script_dir, "..", "AutoHotKey", "AutoHotkey64.exe")
+        ahk = AHK(executable_path=_ahk_exe) if os.path.isfile(_ahk_exe) else None
+        if ahk is None:
+            print(f"[macro_engines] AutoHotKey binary not found at: {_ahk_exe}")
 else:
-    Desktop = None
-    Application = None
+    AHK = None
+    ahk = None
 
 def list_windows():
-    """List all visible windows with titles (for dropdown in UI)."""
-    if Desktop is None:
+    """List all visible windows with titles."""
+    if ahk is None:
         return []
     windows = []
-    for w in Desktop(backend="uia").windows():
-        try:
-            title = w.window_text()
-            handle = w.handle
-            if title.strip():
-                windows.append({"title": title, "handle": handle})
-        except Exception:
-            continue
+    try:
+        for win in ahk.windows():
+            title = getattr(win, "title", "")
+            handle = getattr(win, "id", None)
+            if title and str(title).strip():
+                windows.append({"title": title, "handle": int(handle)})
+    except Exception:
+        pass
     return windows
+
+def _get_window(handle):
+    if ahk is None:
+        raise RuntimeError("Macro engine not supported on this OS")
+    try:
+        return ahk.win_get(id=int(handle))
+    except Exception:
+        return None
 
 def send_keypress_to_window(handle, key):
     """Send a single keypress to the specified window handle."""
-    if Application is None:
-        raise RuntimeError("Macro engine not supported on this OS")
+    win = _get_window(handle)
+    if win is None:
+        return False, "Window not found"
     try:
-        app = Application(backend="uia").connect(handle=handle)
-        win = app.window(handle=handle)
-        win.set_focus()  # pywinauto still needs focus for most key sends
-        win.type_keys(key, with_spaces=True, set_foreground=True)
+        win.activate()
+        win.send(key)
         return True
     except Exception as e:
         return False, str(e)
 
 def type_text_to_window(handle, text):
-    """Type a string into the window (as if pasted or typed)."""
-    if Application is None:
-        raise RuntimeError("Macro engine not supported on this OS")
+    """Type a string into the window."""
+    win = _get_window(handle)
+    if win is None:
+        return False, "Window not found"
     try:
-        app = Application(backend="uia").connect(handle=handle)
-        win = app.window(handle=handle)
-        win.set_focus()
-        win.type_keys(text, with_spaces=True, set_foreground=True)
+        win.activate()
+        win.send(text)
         return True
     except Exception as e:
         return False, str(e)

--- a/Data/Agent/agent-requirements.txt
+++ b/Data/Agent/agent-requirements.txt
@@ -20,4 +20,4 @@ Pillow                 # Image processing (Windows)
 ###av                     # Required by aiortc for video/audio codecs
 
 # Macro Automation
-pywinauto # Windows-based Macro Automation Library
+ahk # AutoHotKey

--- a/Data/Server/WebUI/src/nodes/Agent Roles/Node_Agent_Role_Macro.jsx
+++ b/Data/Server/WebUI/src/nodes/Agent Roles/Node_Agent_Role_Macro.jsx
@@ -268,7 +268,7 @@ export default {
 Send automated key presses or typed text to any open application window on the connected agent.
 Supports manual, continuous, trigger, and one-shot modes for automation and event-driven workflows.
 `,
-  content: "Send Key Press or Typed Text to Window via Agent",
+  content: "Send Key Press or Typed Text to Window via Agent (AutoHotKey)",
   component: MacroKeyPressNode,
   config: [
     { key: "window_handle", label: "Target Window", type: "select", dynamicOptions: true, defaultValue: "" },


### PR DESCRIPTION
## Summary
- replace PyWinAuto macro engine with AutoHotKey
- update agent requirements
- copy AutoHotKey binaries when launching agent
- mention AutoHotKey in macro role UI

## Testing
- `python3 -m py_compile Data/Agent/borealis-agent.py Data/Agent/Python_API_Endpoints/macro_engines.py`

------
https://chatgpt.com/codex/tasks/task_e_685b81b94b4c832f81619828360e405f