### PR TITLE
feat: add workflow folder management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ Borealis-Server.exe
 /Dependencies/Python/
 /Dependencies/AutoHotKey/
 /Data/Server/Python_API_Endpoints/Tesseract-OCR/
+
+# Ignore Electron dependencies
+/Data/Electron/node_modules/
+/Data/Electron/package-lock.json

--- a/Data/Server/WebUI/package.json
+++ b/Data/Server/WebUI/package.json
@@ -12,6 +12,7 @@
     "@emotion/styled": "11.14.0",
     "@mui/icons-material": "7.0.2",
     "@mui/material": "7.0.2",
+    "@mui/lab": "7.0.0-alpha.2",
     "normalize.css": "8.0.1",
     "prismjs": "1.30.0",
     "react": "19.1.0",

--- a/Data/Server/WebUI/src/Dialogs.jsx
+++ b/Data/Server/WebUI/src/Dialogs.jsx
@@ -11,6 +11,10 @@ import {
   MenuItem,
   TextField
 } from "@mui/material";
+import TreeView from "@mui/lab/TreeView";
+import TreeItem from "@mui/lab/TreeItem";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 
 export function CloseAllDialog({ open, onClose, onConfirm }) {
   return (
@@ -127,6 +131,93 @@ export function RenameWorkflowDialog({ open, value, onChange, onCancel, onSave }
       <DialogActions>
         <Button onClick={onCancel} sx={{ color: "#58a6ff" }}>Cancel</Button>
         <Button onClick={onSave} sx={{ color: "#58a6ff" }}>Save</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+export function CreateFolderDialog({ open, value, onChange, onCancel, onCreate }) {
+  return (
+    <Dialog open={open} onClose={onCancel} PaperProps={{ sx: { bgcolor: "#121212", color: "#fff" } }}>
+      <DialogTitle>Create Folder</DialogTitle>
+      <DialogContent>
+        <DialogContentText sx={{ color: "#ccc", mb: 1 }}>
+          To create nested folders, use a structure such as "TopFolder/SubFolder/Subfolder".
+        </DialogContentText>
+        <TextField
+          autoFocus
+          margin="dense"
+          label="Folder Path"
+          fullWidth
+          variant="outlined"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          sx={{
+            "& .MuiOutlinedInput-root": {
+              backgroundColor: "#2a2a2a",
+              color: "#ccc",
+              "& fieldset": { borderColor: "#444" },
+              "&:hover fieldset": { borderColor: "#666" }
+            },
+            label: { color: "#aaa" },
+            mt: 1
+          }}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onCancel} sx={{ color: "#58a6ff" }}>Cancel</Button>
+        <Button onClick={onCreate} sx={{ color: "#58a6ff" }}>Create</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+function buildTree(folders) {
+  const root = {};
+  folders.forEach((p) => {
+    const parts = p.split("/").filter(Boolean);
+    let node = root;
+    parts.forEach((part) => {
+      if (!node[part]) node[part] = {};
+      node = node[part];
+    });
+  });
+  return root;
+}
+
+function renderTree(node, base = "") {
+  return Object.keys(node).map((name) => {
+    const current = base ? `${base}/${name}` : name;
+    return (
+      <TreeItem key={current} nodeId={current} label={name}>
+        {renderTree(node[name], current)}
+      </TreeItem>
+    );
+  });
+}
+
+export function MoveWorkflowDialog({ open, folders, value, onSelect, onCancel, onMove }) {
+  const tree = buildTree(folders);
+  return (
+    <Dialog open={open} onClose={onCancel} PaperProps={{ sx: { bgcolor: "#121212", color: "#fff" } }}>
+      <DialogTitle>Move Workflow</DialogTitle>
+      <DialogContent sx={{ minWidth: 300 }}>
+        <TreeView
+          defaultExpandAll
+          selected={value || ""}
+          onNodeSelect={(e, nodeId) => onSelect(nodeId)}
+          defaultCollapseIcon={<ExpandMoreIcon />}
+          defaultExpandIcon={<ChevronRightIcon />}
+          sx={{ mt: 1 }}
+        >
+          <TreeItem nodeId="" label="Workflows">
+            {renderTree(tree)}
+          </TreeItem>
+        </TreeView>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onCancel} sx={{ color: "#58a6ff" }}>Cancel</Button>
+        <Button onClick={onMove} sx={{ bgcolor: "#ff4f4f", color: "#fff", "&:hover": { bgcolor: "#e04444" } }}>Move</Button>
       </DialogActions>
     </Dialog>
   );

--- a/Data/Server/WebUI/src/Workflow_List.jsx
+++ b/Data/Server/WebUI/src/Workflow_List.jsx
@@ -14,8 +14,8 @@ import {
   Menu,
   MenuItem
 } from "@mui/material";
-import { PlayCircle as PlayCircleIcon, MoreVert as MoreVertIcon } from "@mui/icons-material";
-import { RenameWorkflowDialog } from "./Dialogs";
+import { PlayCircle as PlayCircleIcon, MoreVert as MoreVertIcon, CreateNewFolder as CreateNewFolderIcon } from "@mui/icons-material";
+import { RenameWorkflowDialog, CreateFolderDialog, MoveWorkflowDialog } from "./Dialogs";
 
 function formatDateTime(dateString) {
   if (!dateString) return "";
@@ -39,6 +39,11 @@ export default function WorkflowList({ onOpenWorkflow }) {
   const [selected, setSelected] = useState(null);
   const [renameOpen, setRenameOpen] = useState(false);
   const [renameValue, setRenameValue] = useState("");
+  const [createOpen, setCreateOpen] = useState(false);
+  const [createValue, setCreateValue] = useState("");
+  const [moveOpen, setMoveOpen] = useState(false);
+  const [folders, setFolders] = useState([]);
+  const [selectedFolder, setSelectedFolder] = useState("");
 
   const loadRows = useCallback(async () => {
     try {
@@ -60,9 +65,22 @@ export default function WorkflowList({ onOpenWorkflow }) {
     }
   }, []);
 
+  const loadFolders = useCallback(async () => {
+    try {
+      const resp = await fetch("/api/storage/list_folders");
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      const data = await resp.json();
+      setFolders(data.folders || []);
+    } catch (err) {
+      console.error("Failed to load folders:", err);
+      setFolders([]);
+    }
+  }, []);
+
   useEffect(() => {
     loadRows();
-  }, [loadRows]);
+    loadFolders();
+  }, [loadRows, loadFolders]);
 
   const handleSort = (col) => {
     if (orderBy === col) setOrder(order === "asc" ? "desc" : "asc");
@@ -90,6 +108,26 @@ export default function WorkflowList({ onOpenWorkflow }) {
     if (onOpenWorkflow) {
       onOpenWorkflow();
     }
+  };
+
+  const handleCreateFolder = () => {
+    setCreateValue("");
+    setCreateOpen(true);
+  };
+
+  const handleCreateSave = async () => {
+    try {
+      await fetch("/api/storage/create_folder", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ path: createValue })
+      });
+      await loadFolders();
+    } catch (err) {
+      console.error("Failed to create folder:", err);
+    }
+    setCreateOpen(false);
+    setCreateValue("");
   };
 
   const handleRowClick = (workflow) => {
@@ -133,6 +171,29 @@ export default function WorkflowList({ onOpenWorkflow }) {
     setSelected(null);
   };
 
+  const startMove = () => {
+    closeMenu();
+    setSelectedFolder("");
+    setMoveOpen(true);
+  };
+
+  const handleMove = async () => {
+    if (!selected) return;
+    try {
+      await fetch("/api/storage/move_workflow", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ path: selected.rel_path, dest: selectedFolder })
+      });
+      await loadRows();
+      await loadFolders();
+    } catch (err) {
+      console.error("Failed to move workflow:", err);
+    }
+    setMoveOpen(false);
+    setSelected(null);
+  };
+
   const renderNameCell = (r) => {
     const hasPrefix = r.breadcrumb_prefix && r.breadcrumb_prefix.length > 0;
     const primary = r.tab_name && r.tab_name.trim().length > 0 ? r.tab_name.trim() : r.file_name;
@@ -164,20 +225,36 @@ export default function WorkflowList({ onOpenWorkflow }) {
             List of available workflows.
           </Typography>
         </Box>
-        <Button
-          startIcon={<PlayCircleIcon />}
-          sx={{
-            color: "#58a6ff",
-            borderColor: "#58a6ff",
-            textTransform: "none",
-            border: "1px solid #58a6ff",
-            backgroundColor: "#1e1e1e",
-            "&:hover": { backgroundColor: "#1b1b1b" }
-          }}
-          onClick={handleNewWorkflow}
-        >
-          New Workflow
-        </Button>
+        <Box sx={{ display: "flex", gap: 1 }}>
+          <Button
+            startIcon={<CreateNewFolderIcon />}
+            sx={{
+              color: "#58a6ff",
+              borderColor: "#58a6ff",
+              textTransform: "none",
+              border: "1px solid #58a6ff",
+              backgroundColor: "#1e1e1e",
+              "&:hover": { backgroundColor: "#1b1b1b" }
+            }}
+            onClick={handleCreateFolder}
+          >
+            Create Folder
+          </Button>
+          <Button
+            startIcon={<PlayCircleIcon />}
+            sx={{
+              color: "#58a6ff",
+              borderColor: "#58a6ff",
+              textTransform: "none",
+              border: "1px solid #58a6ff",
+              backgroundColor: "#1e1e1e",
+              "&:hover": { backgroundColor: "#1b1b1b" }
+            }}
+            onClick={handleNewWorkflow}
+          >
+            New Workflow
+          </Button>
+        </Box>
       </Box>
       <Table size="small" sx={{ minWidth: 680 }}>
         <TableHead>
@@ -259,6 +336,7 @@ export default function WorkflowList({ onOpenWorkflow }) {
         onClose={closeMenu}
         PaperProps={{ sx: { bgcolor: "#1e1e1e", color: "#fff", fontSize: "13px" } }}
       >
+        <MenuItem onClick={startMove}>Move Flow</MenuItem>
         <MenuItem onClick={startRename}>Rename</MenuItem>
       </Menu>
       <RenameWorkflowDialog
@@ -267,6 +345,21 @@ export default function WorkflowList({ onOpenWorkflow }) {
         onChange={setRenameValue}
         onCancel={() => setRenameOpen(false)}
         onSave={handleRenameSave}
+      />
+      <CreateFolderDialog
+        open={createOpen}
+        value={createValue}
+        onChange={setCreateValue}
+        onCancel={() => setCreateOpen(false)}
+        onCreate={handleCreateSave}
+      />
+      <MoveWorkflowDialog
+        open={moveOpen}
+        folders={folders}
+        value={selectedFolder}
+        onSelect={setSelectedFolder}
+        onCancel={() => setMoveOpen(false)}
+        onMove={handleMove}
       />
     </Paper>
   );

--- a/Data/Server/server.py
+++ b/Data/Server/server.py
@@ -243,6 +243,63 @@ def rename_workflow():
     except Exception as e:
         return jsonify({"error": str(e)}), 500
 
+
+@app.route("/api/storage/create_folder", methods=["POST"])
+def create_folder():
+    data = request.get_json(silent=True) or {}
+    folder_path = (data.get("path") or "").strip()
+    workflows_root = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "Workflows")
+    )
+    abs_folder = os.path.abspath(os.path.join(workflows_root, folder_path))
+    if not abs_folder.startswith(workflows_root):
+        return jsonify({"error": "Invalid path"}), 400
+    try:
+        os.makedirs(abs_folder, exist_ok=True)
+        rel_new = os.path.relpath(abs_folder, workflows_root).replace(os.sep, "/")
+        return jsonify({"status": "ok", "rel_path": rel_new})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@app.route("/api/storage/list_folders", methods=["GET"])
+def list_folders():
+    workflows_root = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "Workflows")
+    )
+    folders = [""]
+    if os.path.isdir(workflows_root):
+        for root, dirs, _ in os.walk(workflows_root):
+            for d in dirs:
+                rel = os.path.relpath(os.path.join(root, d), workflows_root)
+                folders.append(rel.replace(os.sep, "/"))
+    folders = sorted(set(folders))
+    return jsonify({"folders": folders})
+
+
+@app.route("/api/storage/move_workflow", methods=["POST"])
+def move_workflow():
+    data = request.get_json(silent=True) or {}
+    rel_path = (data.get("path") or "").strip()
+    dest_folder = (data.get("dest") or "").strip()
+    workflows_root = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "Workflows")
+    )
+    src_abs = os.path.abspath(os.path.join(workflows_root, rel_path))
+    dest_folder_abs = os.path.abspath(os.path.join(workflows_root, dest_folder))
+    if not src_abs.startswith(workflows_root) or not os.path.isfile(src_abs):
+        return jsonify({"error": "Workflow not found"}), 404
+    if not dest_folder_abs.startswith(workflows_root):
+        return jsonify({"error": "Invalid destination"}), 400
+    try:
+        os.makedirs(dest_folder_abs, exist_ok=True)
+        dest_abs = os.path.join(dest_folder_abs, os.path.basename(src_abs))
+        os.replace(src_abs, dest_abs)
+        rel_new = os.path.relpath(dest_abs, workflows_root).replace(os.sep, "/")
+        return jsonify({"status": "ok", "rel_path": rel_new})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
 # ---------------------------------------------
 # Borealis Agent API Endpoints
 # ---------------------------------------------


### PR DESCRIPTION
## Summary
- allow creating workflow folders via new API and UI dialog
- add move workflow support with folder tree selection
- expose storage endpoints to list folders and move or create workflows

## Testing
- `pytest`
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68982757dd88832fa91ef85a1b3d7546