### PR TITLE
Enable workflow import/export and rename

### DIFF
--- a/Data/Server/WebUI/src/App.jsx
+++ b/Data/Server/WebUI/src/App.jsx
@@ -175,6 +175,86 @@ export default function App() {
     setRenameDialogOpen(false);
   };
 
+  const handleExportFlow = useCallback(() => {
+    const tab = tabs.find((t) => t.id === activeTabId);
+    if (!tab) return;
+    const payload = {
+      tab_name: tab.tab_name,
+      nodes: tab.nodes,
+      edges: tab.edges
+    };
+    const fileName = `${tab.tab_name || "workflow"}.json`;
+    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = fileName;
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [tabs, activeTabId]);
+
+  const handleImportFlow = useCallback(() => {
+    if (fileInputRef.current) {
+      fileInputRef.current.value = null;
+      fileInputRef.current.click();
+    }
+  }, []);
+
+  const onFileInputChange = useCallback(
+    (e) => {
+      const file = e.target.files && e.target.files[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = () => {
+        try {
+          const data = JSON.parse(reader.result);
+          const newId = "flow_" + Date.now();
+          setTabs((prev) => [
+            ...prev,
+            {
+              id: newId,
+              tab_name:
+                data.tab_name || data.name || file.name.replace(/\.json$/i, ""),
+              nodes: data.nodes || [],
+              edges: data.edges || []
+            }
+          ]);
+          setActiveTabId(newId);
+          setCurrentPage("workflow-editor");
+        } catch (err) {
+          console.error("Failed to import workflow:", err);
+        }
+      };
+      reader.readAsText(file);
+      e.target.value = "";
+    },
+    [setTabs]
+  );
+
+  const handleSaveFlow = useCallback(async () => {
+    const tab = tabs.find((t) => t.id === activeTabId);
+    if (!tab) return;
+    const name = window.prompt("Enter workflow name", tab.tab_name || "workflow");
+    if (!name) return;
+    const payload = {
+      name,
+      workflow: {
+        tab_name: tab.tab_name,
+        nodes: tab.nodes,
+        edges: tab.edges
+      }
+    };
+    try {
+      await fetch("/api/storage/save_workflow", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload)
+      });
+    } catch (err) {
+      console.error("Failed to save workflow:", err);
+    }
+  }, [tabs, activeTabId]);
+
   const renderMainContent = () => {
     switch (currentPage) {
       case "devices":
@@ -230,11 +310,12 @@ export default function App() {
             <Box sx={{ display: "flex", flexGrow: 1, overflow: "hidden" }}>
               <NodeSidebar
                 categorizedNodes={categorizedNodes}
-                handleExportFlow={() => {}}
-                handleImportFlow={() => {}}
-                handleOpenCloseAllDialog={() => {}}
+                handleExportFlow={handleExportFlow}
+                handleImportFlow={handleImportFlow}
+                handleSaveFlow={handleSaveFlow}
+                handleOpenCloseAllDialog={() => setConfirmCloseOpen(true)}
                 fileInputRef={fileInputRef}
-                onFileInputChange={() => {}}
+                onFileInputChange={onFileInputChange}
               />
               <Box sx={{ display: "flex", flexDirection: "column", flexGrow: 1, overflow: "hidden" }}>
                 <FlowTabs

--- a/Data/Server/WebUI/src/Dialogs.jsx
+++ b/Data/Server/WebUI/src/Dialogs.jsx
@@ -95,6 +95,43 @@ export function RenameTabDialog({ open, value, onChange, onCancel, onSave }) {
   );
 }
 
+export function RenameWorkflowDialog({ open, value, onChange, onCancel, onSave }) {
+  return (
+    <Dialog open={open} onClose={onCancel} PaperProps={{ sx: { bgcolor: "#121212", color: "#fff" } }}>
+      <DialogTitle>Rename Workflow</DialogTitle>
+      <DialogContent>
+        <TextField
+          autoFocus
+          margin="dense"
+          label="Workflow Name"
+          fullWidth
+          variant="outlined"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          sx={{
+            "& .MuiOutlinedInput-root": {
+              backgroundColor: "#2a2a2a",
+              color: "#ccc",
+              "& fieldset": {
+                borderColor: "#444"
+              },
+              "&:hover fieldset": {
+                borderColor: "#666"
+              }
+            },
+            label: { color: "#aaa" },
+            mt: 1
+          }}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onCancel} sx={{ color: "#58a6ff" }}>Cancel</Button>
+        <Button onClick={onSave} sx={{ color: "#58a6ff" }}>Save</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
 export function DeleteDeviceDialog({ open, onCancel, onConfirm }) {
   return (
     <Dialog open={open} onClose={onCancel} PaperProps={{ sx: { bgcolor: "#121212", color: "#fff" } }}>

--- a/Data/Server/WebUI/src/Node_Sidebar.jsx
+++ b/Data/Server/WebUI/src/Node_Sidebar.jsx
@@ -12,6 +12,7 @@ import {
 } from "@mui/material";
 import {
   ExpandMore as ExpandMoreIcon,
+  SaveAlt as SaveAltIcon,
   Save as SaveIcon,
   FileOpen as FileOpenIcon,
   DeleteForever as DeleteForeverIcon,
@@ -25,6 +26,7 @@ export default function NodeSidebar({
   categorizedNodes,
   handleExportFlow,
   handleImportFlow,
+  handleSaveFlow,
   handleOpenCloseAllDialog,
   fileInputRef,
   onFileInputChange
@@ -72,8 +74,13 @@ export default function NodeSidebar({
               </AccordionSummary>
               <AccordionDetails sx={{ p: 0, bgcolor: "#232323" }}>
                 <Tooltip title="Export Current Tab to a JSON File" placement="right" arrow>
-                  <Button fullWidth startIcon={<SaveIcon />} onClick={handleExportFlow} sx={buttonStyle}>
+                  <Button fullWidth startIcon={<SaveAltIcon />} onClick={handleExportFlow} sx={buttonStyle}>
                     Export Current Flow
+                  </Button>
+                </Tooltip>
+                <Tooltip title="Save Current Flow to Workflows Folder" placement="right" arrow>
+                  <Button fullWidth startIcon={<SaveIcon />} onClick={handleSaveFlow} sx={buttonStyle}>
+                    Save Workflow
                   </Button>
                 </Tooltip>
                 <Tooltip title="Import JSON File into New Flow Tab" placement="right" arrow>

--- a/Data/Server/WebUI/src/Workflow_List.jsx
+++ b/Data/Server/WebUI/src/Workflow_List.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useEffect } from "react";
+import React, { useState, useMemo, useEffect, useCallback } from "react";
 import {
   Paper,
   Box,
@@ -9,9 +9,13 @@ import {
   TableCell,
   TableHead,
   TableRow,
-  TableSortLabel
+  TableSortLabel,
+  IconButton,
+  Menu,
+  MenuItem
 } from "@mui/material";
-import { PlayCircle as PlayCircleIcon } from "@mui/icons-material";
+import { PlayCircle as PlayCircleIcon, MoreVert as MoreVertIcon } from "@mui/icons-material";
+import { RenameWorkflowDialog } from "./Dialogs";
 
 function formatDateTime(dateString) {
   if (!dateString) return "";
@@ -31,34 +35,34 @@ export default function WorkflowList({ onOpenWorkflow }) {
   const [rows, setRows] = useState([]);
   const [orderBy, setOrderBy] = useState("name");
   const [order, setOrder] = useState("asc");
+  const [menuAnchor, setMenuAnchor] = useState(null);
+  const [selected, setSelected] = useState(null);
+  const [renameOpen, setRenameOpen] = useState(false);
+  const [renameValue, setRenameValue] = useState("");
+
+  const loadRows = useCallback(async () => {
+    try {
+      const resp = await fetch("/api/storage/load_workflows");
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      const data = await resp.json();
+      const mapped = (data.workflows || []).map((w) => ({
+        ...w,
+        name: w.tab_name && w.tab_name.trim() ? w.tab_name.trim() : w.file_name,
+        description: "",
+        category: "",
+        lastEdited: w.last_edited,
+        lastEditedEpoch: w.last_edited_epoch
+      }));
+      setRows(mapped);
+    } catch (err) {
+      console.error("Failed to load workflows:", err);
+      setRows([]);
+    }
+  }, []);
 
   useEffect(() => {
-    let alive = true;
-    (async () => {
-      try {
-        const resp = await fetch("/api/storage/load_workflows");
-        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-        const data = await resp.json();
-        if (!alive) return;
-
-        const mapped = (data.workflows || []).map(w => ({
-          ...w,
-          name: w.tab_name && w.tab_name.trim() ? w.tab_name.trim() : w.file_name,
-          description: "",
-          category: "",
-          lastEdited: w.last_edited,
-          lastEditedEpoch: w.last_edited_epoch
-        }));
-        setRows(mapped);
-      } catch (err) {
-        console.error("Failed to load workflows:", err);
-        setRows([]);
-      }
-    })();
-    return () => {
-      alive = false;
-    };
-  }, []);
+    loadRows();
+  }, [loadRows]);
 
   const handleSort = (col) => {
     if (orderBy === col) setOrder(order === "asc" ? "desc" : "asc");
@@ -92,6 +96,41 @@ export default function WorkflowList({ onOpenWorkflow }) {
     if (onOpenWorkflow) {
       onOpenWorkflow(workflow);
     }
+  };
+
+  const openMenu = (e, row) => {
+    e.stopPropagation();
+    setMenuAnchor(e.currentTarget);
+    setSelected(row);
+  };
+
+  const closeMenu = () => setMenuAnchor(null);
+
+  const startRename = () => {
+    closeMenu();
+    if (selected) {
+      const initial = selected.tab_name && selected.tab_name.trim().length > 0
+        ? selected.tab_name.trim()
+        : selected.file_name.replace(/\.json$/i, "");
+      setRenameValue(initial);
+      setRenameOpen(true);
+    }
+  };
+
+  const handleRenameSave = async () => {
+    if (!selected) return;
+    try {
+      await fetch("/api/storage/rename_workflow", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ path: selected.rel_path, new_name: renameValue })
+      });
+      await loadRows();
+    } catch (err) {
+      console.error("Failed to rename workflow:", err);
+    }
+    setRenameOpen(false);
+    setSelected(null);
   };
 
   const renderNameCell = (r) => {
@@ -179,6 +218,7 @@ export default function WorkflowList({ onOpenWorkflow }) {
                 Last Edited
               </TableSortLabel>
             </TableCell>
+            <TableCell />
           </TableRow>
         </TableHead>
         <TableBody>
@@ -193,17 +233,41 @@ export default function WorkflowList({ onOpenWorkflow }) {
               <TableCell>{r.description}</TableCell>
               <TableCell>{r.category}</TableCell>
               <TableCell>{formatDateTime(r.lastEdited)}</TableCell>
+              <TableCell align="right" onClick={(e) => e.stopPropagation()}>
+                <IconButton
+                  size="small"
+                  onClick={(e) => openMenu(e, r)}
+                  sx={{ color: "#ccc" }}
+                >
+                  <MoreVertIcon fontSize="small" />
+                </IconButton>
+              </TableCell>
             </TableRow>
           ))}
           {sorted.length === 0 && (
             <TableRow>
-              <TableCell colSpan={4} sx={{ color: "#888" }}>
+              <TableCell colSpan={5} sx={{ color: "#888" }}>
                 No workflows found.
               </TableCell>
             </TableRow>
           )}
         </TableBody>
       </Table>
+      <Menu
+        anchorEl={menuAnchor}
+        open={Boolean(menuAnchor)}
+        onClose={closeMenu}
+        PaperProps={{ sx: { bgcolor: "#1e1e1e", color: "#fff", fontSize: "13px" } }}
+      >
+        <MenuItem onClick={startRename}>Rename</MenuItem>
+      </Menu>
+      <RenameWorkflowDialog
+        open={renameOpen}
+        value={renameValue}
+        onChange={setRenameValue}
+        onCancel={() => setRenameOpen(false)}
+        onSave={handleRenameSave}
+      />
     </Paper>
   );
 }

--- a/Data/Server/server.py
+++ b/Data/Server/server.py
@@ -186,6 +186,63 @@ def load_workflow():
     obj = _safe_read_json(abs_path)
     return jsonify(obj)
 
+
+@app.route("/api/storage/save_workflow", methods=["POST"])
+def save_workflow():
+    data = request.get_json(silent=True) or {}
+    name = (data.get("name") or "").strip()
+    workflow = data.get("workflow")
+    if not name or not isinstance(workflow, dict):
+        return jsonify({"error": "Invalid payload"}), 400
+
+    if not name.lower().endswith(".json"):
+        name += ".json"
+    workflows_root = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "Workflows")
+    )
+    os.makedirs(workflows_root, exist_ok=True)
+    safe_name = os.path.basename(name)
+    abs_path = os.path.join(workflows_root, safe_name)
+    try:
+        with open(abs_path, "w", encoding="utf-8") as fh:
+            json.dump(workflow, fh, indent=2)
+        return jsonify({"status": "ok", "file_name": safe_name})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@app.route("/api/storage/rename_workflow", methods=["POST"])
+def rename_workflow():
+    data = request.get_json(silent=True) or {}
+    rel_path = (data.get("path") or "").strip()
+    new_name = (data.get("new_name") or "").strip()
+    workflows_root = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "Workflows")
+    )
+    old_abs = os.path.abspath(os.path.join(workflows_root, rel_path))
+    if not old_abs.startswith(workflows_root) or not os.path.isfile(old_abs):
+        return jsonify({"error": "Workflow not found"}), 404
+    if not new_name:
+        return jsonify({"error": "Invalid new_name"}), 400
+    if not new_name.lower().endswith(".json"):
+        new_name += ".json"
+    new_abs = os.path.join(os.path.dirname(old_abs), os.path.basename(new_name))
+    base_name = os.path.splitext(os.path.basename(new_abs))[0]
+    try:
+        os.rename(old_abs, new_abs)
+        obj = _safe_read_json(new_abs)
+        for k in ["tabName", "tab_name", "name", "title"]:
+            if k in obj:
+                obj[k] = base_name
+        if "tab_name" not in obj:
+            obj["tab_name"] = base_name
+        with open(new_abs, "w", encoding="utf-8") as fh:
+            json.dump(obj, fh, indent=2)
+        rel_new = os.path.relpath(new_abs, workflows_root).replace(os.sep, "/")
+        return jsonify({"status": "ok", "rel_path": rel_new})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
 # ---------------------------------------------
 # Borealis Agent API Endpoints
 # ---------------------------------------------

--- a/Workflows/Examples/API Requests/Value Parser.json
+++ b/Workflows/Examples/API Requests/Value Parser.json
@@ -1,0 +1,106 @@
+{
+  "tab_name": "Value Parser",
+  "nodes": [
+    {
+      "data": {
+        "body": "",
+        "content": "Fetch JSON from HTTP or remote API endpoint, with CORS proxy option.",
+        "intervalSec": "10",
+        "label": "API Request",
+        "result": "{\n  \"status\": \"ok\"\n}",
+        "url": "http://localhost:5000/health",
+        "useProxy": "true"
+      },
+      "dragHandle": ".borealis-node-header",
+      "dragging": false,
+      "height": 124,
+      "id": "node-1754799747658",
+      "position": {
+        "x": 27.333333333333314,
+        "y": 28
+      },
+      "positionAbsolute": {
+        "x": 27.333333333333314,
+        "y": 28
+      },
+      "selected": false,
+      "type": "API_Request",
+      "width": 160
+    },
+    {
+      "data": {
+        "content": "Display prettified multi-line JSON from upstream node.",
+        "jsonData": {
+          "status": "ok"
+        },
+        "label": "Display JSON Data"
+      },
+      "dragHandle": ".borealis-node-header",
+      "dragging": false,
+      "height": 150,
+      "id": "node-1754799750393",
+      "position": {
+        "x": 245.33333333333326,
+        "y": 28
+      },
+      "positionAbsolute": {
+        "x": 245.33333333333326,
+        "y": 28
+      },
+      "selected": false,
+      "type": "Node_JSON_Pretty_Display",
+      "width": 260
+    },
+    {
+      "data": {
+        "content": "Provide a dot-separated key path (e.g. 'name.en'); outputs the extracted string or 'Key Not Found'.",
+        "keyName": "status",
+        "label": "JSON Value Extractor",
+        "result": "ok"
+      },
+      "dragHandle": ".borealis-node-header",
+      "dragging": false,
+      "height": 145,
+      "id": "node-1754799751513",
+      "position": {
+        "x": 559.3333333333333,
+        "y": 28
+      },
+      "positionAbsolute": {
+        "x": 559.3333333333333,
+        "y": 28
+      },
+      "selected": false,
+      "type": "JSON_Value_Extractor",
+      "width": 160
+    }
+  ],
+  "edges": [
+    {
+      "animated": true,
+      "id": "reactflow__edge-node-1754799747658-node-1754799750393",
+      "source": "node-1754799747658",
+      "sourceHandle": null,
+      "style": {
+        "stroke": "#58a6ff",
+        "strokeDasharray": "6 3"
+      },
+      "target": "node-1754799750393",
+      "targetHandle": null,
+      "type": "bezier"
+    },
+    {
+      "animated": true,
+      "id": "reactflow__edge-node-1754799750393-node-1754799751513",
+      "source": "node-1754799750393",
+      "sourceHandle": null,
+      "style": {
+        "stroke": "#58a6ff",
+        "strokeDasharray": "6 3"
+      },
+      "target": "node-1754799751513",
+      "targetHandle": null,
+      "type": "bezier"
+    }
+  ]
+}

--- a/Workflows/Examples/Basic/Logic Comparison.json
+++ b/Workflows/Examples/Basic/Logic Comparison.json
@@ -1,0 +1,113 @@
+{
+  "tab_name": "Logic Comparison",
+  "nodes": [
+    {
+      "data": {
+        "content": "Store a String or Number",
+        "label": "String Input A",
+        "value": "Bunny"
+      },
+      "dragHandle": ".borealis-node-header",
+      "dragging": false,
+      "height": 67,
+      "id": "node-1754800111049",
+      "position": {
+        "x": 19.333333333333314,
+        "y": 20.666666666666657
+      },
+      "positionAbsolute": {
+        "x": 19.333333333333314,
+        "y": 20.666666666666657
+      },
+      "selected": false,
+      "type": "DataNode",
+      "width": 160
+    },
+    {
+      "data": {
+        "accentColor": "#ff8c00",
+        "content": "Store a String or Number",
+        "label": "String Input B",
+        "value": "Bunny"
+      },
+      "dragHandle": ".borealis-node-header",
+      "dragging": false,
+      "height": 67,
+      "id": "node-1754800112609",
+      "position": {
+        "x": 19.33333333333337,
+        "y": 121.33333333333337
+      },
+      "positionAbsolute": {
+        "x": 19.33333333333337,
+        "y": 121.33333333333337
+      },
+      "selected": false,
+      "style": {
+        "--borealis-accent": "#ff8c00",
+        "--borealis-accent-dark": "#b36200",
+        "--borealis-title": "#ff8c00"
+      },
+      "type": "DataNode",
+      "width": 160
+    },
+    {
+      "id": "node-1754800323495",
+      "type": "ComparisonNode",
+      "position": {
+        "x": 271.3333333333333,
+        "y": 69.33333333333333
+      },
+      "data": {
+        "label": "Does A and B Match?",
+        "content": "Compare A and B using Logic, with new range operator.",
+        "value": "1",
+        "accentColor": "#c0ff00",
+        "inputType": "String",
+        "operator": "Equal (==)"
+      },
+      "dragHandle": ".borealis-node-header",
+      "width": 160,
+      "height": 67,
+      "positionAbsolute": {
+        "x": 271.3333333333333,
+        "y": 69.33333333333333
+      },
+      "selected": false,
+      "dragging": false,
+      "style": {
+        "--borealis-accent": "#c0ff00",
+        "--borealis-accent-dark": "#86b300",
+        "--borealis-title": "#c0ff00"
+      }
+    }
+  ],
+  "edges": [
+    {
+      "source": "node-1754800111049",
+      "sourceHandle": null,
+      "target": "node-1754800323495",
+      "targetHandle": "a",
+      "type": "bezier",
+      "animated": true,
+      "style": {
+        "strokeDasharray": "6 3",
+        "stroke": "#58a6ff"
+      },
+      "id": "reactflow__edge-node-1754800111049-node-1754800323495a"
+    },
+    {
+      "source": "node-1754800112609",
+      "sourceHandle": null,
+      "target": "node-1754800323495",
+      "targetHandle": "b",
+      "type": "bezier",
+      "animated": true,
+      "style": {
+        "strokeDasharray": "6 3",
+        "stroke": "#58a6ff"
+      },
+      "id": "reactflow__edge-node-1754800112609-node-1754800323495b"
+    }
+  ]
+}

--- a/Workflows/Examples/Basic/Math Operations.json
+++ b/Workflows/Examples/Basic/Math Operations.json
@@ -1,0 +1,147 @@
+{
+  "tab_name": "Math Operations",
+  "nodes": [
+    {
+      "id": "node-1754800111049",
+      "type": "DataNode",
+      "position": {
+        "x": 19.333333333333314,
+        "y": 20.666666666666657
+      },
+      "data": {
+        "label": "Number Input A",
+        "content": "Store a String or Number",
+        "value": "5"
+      },
+      "dragHandle": ".borealis-node-header",
+      "width": 160,
+      "height": 67,
+      "selected": false,
+      "positionAbsolute": {
+        "x": 19.333333333333314,
+        "y": 20.666666666666657
+      },
+      "dragging": false
+    },
+    {
+      "id": "node-1754800112609",
+      "type": "DataNode",
+      "position": {
+        "x": 19.33333333333337,
+        "y": 121.33333333333337
+      },
+      "data": {
+        "label": "Number Input B",
+        "content": "Store a String or Number",
+        "accentColor": "#ff8c00",
+        "value": "3"
+      },
+      "dragHandle": ".borealis-node-header",
+      "width": 160,
+      "height": 67,
+      "selected": false,
+      "positionAbsolute": {
+        "x": 19.33333333333337,
+        "y": 121.33333333333337
+      },
+      "dragging": false,
+      "style": {
+        "--borealis-accent": "#ff8c00",
+        "--borealis-accent-dark": "#b36200",
+        "--borealis-title": "#ff8c00"
+      }
+    },
+    {
+      "id": "node-1754800119705",
+      "type": "MathNode",
+      "position": {
+        "x": 276.66666666666663,
+        "y": 69.33333333333334
+      },
+      "data": {
+        "label": "Multiply A x B",
+        "content": "Perform Math Operations",
+        "value": "15",
+        "operator": "Multiply",
+        "accentColor": "#00d18c"
+      },
+      "dragHandle": ".borealis-node-header",
+      "width": 160,
+      "height": 67,
+      "positionAbsolute": {
+        "x": 276.66666666666663,
+        "y": 69.33333333333334
+      },
+      "selected": false,
+      "dragging": false,
+      "style": {
+        "--borealis-accent": "#00d18c",
+        "--borealis-accent-dark": "#009262",
+        "--borealis-title": "#00d18c"
+      }
+    },
+    {
+      "id": "node-1754800128555",
+      "type": "DataNode",
+      "position": {
+        "x": 517.3333333333334,
+        "y": 69.33333333333333
+      },
+      "data": {
+        "label": "Usable Result",
+        "content": "Store a String or Number",
+        "value": "15"
+      },
+      "dragHandle": ".borealis-node-header",
+      "width": 160,
+      "height": 67,
+      "positionAbsolute": {
+        "x": 517.3333333333334,
+        "y": 69.33333333333333
+      },
+      "selected": true,
+      "dragging": false
+    }
+  ],
+  "edges": [
+    {
+      "source": "node-1754800111049",
+      "sourceHandle": null,
+      "target": "node-1754800119705",
+      "targetHandle": "a",
+      "type": "bezier",
+      "animated": true,
+      "style": {
+        "strokeDasharray": "6 3",
+        "stroke": "#58a6ff"
+      },
+      "id": "reactflow__edge-node-1754800111049-node-1754800119705a"
+    },
+    {
+      "source": "node-1754800112609",
+      "sourceHandle": null,
+      "target": "node-1754800119705",
+      "targetHandle": "b",
+      "type": "bezier",
+      "animated": true,
+      "style": {
+        "strokeDasharray": "6 3",
+        "stroke": "#58a6ff"
+      },
+      "id": "reactflow__edge-node-1754800112609-node-1754800119705b"
+    },
+    {
+      "source": "node-1754800119705",
+      "sourceHandle": null,
+      "target": "node-1754800128555",
+      "targetHandle": null,
+      "type": "bezier",
+      "animated": true,
+      "style": {
+        "strokeDasharray": "6 3",
+        "stroke": "#58a6ff"
+      },
+      "id": "reactflow__edge-node-1754800119705-node-1754800128555"
+    }
+  ]
+}

--- a/Workflows/Examples/OCR/Text Recognition.json
+++ b/Workflows/Examples/OCR/Text Recognition.json
@@ -1,0 +1,276 @@
+{
+  "tab_name": "Text Recognition",
+  "nodes": [
+    {
+      "id": "node-1754800498085",
+      "type": "Borealis_Agent",
+      "position": {
+        "x": 25.999999999999943,
+        "y": 24.000000000000014
+      },
+      "data": {
+        "label": "Borealis Agent",
+        "content": "Select and manage an Agent with dynamic roles",
+        "agent_id": ""
+      },
+      "dragHandle": ".borealis-node-header",
+      "positionAbsolute": {
+        "x": 25.999999999999943,
+        "y": 24.000000000000014
+      },
+      "width": 205,
+      "height": 146,
+      "selected": false,
+      "dragging": false
+    },
+    {
+      "id": "node-1754800514571",
+      "type": "Agent_Role_Screenshot",
+      "position": {
+        "x": 278,
+        "y": 24
+      },
+      "data": {
+        "label": "Agent Role: Screenshot",
+        "content": "Capture screenshot region via agent",
+        "interval": "1000",
+        "x": "250",
+        "y": "100",
+        "w": "300",
+        "h": "200",
+        "visible": "true",
+        "alias": ""
+      },
+      "dragHandle": ".borealis-node-header",
+      "width": 166,
+      "height": 115,
+      "selected": false,
+      "positionAbsolute": {
+        "x": 278,
+        "y": 24
+      },
+      "dragging": false
+    },
+    {
+      "id": "node-1754800556810",
+      "type": "Image_Viewer",
+      "position": {
+        "x": 507.33333333333326,
+        "y": 24
+      },
+      "data": {
+        "label": "Raw Image Viewer",
+        "content": "Visual preview of base64 image with zoom overlay."
+      },
+      "dragHandle": ".borealis-node-header",
+      "width": 160,
+      "height": 69,
+      "selected": false,
+      "positionAbsolute": {
+        "x": 507.33333333333326,
+        "y": 24
+      },
+      "dragging": false
+    },
+    {
+      "id": "node-1754800584420",
+      "type": "BWThresholdNode",
+      "position": {
+        "x": 507.33333333333337,
+        "y": 110
+      },
+      "data": {
+        "label": "BW Threshold",
+        "content": "Applies black & white threshold to base64 image input."
+      },
+      "dragHandle": ".borealis-node-header",
+      "width": 160,
+      "height": 96,
+      "selected": false,
+      "positionAbsolute": {
+        "x": 507.33333333333337,
+        "y": 110
+      },
+      "dragging": false
+    },
+    {
+      "id": "node-1754800597090",
+      "type": "OCR_Text_Extraction",
+      "position": {
+        "x": 46.800008138020814,
+        "y": 280.00000000000006
+      },
+      "data": {
+        "label": "OCR Text Extraction",
+        "content": "Extract Multi-Line Text from Upstream Image Node",
+        "engine": "EasyOCR",
+        "backend": "GPU",
+        "dataType": "Mixed",
+        "customRateEnabled": "true",
+        "customRateMs": "1000",
+        "changeThreshold": "0"
+      },
+      "dragHandle": ".borealis-node-header",
+      "width": 231,
+      "height": 160,
+      "selected": false,
+      "positionAbsolute": {
+        "x": 46.800008138020814,
+        "y": 280.00000000000006
+      },
+      "dragging": false
+    },
+    {
+      "id": "node-1754800680302",
+      "type": "ArrayIndexExtractor",
+      "position": {
+        "x": 497.3333333333333,
+        "y": 280
+      },
+      "data": {
+        "label": "Array Index Extractor",
+        "content": "Output a Specific Array Index's Value",
+        "lineNumber": "1"
+      },
+      "dragHandle": ".borealis-node-header",
+      "width": 210,
+      "height": 121,
+      "selected": false,
+      "positionAbsolute": {
+        "x": 497.3333333333333,
+        "y": 280
+      },
+      "dragging": false
+    },
+    {
+      "id": "node-1754800736215",
+      "type": "DataNode",
+      "position": {
+        "x": 328.6666666666665,
+        "y": 568.6666666666666
+      },
+      "data": {
+        "label": "String / Number",
+        "content": "Store a String or Number",
+        "value": "[ERROR] No base64 image data provided."
+      },
+      "dragHandle": ".borealis-node-header",
+      "width": 226,
+      "height": 67,
+      "selected": true,
+      "positionAbsolute": {
+        "x": 328.6666666666665,
+        "y": 568.6666666666666
+      },
+      "dragging": false
+    }
+  ],
+  "edges": [
+    {
+      "source": "node-1754800498085",
+      "sourceHandle": "provisioner",
+      "target": "node-1754800514571",
+      "targetHandle": null,
+      "type": "smoothstep",
+      "animated": true,
+      "style": {
+        "strokeDasharray": "6 3",
+        "stroke": "#58a6ff"
+      },
+      "id": "reactflow__edge-node-1754800498085provisioner-node-1754800514571",
+      "label": "Capture the Screen",
+      "labelBgStyle": {
+        "fill": "#000000"
+      },
+      "labelStyle": {
+        "fill": "#58a6ff"
+      }
+    },
+    {
+      "source": "node-1754800514571",
+      "sourceHandle": null,
+      "target": "node-1754800556810",
+      "targetHandle": null,
+      "type": "bezier",
+      "animated": true,
+      "style": {
+        "strokeDasharray": "6 3",
+        "stroke": "#58a6ff"
+      },
+      "id": "reactflow__edge-node-1754800514571-node-1754800556810"
+    },
+    {
+      "source": "node-1754800514571",
+      "sourceHandle": null,
+      "target": "node-1754800584420",
+      "targetHandle": null,
+      "type": "bezier",
+      "animated": true,
+      "style": {
+        "strokeDasharray": "6 3",
+        "stroke": "#58a6ff"
+      },
+      "id": "reactflow__edge-node-1754800514571-node-1754800584420"
+    },
+    {
+      "source": "node-1754800584420",
+      "sourceHandle": null,
+      "target": "node-1754800597090",
+      "targetHandle": null,
+      "type": "smoothstep",
+      "animated": true,
+      "style": {
+        "strokeDasharray": "6 3",
+        "stroke": "#00d18c"
+      },
+      "id": "reactflow__edge-node-1754800584420-node-1754800597090",
+      "label": "Process Agent Screenshot into Text",
+      "labelBgStyle": {
+        "fill": "#000000"
+      },
+      "labelStyle": {
+        "fill": "#00d18c"
+      }
+    },
+    {
+      "source": "node-1754800597090",
+      "sourceHandle": null,
+      "target": "node-1754800680302",
+      "targetHandle": null,
+      "type": "straight",
+      "animated": true,
+      "style": {
+        "strokeDasharray": "6 3",
+        "stroke": "#00d18c"
+      },
+      "id": "reactflow__edge-node-1754800597090-node-1754800680302",
+      "label": "Extract a Specific Line of Text",
+      "labelBgStyle": {
+        "fill": "#000000"
+      },
+      "labelStyle": {
+        "fill": "#00d18c"
+      }
+    },
+    {
+      "source": "node-1754800680302",
+      "sourceHandle": null,
+      "target": "node-1754800736215",
+      "targetHandle": null,
+      "type": "smoothstep",
+      "animated": true,
+      "style": {
+        "strokeDasharray": "6 3",
+        "stroke": "#ff8c00"
+      },
+      "id": "reactflow__edge-node-1754800680302-node-1754800736215",
+      "label": "Do something with the result",
+      "labelStyle": {
+        "fill": "#ff8c00"
+      },
+      "labelBgStyle": {
+        "fill": "#000000"
+      }
+    }
+  ]
+}

--- a/Workflows/Games/Flyff Universe/Character Status Breakdown.json
+++ b/Workflows/Games/Flyff Universe/Character Status Breakdown.json
@@ -565,5 +565,5 @@
       }
     }
   ],
-  "tab_name": "Flyff Status Breakdown"
+  "tab_name": "Character Status Breakdown"
 }

--- a/Workflows/Games/Flyff Universe/Chat Text Search Alerter.json
+++ b/Workflows/Games/Flyff Universe/Chat Text Search Alerter.json
@@ -1,0 +1,270 @@
+{
+  "tab_name": "Chat Text Search Alerter",
+  "nodes": [
+    {
+      "id": "node-1746283065191",
+      "type": "AlertSoundNode",
+      "position": {
+        "x": 854.1638317296133,
+        "y": 516.4659418511601
+      },
+      "data": {
+        "label": "Alert Sound",
+        "content": "Sound alert when input value = 1",
+        "audio": "data:audio/wav;base64,UklGRt4lAABXQVZFZm10IBAAAAABAAEARKwAAIhYAQACABAAZGF0YbolAAAAAP8MAhv+KAI3/kQBUwBTAEUAN/8oAhv9DAP//vAA4wHV/8YBuf+qAa//vAHL/9gB5//0AgP+EAIf/iwCO/1IBFf8TgVB+zICJQAXAAkA+wDt/94C0f7CAbX/pgGzAcH9zgPd/eoD+f4GAhX9IgMx/j4BTf9YAUv/PAIv/iAAEwIF/PYF6fzaAs0Av/+wAan/tgDFAdP/4AHv//wBC/8YASf/NAFDAFH+VANH/TgCKwAd/g4CAf/yAOUA1wDJALsArQCtALsAyQHX/eQE8/wABA/9HAErADkAR/9UAlH9QgM1/SYDGf4KAP0B7//gAdP/xAG3/6gBsf++Ac3/2gHp//YABQIT/SADL/08A0v9WANN/T4CMf8iARX+BgL5/uoC3f7OAcEAs/+mArX+wgDRAd8A7QD7AAn/FgEl/zICQf5OAVcASf46Ay39HgMR/gIA9QDnAdn/ygK9/q4AqwG5AMcA1QDjAPH//gIN/hoCKf42AkX+UgFTAEX/NgIp/hoCDf7/AfIA5ADWAMgAugCsAK4AvADKANgA5gD0AAIAEAAeACwAOv9HAVYAUABCADT/JQEY/wkB/ADu/98C0v3DA7b9pwOy/r8Czv7bAur+9wEGABQAIgEw/j0CTP1ZA0z+PQEwACL/EwEGAPj/6QHcAM7/vwKy/qcBtgHE/tEC4P7tAvz+CQIY/yX/MwNC/E8EVv1HAToBLP8dABAAAgH0/uUC2P7JAbwArgCsALoAyADWAOQA8gAAAA4AHAAqADgARgBUAFIARAA2ACgAGgAMAP4A8ADiANQAxgC4AKoAsAC+/8sD2vznBPb8AwQS/B8ELvw7BEr9VwJO/j8BMgAkABb/BwL6/usB3gDQ/sEEtPylBLT8wQPQ/90A7AD6AAgAFgAkADIAQABOAFgBSv07BS77HwQS/QMB9gHo/9kBzP+9ALAAqgG4/8UB1ADi/+8C/v0LAxr9JwM2/kMAUgJU/UUDOP0pAhz/DQIA/fEC5ADW/scEuvurBK79uwPK/dcE5vvyBQH7DgUd/CoDOf5GAVUAUQBDADX/JgEZAAsA/QDv/+AB0wDF/7YBqf+wAr/+zAHb/+gB9/8EARMAIf8uAT0AS/9YAk3+PgExACMAFQAHAPkA6//cAc8AwQCz/6YCtf3CA9H+3gDtAvv9CAMX/iQBMwBB/k4DV/1IBDv9LAAfARH/AgL1/uYB2f/KAb0Ar/+qAbn/xgHVAOMA8f/+AQ3/GgIp/jYBRf9SAVP/RAE3/ygBG/8MAP8B8QDj/9QBx/+4AKsCr/y8Bcv72ATn/fQCAwAR/h4DLf06A0n+VgFP/0ABM/8kARcACf/6Ae3/3gHR/8IBtf+mAbMAwf/OAd3/6gL5/QYEFfwiAzH/Pv9MAln/SgA9AS/+IAIT/gQD9/3oAtv/zAC/ALEBqf62A8X90gLh/+4A/QEL/xgAJwE1/0IBUf9UAUf/OAEr/xwADwEB/vID5fzWBMn8ugSt/awCu//IANcA5QHz/gADD/0cAiv+OAJH/lQCUf5CAjX+JgEZ/wsC/v7vAuL90wPG/rcBqv+vAb7/ywLa/ecD9v0DAxL+HwEuATz+SQJY/k0BQAAyACQAFgAIAPr/6wLe/c8Ewv2zAaYBtP3BBND93QLs/vkCCP0VBCT8MQNA/U0EWPxJAzz9LQIgABIABAD2/ucD2v3LA77+rwCqAbj+xQPU/eED8P39Awz9GQIoADb+QwRS+1MFRvs3BSr7GwUO/P8D8v7jAdYAyAC6AKz/rQK8/skC2P3lA/T+AQEQAB7/KwE6/0cBVgBQAEIANP4lBBj7CQb8+u0F4PzRA8T9tQOo/bEDwP3NA9z96QL4/wUBFP8hATD/PQFM/1kBTP89ATAAIv8TAQYA+P7pA9z9zQPA/bEDqP21AsT/0QDgAe7/+wEK/xcAJgE0/0EBUP9VAEgCOv0rAx79DwMC/vMB5v/XAcoAvP+tAaz/uQHIANb/4wDyAQAADgAc/ykBOP9FAlT/UQBEADYAKAEa/wsB/v7vAuL/0wHG/7cAqgCwAL4BzP/ZAOcA9QADARH+HgIt/joCSf9W/04DQfwyBCX9FgEJAfv/7ADfANEAwwC1Aaf/sgDBAM8A3QDrAPkABwAVACMAMQA/AE0AWQFL/TwFL/ogBhP8BAL3/ugB2wDNAb//sAGp/rYCxf/SAOEC7/38Agv+GAMn/DQFQ/pQBVX+Rv84Ayv9HAIP/wAB8//kAdf/yAC7Aa3/rAC7Acn+1gLl//IAAQEP/hwCK/44Akf+VAJR/kIBNQAn/xgCC/78Ae//4AHTAMUAt/+oAbH/vgHNANv/6AH3/wQAEwEh/y4APQBLAFkATQA/ADEAIwAVAAcA+QDrAN0AzwHB/rIDp/20AcMB0f/eAO0B+/8I/xYDJf0yAkH/TgBXAEkBO/8sAR/+EAMD/PQF5/zYAssAvf+uAqv+uALH/tQB4wDxAP8ADQAb/ygCN/1EA1P+UgFFATf+KAIb/gwC///wAOMB1f3GBbn6qgWv/bwAywLZ/+b/9AID/RADH/8sADsASQBX/04CQf4yASUBGP4JAvz+7QHgANIAxAC2AKgAsgDAAM4A3ADqAfj+BQIU/iEDMP09A0z8WQRM/T0CMP8hABQBBv73Aur+2wHOAcD+sQKo/7X/wwPS/d8C7v/7AAoAGAIm/DMEQv1PAlb/RwA6ACwBHv4PAgL+8wLm/9f/yQK8/q0DrPy5BMj91QLk//H//wMO/RsCKv83/0UCVP9RAEQANgAoABoADAH+/e8F4vrTBsb6twWq/q//vQLM/tkB6AH2/QMEEvwfBC78OwNK/lcCTv0/BDL7IwUW/QcA+gLs/d0D0P7BAbT/pQG0/8EB0P/dAez/+QII/RUDJP4xAUABTv5XAkr+OwIu/h8CEv4DAvb+5wLa/ssCvv6vAqr+twLG/9MA4gDwAP4ADAAaASj9NQRE/FEEVPxFAzj+KQEcAQ79/wTy/OMD1v7HArr+qwGuALz/yQLY/+X/8wECABD/HQMs/DkDSP1VA1D+QQI0/iUBGP8JAvz+7QLg/tECxP+1AKgBsv2/BM792gLp/vYBBQATACEAL/88AUsAWQBNAD8AMf8iAxX8BgT5/eoC3f/OAMEBs/6mArX/wgDRAd/+7AH7AAkAFwEl/TIFQflOCFf5SAU7/SwCH/8QAAMA9QDnANkAywG9/q4BqwC5AMcA1QHj/fAE//0MARsBKf42AkX/UgBTAEUANwEp/xoADQD/APEA4wHV/cYEufyqA6/+vADLAdkA5//0AQP/EAAfAS3/OgFJ/1YBT/9AATP/JAEXAAn/+gLt/d4D0f7CAbUApwCz/8ABz//cAuv++AEHABX/IgIx/j4CTf5YAUsAPf8uAiH9EgMF/vYB6f/aAc0Av/+wAqn+tgHFANP/4ALv/vwCC/4YAScANf9CAlH+VAJH/jgCK/0cAw//AADzAeX+1gLJ/7oBrf+sALsCyf3WA+X98gIBAA/+HAIr/jgCR/9U/1ACQ/80/yYCGf0KBP387gTh+9IExf+2/qgDsf6+Ac3/2gHp//YCBf4SASH/LgI9/koCWf5MAT8BMf4jAhb+BwH6Aez+3QHQ/8ECtP6lArT9wQLQAN7/6wH6/wcBFv8jATL+PwNO/VcDSv07Ay79HwISAAT/9QLo/tkBzAC+/68Cqv63Asb+0wHiAPAA/gAM/xkCKP41AkT+UQJU/kUCOP4pAhz+DQIA/vEC5P7VAsj+uQKs/q0CvP7JAtj+5QL0/gEBEAEe/isCOv5HAVYAUABCADQAJgAYAAoA/ADuAOAB0v/DAbb+pwOy/b8Dzv3bAur/9wEG/xMAIgAwAT7/SwBaAEwAPgEw/yH/EwIG/vcC6v7bAc4AwACy/6cCtv7DAdIA4ADuAPwACv8XAib+MwNC/E8EVvxHBDr9KwIe/w8AAgH0/+UA2AHK/rsDrv2rArr/xwHW/+MB8v7/Aw79GwQq+zcERv1TAlIARP41Ayj9GQIM//0A8AHi/9MBxv+3AKoAsAG+/8sB2v/nAPYABAES/x8ALgA8AEoBWP5NAkD+MQIk/xUBCP75Auz/3QHQ/8EBtP+lALQCwv3OA93+6gD5Agf9FAMj/TADP/5MAVn/SgE9AC//IAET/wQB9wDp/toDzf2+A7H+qAC3AcX/0gHh/+4B/f8KARn/JgE1/0IBUf9UAEcBOf4qAx39DgEBAvP85AXX+8gDuwCt/6wCu/7IAdf/5AHzAAEBD/4cASsAOQBHAFX/UAFDADUAJwAZ/goD/f7uAeEA0/7EA7f+qACxAr/8zAXb/OgC9wAF/xIBIf8uAT0ASwBZ/0wBP/8wAiP+FAIH/fgD6/7cAc8AwQCzAKf/tAHDANH/3gLt/voBCQAXACUAMwBBAE8AVwBJATv+LAEfARH+AgL1/uYC2f7KAr3/rgCrAbn+xgPV/eIC8QD//gwDG/4oADcBRf9SAFMBRf82ACkBG/4MAv//8ADjAdX+xgK5/6oBr/+8AMsA2QHn/vQDA/wQBB/9LAI7/0gAVwFP/kACM/8kARf/CAH7/uwC3//QAcMAtf6mA7P9wALP/9wB6/74Awf8FAQj/DAFP/tMBFn9SgI+/y8BIv8TAQb/9wDqAdz/zQHA/7EAqAG2/8MB0v/fAO4B/P8JABgBJv4zA0L8TwRW/UcCOv8rAB4AEAEC/vMC5v/XAMoAvAGu/6sBuv/HANYB5P/xAQD/DQEc/ykAOAFG/1MBUv9DATb/JwEa/wsB/gDw/+EB1P/FAbgAqv+vAb7/ywLa/ucB9gAE/xECIP4tATwASgBYAE4AQAAyACQBFv4HAvr/6wDeAdD+wQK0/6UAtADCAdD+3QPs/fkCCP8VAST/MQFAAE7+VwRK/DsCLgAgABIABAD2/+cB2gHM/r0BsAGq/bcExvzTA+L/7wD+AAwAGv8nAjb+QwJS/1P/RQI4/SkEHP0NAgD/8f/jAtb+xwO6/KsFrvu7BMr91wLm//MBAv8PAR7/KwA6AUj/VQFQ/0EANAAmARj+CQP8/e0C4P/R/8MCtv+nALIBwP7NAtz+6QH4AQb+EwIi/y/+PQVM+1kETPw9AzD/IQAUAQb+9wHqAdz9zQTA/LEDqP61AsP+0ALf/uwB+wAJABcAJf8yAkH9TgRX/EgCOwAt/x4CEf4CAfX/5gHZ/8oBvf+uAasAuf/GAdUA4//wAv/+DAIb/igCN/1EA1P+UgFFADcAKf4aAw39/gPx/uIA1QHH/7gCq/6uAL0Cy/7YAuf+9AEDABEAHwAt/zoBSf9WAU//QAEz/yQBF/8IAPsB7f/eANECw/20A6f9sgPB/c4D3f3qA/n+BgEV/yIAMQE/AE3+WANL/TwCLwAh/hIDBf32Aun/2gDNAb//sACpAbf+xAPT/OAF7/v8BAv+GAAnATX/QgBRAVX/RgA5ACsBHf4OAgH/8gDlAdf+yAK7/6wArQG7/8gA1wHl/vIDAf0OAx38KgQ5/UYDVf5QAEMBNf8mARkAC//8Ae8A4f/SAcUAtwCp/7ABv//MAdsB6f32AwX+EgEhAC8APQBLAFkATQA/ADEAIwAV/wYD+fzqBN39zgHBALMApwC1AMMA0f/eAu39+gMJ/RYCJQAz/0ABT/9WAEoBPP8tASD/EQEE//UA6AHa/8sBvv+vAaoAuP/FAdT/4QHwAf79CwMa/icBNgFE/lECVP5FAjj+KQIc/g0CAP/xAOT/1QLI/rkCrP+t/7sDyvzXBOb98wECARD+HQIs/jkCSP1VBFD8QQM0/SUCGP8JAfz/7QDgAdL+wwO2/acDsv2/A8792wPq/vcCBv0TAyL+LwI+/ksCWv1LAz7/L/8hARQABv/3Aur+2wDOAsD+sQKo/rUCxP7RAeAA7gD8AAoAGP8lAjT+QQFQAFb/RwI6/isCHv4PAgL+8wLm/9cAygC8Aa7+qwK6/scC1v7jAvL+/wEOABwAKgA4AEb/UwJS/UMDNv4nABoBDP/9AfD/4QHU/sUDuP6pAbAAvv/LAdoA6P/1AgT+EQEgAC7/OwJK/lcCTv4/AjL9IwQW/AcE+vzrAt7/zwDCAbT/pQC0AcL+zwPe/esC+v8HARb/IwIy/T8DTv1XAkr/OwEu/x8BEv8DAPYB6P7ZA8z+vQCwAar+tgLFANP/4AHv//wBC/8YASf/NABDAVEAVf9GATn/KgEd/w4CAf7yAeUB1/3IBLv8rASt+7oGyfrWBeX88gMB/g4BHf8qATn/RgFV/1ABQ/80ASf/GAALAf3+7gPh/dICxf62Aqn+sAK//swC2/7oAvf+BAETACH/LgI9/koBWQBN/z4CMf0iAxX+BgL5/uoB3f/OAcEAs/+mArX9wgTR/N4C7f/6Agn+FgIl/TIDQf5OAVcASQA7AC0AH/8QAQP/9ALn/tgBy/+8Aa//qgK5/cYD1f3iA/H9/gMN/hoAKQE3AEX/UgFT/0QBNwEp/hoBDQD/APEB4/7UAsf/uAGr/64AvQDLAdn/5gD1AQP+EAIf/iwCO/9IAFcATwBBADMAJQAXAAkA+wDt/94C0f3CA7X+pgGz/8ABz/7cA+v9+AIH/xQAIwEx/j4DTf1YAksAPf4uAyH9EgMF/fYC6f/aAc3/vgGx/qgDt/3EA9P94ALv//wBC/8YASf/NABDAlH9VQNI/TkCLP8dAhD9AQL0AOb/1wHK/7sBrv+rArr9xwPW/uMB8v7/Aw79GwMq/jcARgFU/1EBRP81ASj/GQAMAv797wLiANT+xQO4/akDsP29A8z92QLoAPb/AwES/h8DLv07Akr/VwFO/z8BMv4jAhb/BwH6/+sB3v7PAsL/swGm/7MBwv/PAd4A7P/5AQj/FQEkADL/PwFO/lcDSv07Ay79HwIS/wMB9v/nAdr/ywC+AbD+qQO4/cUD1P3hAvD//QAMARr/JwE2/0MAUgBUAUb+NwMq/RsCDv7/AvL+4wPW/ccBugCsAK4BvP7JAtj+5QL0AAL+DwIe/ysAOgFI/lUCUP5BAjT+JQIY/wn/+wLu/t8C0v/DAbb+pwKy/78Bzv/bAer/9wEG/xMBIv8vAD4CTPxZBEz9PQIw/yEAFAEG/vcC6v7bAc4BwP2xBKj7tQXE/NED4P3tBPz8CQQY/CUENPxBBFD9VQJI/jkBLAAeABAAAgD0/+UB2ADKALz/rQKr/rgBxwDV/+IC8f7+Ag3+GgIp/jYCRf5SAlP+RAE3ACn/GgIN/f4D8f7iAdUAx/+4Aqv+rgK9/8r/2APn/PQDA/8Q/x4CLf06A0n9VgNP/UACMwAl/xYACQH7/uwD3/7QAMMBtf+mALMBwf7OAt0A6//4AQf/FAAjATH/PgBNAln9SgM9/S4CIf8SAAUB9//oAdv/zAC/ALEBqf+2AcX/0gHh/+4C/f0KAxn9JgM1/kIBUf9UAUf/OAEr/xwBDwAB//IB5f/WAcn/ugGt/qwDu/zIBdf65AXz/QABDwEd/ioBOQFH/VQEUf1CATUBJ/0YBAv8/ATv/OAE0/zEA7f+qAKx/r4DzfvaBun69gYF/BICIf8u/zwDS/1YA03+PgAxASP/FAEH//gA6wHd/84BwQCz/qYDtf3CA9H+3gHtAPv/CAEXACX/MgJB/k4BVwFJ/ToELfweAxH+AgL1/uYC2f7KAr3/rgGr/rgCx//UAeP/8AD//wwCG/8oADf/RAFSAFQARgA4/ykCHP4NAQAA8gDk/9UCyP65Aqz+rQK8/skB2ADmAPQAAgAQAB7/KwI6/UcDVv5PAUIANP8lABgBCv/7Ae4A4P7RA8T9tQOo/bEDwP7NAdz/6QD4AQYAFP8hATD/PQFMAFoATP89AjD+IQIU/gUB+AHq/tsDzvu/BbL9pwK2/sMC0v7fAu7++wIK/hcBJgA0AEIAUABWAEj/OQIs/h0CEP4BAfQA5gDYAMoAvP+tAqz+uQHIANYA5AHy/v8CDv4bAyr9NwNG/VMDUv5DATb/JwEa/wsC/v7vAOIB1P/FAbj/qQCwAb7/ywHa/ucD9v0DAxL8HwUu+zsESv1XAU4CQP0xAiT/FQAIAvr96wPe/c8Dwv2zAqb/swHC/s8D3v3rAvoACP4VAiQAMv4/A07+VwFK/zsBLv8fAhL+AwH2Aej+2QLM/r0CsP6pArj+xQLU/+H/7wL+/QsEGvwnBDb9QwFSAFT/RQI4/ykAHAEO/v8B8gHk/tUDyP25Aq3/rAG7/sgC1/7kA/P9AAIP/hwCK/84AEcBVf5QA0P9NAIn/hgDC/z8Be/74ATT/cQCt/+oALEBv/7MAtv/6AD3AAUAEwAhAS/+PAFLAVn+TAM//DAEI/0UAgf/+ADrAd3/zgHB/7IBp/+0AcMA0f/eAe3/+gIJ/hYCJf4yAUEAT/9WA0n8OgQt/B4DEf4CAvX+5gLZ/8oAvQGv/qoCuf/GANUB4//wAf/+DAIb/ygANwFF/lICU/5EAjf+KAIb/wwA/wHx/uID1f3GArn/qgGv/7wBy/7YAuf/9AADABEAH/8sAjv+SAFXAE//QAEzACX/FgEJAPsA7QDf/9ACw/20Baf7sgPB/s4C3f7qA/n8BgQV/CIEMf0+Ak3/WABLAD0BL/8gARP+BAL3/ugC2//MAL8AsQCp/7YCxf/SAOEA7wD9AAsBGf4mAjX+QgJR/lQCR/44ASsAHf8OAgH98gLlANf/yAG7/6wArQG7/8gB1wDl/vIDAf0OAx3+KgA5AUb/UwFS/0MANgAoAhr9CwP+/e8D4v7TAcYAuACqALD/vQHMANoA6AD2AAT/EQIg/i0BPAFK/VcFTvo/BTL9IwEWAQj/+QDsAN4A0ADCAbT+pQG0AcL9zwXe+usE+v4HARYAJAAy/z8BTv9XAUr/OwAuAiD8EQUE+vUG6PzZAsz+vQKw/6kBuP/F/9MC4v7vA/79CwEaACj/NQJE/1H/UwJG/TYEKfwaAw39/wPz/uQB1//IALsBrf+uAb3/ygHZ/+YA9QEB/w4BHQAr/jgDR/1UA0/9QAMz/SQCFwAJ//wB7/7gAtP+xAK3/6gAs//AAs/93ATr/PgEBfwSAyH+LgI9/koCWf1KAz3+LgEhABP/BAL5/eoD3f7OAcEAs/+oArf+xALT/eAD7/78Agn/Fv8kAjP9QANP/lQBRwA5/yoBHf8OAQH/9AHnANn/ygK9/K4Frfy6A8n+1gDlAfP//wEN/xoAKQE3/0QAUwFR/kIDNfwmBBn8CgX/+vAG4/rUBcj9uQKs/q8Cvv3LBNr85wT2/AEDEP0dAyz+OQJI/VUDTv0/AzL+IwEW/wcA/AHuAOAA0v/DAbb/pwK0/sEC0P7dAewA+gAGABT/IQEw/z0CTP5XAUr/OwIu/R8EEvsDBfj86QPc/s0BwP+xAqr9twPG/dMD4v/v/v0DCv0XAiYBNP1BAlAAVP5FAzj+KQEcAA7//wH0/+UC2P7JArz9rQOu/rsBygHY/eUD9P7/AQ4AHP8pATj/RQFU/08AQgE0/yUAGAAKAP4A8AHi/tMCxv63Aqr/sf+/As7+2wLq//cABAASACAALv87A0r8VwRM/D0DMP4hAhT9BQP6/usB3gDQ/8EBtACo/rUExPvRBeD87QL8AAj/FQEk/zEBQP9NAVb/RwE6ACz+HQMQ/QED9v7nANoBzP+9AbD/qwG6/8cB1gDk//ECAP0LAxr+JwI2/kMBUv9RAUQBNv0nAxr+CwAAA/L84wPW/scCuv6rArD+vQHMANr/5wH2/wECEP0dAiz/OABHAVX/TgBBADMBJf4WAgn+/ALv/uAB0wDF/7YCqf6yAcH/zgHdAOv/+AIF/RIEIfwuAz39SgJZAUv9PAMv/SACE/8EAfn/6gHdAM//wAGz/6gBtwDFANMA4QDv/vwDCf4WASUAM/9AAU//VAFH/zgBKwAd/w4BAQD1/+YC2f7KAb0ArwCtALsByf7WAuX+8gIA/wwAGwEp/jYCRf9SAFEBQ/80ACcBGf8KAf//8AHj/tQDx/24AqsAsf6+A8382gTp/fYCA/8QAB8BLf46Akn/Vv9MAz/8MAQj/BQEB/z6BO393gLR/sICtf6mA7X9wgLR/94A7QH7/gYDFf0iAzH9PgJN/1YBSf86AS3+HgIR/wIB9//oANsAzQG//7ABq/+4Acf/1AHj//AB//8KARn/JgE1/kIDUf1SA0X9NgEpARv/DAAAAfP+5ALX/sgCu/6sAq//vADLAdn+5gL1/wABDwAd/yoBOf9GAVUATwBBADP/JAEXAAkA/QDvAOH/0wLG/rcCqv6xAcAAzgDc/+kC+P0DAxL+HwAuAjz9SQNY/UsCPgAw/iEDFP0FAvr/6wDeANABwv6zAqj/tQDEANIA4ADuAPwBCP0VBST6MQZA+k0GVvpHBjr6KwUe/Q8BAgD2/+cB2gDMAL4AsACsALr/xwLW/eME8vz/Awz+GQEoADb/QwFS/1ECRP01BCj7GQUM/P8D8v7jAdYAyAC6/6sCsP69AcwA2v/nAfYBAv0PAx7+KwE6AEgAVv9NAkD+MQEkABYACAD8/+0C4P3RA8T/tf6nA7T+wQDQAt796wP6/QUDFP4hATAAPv9LAVgASv87AS7/HwES/wMB+P/pAdz/zQHA/7EBqv+3Acb/0wHi/+8B/v8JARj/JQE0AEIAUP9TAkb+NwIq/hsCDv3/BPT85QTY/MkCvACu/60CvP7JAdgA5gD0AAAADgEc/ikCOP5FAVQBUP5BAjT+JQAYAgr9/QTw/OED1P7FALgBqv+xAcAAzv7bA+r99wIE/xEAIAEt/joDSf1WA03+PgAxACMBFf8GAfv/7AHf/tACw/+0AKcBtf/CANEB3//sAfv/BgEV/yIBMf8+AU3/VgFJ/joDLfweBBH+AgD3Aen+2gLNAL//sACrALkBx//UAeP+8AL//goCGf4mAjX+QgJR/lIBRQA3/ygBGwAN//8C8/3kAtf/yAG7/6wBr/68A8v+2ADnAfX/AAAPAh39KgM5/kYAVQJP/UADM/0kAxf9CAP9/e4C4f/SAMUBt/+oAbP/wADPAN0B6//4AQX/Ev8gAy/9PANL/FgES/08Ay/+IAATAQX/+AHr/9wBz//AArP8qAW3+8QE0/7gAO8B/f8IARf+JAQz+0AET/5UAEcCOf4qAR3/DgIB/fQE5/vYBcv8vAOv/qwBu//IAtf+5ALz/v8BDQAbACkANwBFAFMAUQBDADUAJwAZAAsA/wHx/uIB1QDH/7gDq/ywA7/+zAHbAOkA9/8CAxH7HgYt+joESf5WAk3+PgIx/SIDFf0GBPv87ATg/NEDxP61AagAtADCANAA3gDs//kCBv4TAiL/L/89Akz+VwJK/jsCLv8f/xEDBPz3Ber72wTO/L8Esv2pArj/xQDUAeL+7wL+/wkAGAEm/zP/QQNQ/FMFRvo3Bir7GwQO/f8C9P7lA9j9yQK8AK7+rQS8+8kE2P7lAfQAAP8NARz/KQE4/0UBVP9PAkL9MwMm/hcBCgD+/+8C4v7TAcYAuP+pAbIAwADOANz/6QH4AAQAEgAg/y0BPABK/1cCTP49ATAAIv8TAgb++QLs/t0C0P7BArT9pwS2/MME0vzfA+79+wMI/hUBJAAy/z8BTgBW/kcEOvsrBh76DwUC/PUD6P7ZAcwAvv+vAawAuv/HAtb94wLyAAD/CwIa/icBNv9DAVL/UQJE/jUBKP8ZAQz//wHy/+MB1v7HA7r9qwKw/70AzAHa/+cB9v8BARD/HQEs/zkASAJW/U0DQP0xAyT9FQII//sB7gDg/tEDxPy1BKj+s//BBND63Qbs+/kEBv0TAiH/LgE9/0oAWQBLAT3+LgMh/RICBf/4AOsA3QHP/8AAswGp/rYDxfzSBOH97gH9AQn+FgElATP9QARP/VQBRwA5ACsAHQAPAAH/9APn/NgEy/y8A6/+rAK7/8j/1gLl/fIEAPwMBBv9KAI3/kQBUwFR/kIDNfwmAxn+CgH/APEA4wDV/8YBuf+qAbEBv/3MBNv86AP3/gIBEQAf/ywCO/1IA1f9TAM//jAAIwIV/AYF+/zsA9/+0AHD/7QBqP+0AsP90APf/uwB+wAH/xQBIwAx/z4CTf1VA0n+OgEt/x4BEf8CAfcA6f/aAc3/vgGxAKv/uAHH/9QB4wDxAP//CgEZACcANQFD/lABUwFF/jYDKfwaBA39/wPz/eQC1//IAbv+rAOv/bwCy//Y/+YC9f4AAg/9HAQr/DgDR/5TAU8BQf4yAiX+FgIJ/vwC7//gAdP/xAC3Aar+sgPB/c4D3f7qAPkBBf8SAiH+LgE9/0oCWP9KAT39LgQh/RICBQD5/usD3v3PAsL+swOp/bUDxP3RAuD/7QH8/gcDFv0jAjL/PwBOAFUBSP05BCz8HQQQ/AED9v7nAtr+ywK+/rACrf65AcgA1gDkAPIAAP4LBBr8JwQ2/EMDUf5QAkT/Nf8nAxr8CwQA/fEB5AHW/scCuv6sArH+vQLM/tkC6P71AQIAEAAeACwAOgBI/1QCTf4/AjL+IwIW/gcB/AHu/d8E0vzDA7b+qAG1AMIA0ADe/+sC+v4FAhT/If8vAj7+SgJX/kkCPP4tAiD+EQEEAfj+6QLc/s0BwACzAKsAuADGANT/4QLw/v0DCvsXBSb9MwFCAU/9UgNG/jcCKv4bAg7+/wH0Aeb+1wPK/bsBrwGv/7sAygHY/uUD9P3/Ag7/GwEq/zcBRv9SAU8AQv8zASYAGP8JAv797wPi/tMBxv+4Aav/sgHA/80A3ADqAfj/AwER/h0CKv40A0D9SQI+/zAAJQEa/g4CBP77AvP/6QHi/toB1QHQ/tgD4vzpBPH99wL+/gIBCAEM/g8CE/4VARcAEQANAAn/BAECAAD//gL+/v0B/v/+"
+      },
+      "dragHandle": ".borealis-node-header",
+      "width": 232,
+      "height": 214,
+      "positionAbsolute": {
+        "x": 854.1638317296133,
+        "y": 516.4659418511601
+      },
+      "selected": true,
+      "dragging": false
+    },
+    {
+      "id": "node-1746283079084",
+      "type": "RegexSearch",
+      "position": {
+        "x": 826.8305081223305,
+        "y": 305.8868560603816
+      },
+      "data": {
+        "label": "Thing to Search For",
+        "content": "Return 1 or 0 depending on regex match",
+        "pattern": "4F|F4",
+        "flags": ""
+      },
+      "dragHandle": ".borealis-node-header",
+      "width": 160,
+      "height": 63,
+      "selected": false,
+      "positionAbsolute": {
+        "x": 826.8305081223305,
+        "y": 305.8868560603816
+      },
+      "dragging": false
+    },
+    {
+      "id": "node-1746283336373",
+      "type": "Borealis_Agent",
+      "position": {
+        "x": 175.33333333333326,
+        "y": 108.66666666666669
+      },
+      "data": {
+        "label": "Borealis Agent",
+        "content": "Select and manage an Agent with dynamic roles",
+        "agent_id": "lab-operator-01-agent-80be9252"
+      },
+      "dragHandle": ".borealis-node-header",
+      "positionAbsolute": {
+        "x": 175.33333333333326,
+        "y": 108.66666666666669
+      },
+      "width": 205,
+      "height": 146,
+      "selected": false,
+      "dragging": false
+    },
+    {
+      "id": "node-1746283354080",
+      "type": "Agent_Role_Screenshot",
+      "position": {
+        "x": 178.49390151447835,
+        "y": 308.8065719698093
+      },
+      "data": {
+        "label": "Agent Role: Screenshot",
+        "content": "Capture screenshot region via agent",
+        "x": 18,
+        "y": 963,
+        "w": 591,
+        "h": 19
+      },
+      "dragHandle": ".borealis-node-header",
+      "width": 160,
+      "height": 115,
+      "selected": false,
+      "positionAbsolute": {
+        "x": 178.49390151447835,
+        "y": 308.8065719698093
+      },
+      "dragging": false
+    },
+    {
+      "id": "node-1746283603300",
+      "type": "BWThresholdNode",
+      "position": {
+        "x": 492.601784739305,
+        "y": 110.78182722470859
+      },
+      "data": {
+        "label": "BW Threshold",
+        "content": "Applies black & white threshold to base64 image input."
+      },
+      "dragHandle": ".borealis-node-header",
+      "width": 160,
+      "height": 96,
+      "selected": false,
+      "positionAbsolute": {
+        "x": 492.601784739305,
+        "y": 110.78182722470859
+      },
+      "dragging": false
+    },
+    {
+      "id": "node-1746283604811",
+      "type": "Image_Viewer",
+      "position": {
+        "x": 819.0056893262067,
+        "y": 121.39658834948577
+      },
+      "data": {
+        "label": "Image Viewer",
+        "content": "Visual preview of base64 image with zoom overlay."
+      },
+      "dragHandle": ".borealis-node-header",
+      "width": 160,
+      "height": 69,
+      "selected": false,
+      "positionAbsolute": {
+        "x": 819.0056893262067,
+        "y": 121.39658834948577
+      },
+      "dragging": false
+    },
+    {
+      "id": "node-1746283686611",
+      "type": "OCR_Text_Extraction",
+      "position": {
+        "x": 508.5239264264711,
+        "y": 222.23681903487005
+      },
+      "data": {
+        "label": "OCR Text Extraction",
+        "content": "Extract Multi-Line Text from Upstream Image Node",
+        "engine": "EasyOCR",
+        "backend": "GPU",
+        "dataType": "Mixed",
+        "customRateEnabled": true,
+        "customRateMs": 1000,
+        "changeThreshold": 0
+      },
+      "dragHandle": ".borealis-node-header",
+      "positionAbsolute": {
+        "x": 508.5239264264711,
+        "y": 222.23681903487005
+      },
+      "width": 231,
+      "height": 160,
+      "selected": false,
+      "dragging": false
+    }
+  ],
+  "edges": [
+    {
+      "source": "node-1746283079084",
+      "sourceHandle": null,
+      "target": "node-1746283065191",
+      "targetHandle": null,
+      "type": "step",
+      "animated": true,
+      "style": {
+        "strokeDasharray": "6 3",
+        "stroke": "#58a6ff"
+      },
+      "id": "reactflow__edge-node-1746283079084-node-1746283065191",
+      "label": "Search for Tower 4F",
+      "labelBgStyle": {
+        "fill": "#000000",
+        "fillOpacity": 0.8
+      },
+      "labelStyle": {
+        "fill": "#7ed321"
+      }
+    },
+    {
+      "source": "node-1746283336373",
+      "sourceHandle": "provisioner",
+      "target": "node-1746283354080",
+      "targetHandle": null,
+      "type": "step",
+      "animated": true,
+      "style": {
+        "strokeDasharray": "6 3",
+        "stroke": "#58a6ff"
+      },
+      "id": "reactflow__edge-node-1746283336373provisioner-node-1746283354080",
+      "label": "Read Flyff Chat",
+      "labelBgStyle": {
+        "fill": "#000000",
+        "fillOpacity": 0.8
+      },
+      "labelStyle": {
+        "fill": "#7ed321"
+      }
+    },
+    {
+      "source": "node-1746283603300",
+      "sourceHandle": null,
+      "target": "node-1746283604811",
+      "targetHandle": null,
+      "type": "bezier",
+      "animated": true,
+      "style": {
+        "strokeDasharray": "6 3",
+        "stroke": "#f8e71c"
+      },
+      "id": "reactflow__edge-node-1746283603300-node-1746283604811",
+      "label": "Processed Flyff Chat",
+      "labelStyle": {
+        "fill": "#7ed321"
+      },
+      "labelBgStyle": {
+        "fill": "#000000",
+        "fillOpacity": 0.8
+      }
+    },
+    {
+      "source": "node-1746283354080",
+      "sourceHandle": null,
+      "target": "node-1746283603300",
+      "targetHandle": null,
+      "type": "step",
+      "animated": true,
+      "style": {
+        "strokeDasharray": "6 3",
+        "stroke": "#f8e71c"
+      },
+      "id": "reactflow__edge-node-1746283354080-node-1746283603300"
+    },
+    {
+      "source": "node-1746283604811",
+      "sourceHandle": null,
+      "target": "node-1746283686611",
+      "targetHandle": null,
+      "type": "step",
+      "animated": true,
+      "style": {
+        "strokeDasharray": "6 3",
+        "stroke": "#58a6ff"
+      },
+      "id": "reactflow__edge-node-1746283604811-node-1746283686611"
+    },
+    {
+      "source": "node-1746283686611",
+      "sourceHandle": null,
+      "target": "node-1746283079084",
+      "targetHandle": null,
+      "type": "bezier",
+      "animated": true,
+      "style": {
+        "strokeDasharray": "6 3",
+        "stroke": "#7ed321"
+      },
+      "id": "reactflow__edge-node-1746283686611-node-1746283079084"
+    }
+  ]
+}

--- a/Workflows/Games/Flyff Universe/Flyff Status Breakdown.json
+++ b/Workflows/Games/Flyff Universe/Flyff Status Breakdown.json
@@ -565,5 +565,5 @@
       }
     }
   ],
-  "tab_name": "Flyff Character Status"
+  "tab_name": "Flyff Status Breakdown"
 }


### PR DESCRIPTION
## Summary
- enable exporting/importing of workflow JSON files and saving them to disk
- add API endpoints for persisting and renaming workflows
- allow workflows to be renamed from the list via a context menu

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68981ccc5f04832f84416ddee8e0d388