### PR TITLE
Expand workflow list tree view by default

### DIFF
--- a/Data/Server/WebUI/src/Workflow_List.jsx
+++ b/Data/Server/WebUI/src/Workflow_List.jsx
@@ -321,7 +321,7 @@ export default function WorkflowList({ onOpenWorkflow }) {
           sx={{ color: "#e6edf3" }}
           onNodeSelect={handleNodeSelect}
           apiRef={apiRef}
-          defaultExpanded={["root", ...rootChildIds]}
+          defaultExpandedItems={["root", ...rootChildIds]}
         >
           {renderItems(tree)}
         </SimpleTreeView>

--- a/Data/Server/WebUI/src/Workflow_List.jsx
+++ b/Data/Server/WebUI/src/Workflow_List.jsx
@@ -283,6 +283,8 @@ export default function WorkflowList({ onOpenWorkflow }) {
       </TreeItem>
     ));
 
+  const rootChildIds = tree[0]?.children?.map((c) => c.id) || [];
+
   return (
     <Paper sx={{ m: 2, p: 0, bgcolor: "#1e1e1e" }} elevation={2}>
       <Box
@@ -315,10 +317,11 @@ export default function WorkflowList({ onOpenWorkflow }) {
         }}
       >
         <SimpleTreeView
+          key={rootChildIds.join(",")}
           sx={{ color: "#e6edf3" }}
           onNodeSelect={handleNodeSelect}
           apiRef={apiRef}
-          defaultExpanded={["root"]}
+          defaultExpanded={["root", ...rootChildIds]}
         >
           {renderItems(tree)}
         </SimpleTreeView>


### PR DESCRIPTION
## Summary
- Expand workflow tree root and its first-level children on page load for easier browsing

## Testing
- `npm test`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68985f2bc0f4832fa7d3e7abc5cf3223