### PR TITLE
fix: decouple navigation from global timer

### DIFF
--- a/Data/Server/WebUI/src/Navigation_Sidebar.jsx
+++ b/Data/Server/WebUI/src/Navigation_Sidebar.jsx
@@ -21,7 +21,7 @@ import {
   PeopleOutline as CommunityIcon
 } from "@mui/icons-material";
 
-export default function NavigationSidebar({ currentPage, onNavigate }) {
+function NavigationSidebar({ currentPage, onNavigate }) {
   const [expandedNav, setExpandedNav] = useState({
     devices: true,
     filters: true,
@@ -141,3 +141,5 @@ export default function NavigationSidebar({ currentPage, onNavigate }) {
     </Box>
   );
 }
+
+export default React.memo(NavigationSidebar);


### PR DESCRIPTION
## Summary
- prevent NavigationSidebar from rerendering on global timer ticks using React.memo

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898159e4a00832f96c2571e74a8ea53