### PR TITLE
Add device details page with agent data collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ Borealis-Server.exe
 /Dependencies/Python/
 /Dependencies/AutoHotKey/
 /Data/Server/Python_API_Endpoints/Tesseract-OCR/
+# Device database
+/Databases/

--- a/Data/Agent/borealis-agent.py
+++ b/Data/Agent/borealis-agent.py
@@ -404,6 +404,7 @@ def collect_memory():
 
 def collect_storage():
     disks = []
+    plat = platform.system().lower()
     try:
         if psutil:
             for part in psutil.disk_partitions():
@@ -418,18 +419,100 @@ def collect_storage():
                     "total": usage.total,
                     "free": 100 - usage.percent,
                 })
+        elif plat == "windows":
+            ps_cmd = (
+                "Get-PSDrive -PSProvider FileSystem | "
+                "Select-Object Name,Free,Used,Capacity,Root | ConvertTo-Json"
+            )
+            out = subprocess.run(
+                ["powershell", "-NoProfile", "-Command", ps_cmd],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            data = json.loads(out.stdout or "[]")
+            if isinstance(data, dict):
+                data = [data]
+            for d in data:
+                total = d.get("Capacity") or 0
+                used = d.get("Used") or 0
+                usage = (used / total * 100) if total else 0
+                free = 100 - usage
+                drive = d.get("Root") or f"{d.get('Name','')}:"
+                disks.append({
+                    "drive": drive,
+                    "disk_type": "Fixed Disk",
+                    "usage": usage,
+                    "total": total,
+                    "free": free,
+                })
+        else:
+            out = subprocess.run(
+                ["df", "-kP"], capture_output=True, text=True, timeout=60
+            )
+            lines = out.stdout.strip().splitlines()[1:]
+            for line in lines:
+                parts = line.split()
+                if len(parts) >= 6:
+                    total = int(parts[1]) * 1024
+                    used = int(parts[2]) * 1024
+                    usage = float(parts[4].rstrip("%"))
+                    free = 100 - usage
+                    disks.append({
+                        "drive": parts[5],
+                        "disk_type": "Fixed Disk",
+                        "usage": usage,
+                        "total": total,
+                        "free": free,
+                    })
     except Exception as e:
         print(f"[WARN] collect_storage failed: {e}")
     return disks
 
 def collect_network():
     adapters = []
+    plat = platform.system().lower()
     try:
         if psutil:
             for name, addrs in psutil.net_if_addrs().items():
                 ips = [a.address for a in addrs if getattr(a, "family", None) == socket.AF_INET]
                 mac = next((a.address for a in addrs if getattr(a, "family", None) == getattr(psutil, "AF_LINK", object)), "unknown")
                 adapters.append({"adapter": name, "ips": ips, "mac": mac})
+        elif plat == "windows":
+            ps_cmd = (
+                "Get-NetIPConfiguration | "
+                "Select-Object InterfaceAlias,@{Name='IPv4';Expression={$_.IPv4Address.IPAddress}},"
+                "@{Name='MAC';Expression={$_.NetAdapter.MacAddress}} | ConvertTo-Json"
+            )
+            out = subprocess.run(
+                ["powershell", "-NoProfile", "-Command", ps_cmd],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            data = json.loads(out.stdout or "[]")
+            if isinstance(data, dict):
+                data = [data]
+            for a in data:
+                ip = a.get("IPv4")
+                adapters.append({
+                    "adapter": a.get("InterfaceAlias", "unknown"),
+                    "ips": [ip] if ip else [],
+                    "mac": a.get("MAC", "unknown"),
+                })
+        else:
+            out = subprocess.run(
+                ["ip", "-o", "-4", "addr", "show"],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            for line in out.stdout.splitlines():
+                parts = line.split()
+                if len(parts) >= 4:
+                    name = parts[1]
+                    ip = parts[3].split("/")[0]
+                    adapters.append({"adapter": name, "ips": [ip], "mac": "unknown"})
     except Exception as e:
         print(f"[WARN] collect_network failed: {e}")
     return adapters

--- a/Data/Agent/borealis-agent.py
+++ b/Data/Agent/borealis-agent.py
@@ -16,6 +16,7 @@ import importlib.util
 import time  # Heartbeat timestamps
 import subprocess
 import getpass
+import datetime
 
 import requests
 try:
@@ -228,13 +229,45 @@ def _get_internal_ip():
 
 def collect_summary():
     try:
-        last_user = getpass.getuser()
+        username = getpass.getuser()
+        domain = os.environ.get("USERDOMAIN") or socket.gethostname()
+        last_user = f"{domain}\\{username}" if username else "unknown"
     except Exception:
         last_user = "unknown"
     try:
         last_reboot = "unknown"
         if psutil:
-            last_reboot = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(psutil.boot_time()))
+            last_reboot = time.strftime(
+                "%Y-%m-%d %H:%M:%S",
+                time.localtime(psutil.boot_time()),
+            )
+        else:
+            plat = platform.system().lower()
+            if plat == "windows":
+                ps_cmd = "(Get-CimInstance Win32_OperatingSystem).LastBootUpTime"
+                out = subprocess.run(
+                    ["powershell", "-NoProfile", "-Command", ps_cmd],
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                )
+                raw = out.stdout.strip()
+                if raw:
+                    try:
+                        boot = datetime.datetime.strptime(raw.split(".")[0], "%Y%m%d%H%M%S")
+                        last_reboot = boot.strftime("%Y-%m-%d %H:%M:%S")
+                    except Exception:
+                        pass
+            else:
+                try:
+                    out = subprocess.run(
+                        ["uptime", "-s"], capture_output=True, text=True, timeout=30
+                    )
+                    val = out.stdout.strip()
+                    if val:
+                        last_reboot = val
+                except Exception:
+                    pass
     except Exception:
         last_reboot = "unknown"
 

--- a/Data/Agent/borealis-agent.py
+++ b/Data/Agent/borealis-agent.py
@@ -14,6 +14,15 @@ import random  # Macro Randomization
 import platform  # OS Detection
 import importlib.util
 import time  # Heartbeat timestamps
+import subprocess
+import getpass
+
+import requests
+try:
+    import psutil
+except Exception:
+    psutil = None
+import aiohttp
 
 import socketio
 from qasync import QEventLoop
@@ -204,6 +213,244 @@ async def send_heartbeat():
         except Exception as e:
             print(f"[WARN] heartbeat emit failed: {e}")
         await asyncio.sleep(5)
+
+# ---------------- Detailed Agent Data ----------------
+
+def _get_internal_ip():
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.connect(("8.8.8.8", 80))
+        ip = s.getsockname()[0]
+        s.close()
+        return ip
+    except Exception:
+        return "unknown"
+
+def collect_summary():
+    try:
+        last_user = getpass.getuser()
+    except Exception:
+        last_user = "unknown"
+    try:
+        last_reboot = "unknown"
+        if psutil:
+            last_reboot = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(psutil.boot_time()))
+    except Exception:
+        last_reboot = "unknown"
+
+    created = CONFIG.data.get("created")
+    if not created:
+        created = time.strftime("%Y-%m-%d %H:%M:%S")
+        CONFIG.data["created"] = created
+        CONFIG._write()
+
+    try:
+        external_ip = requests.get("https://api.ipify.org", timeout=5).text.strip()
+    except Exception:
+        external_ip = "unknown"
+
+    return {
+        "hostname": socket.gethostname(),
+        "operating_system": CONFIG.data.get("agent_operating_system", detect_agent_os()),
+        "last_user": last_user,
+        "internal_ip": _get_internal_ip(),
+        "external_ip": external_ip,
+        "last_reboot": last_reboot,
+        "created": created,
+    }
+
+def collect_software():
+    items = []
+    plat = platform.system().lower()
+    try:
+        if plat == "windows":
+            try:
+                out = subprocess.run(["wmic", "product", "get", "name,version"],
+                                     capture_output=True, text=True, timeout=60)
+                for line in out.stdout.splitlines():
+                    if line.strip() and not line.lower().startswith("name"):
+                        parts = line.strip().split("  ")
+                        name = parts[0].strip()
+                        version = parts[-1].strip() if len(parts) > 1 else ""
+                        if name:
+                            items.append({"name": name, "version": version})
+            except FileNotFoundError:
+                ps_cmd = (
+                    "Get-ItemProperty "
+                    "'HKLM:\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*',"
+                    "'HKLM:\\Software\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*' "
+                    "| Where-Object { $_.DisplayName } "
+                    "| Select-Object DisplayName,DisplayVersion "
+                    "| ConvertTo-Json"
+                )
+                out = subprocess.run(
+                    ["powershell", "-NoProfile", "-Command", ps_cmd],
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                )
+                data = json.loads(out.stdout or "[]")
+                if isinstance(data, dict):
+                    data = [data]
+                for pkg in data:
+                    name = pkg.get("DisplayName")
+                    if name:
+                        items.append({
+                            "name": name,
+                            "version": pkg.get("DisplayVersion", "")
+                        })
+        elif plat == "linux":
+            out = subprocess.run(["dpkg-query", "-W", "-f=${Package}\t${Version}\n"], capture_output=True, text=True)
+            for line in out.stdout.splitlines():
+                if "\t" in line:
+                    name, version = line.split("\t", 1)
+                    items.append({"name": name, "version": version})
+        else:
+            out = subprocess.run([sys.executable, "-m", "pip", "list", "--format", "json"], capture_output=True, text=True)
+            data = json.loads(out.stdout or "[]")
+            for pkg in data:
+                items.append({"name": pkg.get("name"), "version": pkg.get("version")})
+    except Exception as e:
+        print(f"[WARN] collect_software failed: {e}")
+    return items[:100]
+
+def collect_memory():
+    entries = []
+    plat = platform.system().lower()
+    try:
+        if plat == "windows":
+            try:
+                out = subprocess.run(
+                    ["wmic", "memorychip", "get", "BankLabel,Speed,SerialNumber,Capacity"],
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                )
+                lines = [l for l in out.stdout.splitlines() if l.strip() and "BankLabel" not in l]
+                for line in lines:
+                    parts = [p for p in line.split() if p]
+                    if len(parts) >= 4:
+                        entries.append({
+                            "slot": parts[0],
+                            "speed": parts[1],
+                            "serial": parts[2],
+                            "capacity": parts[3],
+                        })
+            except FileNotFoundError:
+                ps_cmd = (
+                    "Get-CimInstance Win32_PhysicalMemory | "
+                    "Select-Object BankLabel,Speed,SerialNumber,Capacity | ConvertTo-Json"
+                )
+                out = subprocess.run(
+                    ["powershell", "-NoProfile", "-Command", ps_cmd],
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                )
+                data = json.loads(out.stdout or "[]")
+                if isinstance(data, dict):
+                    data = [data]
+                for stick in data:
+                    entries.append({
+                        "slot": stick.get("BankLabel", "unknown"),
+                        "speed": str(stick.get("Speed", "unknown")),
+                        "serial": stick.get("SerialNumber", "unknown"),
+                        "capacity": stick.get("Capacity", "unknown"),
+                    })
+        elif plat == "linux":
+            out = subprocess.run(["dmidecode", "-t", "17"], capture_output=True, text=True)
+            slot = speed = serial = capacity = None
+            for line in out.stdout.splitlines():
+                line = line.strip()
+                if line.startswith("Locator:"):
+                    slot = line.split(":", 1)[1].strip()
+                elif line.startswith("Speed:"):
+                    speed = line.split(":", 1)[1].strip()
+                elif line.startswith("Serial Number:"):
+                    serial = line.split(":", 1)[1].strip()
+                elif line.startswith("Size:"):
+                    capacity = line.split(":", 1)[1].strip()
+                elif not line and slot:
+                    entries.append({
+                        "slot": slot,
+                        "speed": speed or "unknown",
+                        "serial": serial or "unknown",
+                        "capacity": capacity or "unknown",
+                    })
+                    slot = speed = serial = capacity = None
+            if slot:
+                entries.append({
+                    "slot": slot,
+                    "speed": speed or "unknown",
+                    "serial": serial or "unknown",
+                    "capacity": capacity or "unknown",
+                })
+    except Exception as e:
+        print(f"[WARN] collect_memory failed: {e}")
+
+    if not entries:
+        try:
+            if psutil:
+                vm = psutil.virtual_memory()
+                entries.append({
+                    "slot": "physical",
+                    "speed": "unknown",
+                    "serial": "unknown",
+                    "capacity": vm.total,
+                })
+        except Exception:
+            pass
+    return entries
+
+def collect_storage():
+    disks = []
+    try:
+        if psutil:
+            for part in psutil.disk_partitions():
+                try:
+                    usage = psutil.disk_usage(part.mountpoint)
+                except Exception:
+                    continue
+                disks.append({
+                    "drive": part.device,
+                    "disk_type": "Removable" if "removable" in part.opts.lower() else "Fixed Disk",
+                    "usage": usage.percent,
+                    "total": usage.total,
+                    "free": 100 - usage.percent,
+                })
+    except Exception as e:
+        print(f"[WARN] collect_storage failed: {e}")
+    return disks
+
+def collect_network():
+    adapters = []
+    try:
+        if psutil:
+            for name, addrs in psutil.net_if_addrs().items():
+                ips = [a.address for a in addrs if getattr(a, "family", None) == socket.AF_INET]
+                mac = next((a.address for a in addrs if getattr(a, "family", None) == getattr(psutil, "AF_LINK", object)), "unknown")
+                adapters.append({"adapter": name, "ips": ips, "mac": mac})
+    except Exception as e:
+        print(f"[WARN] collect_network failed: {e}")
+    return adapters
+
+async def send_agent_details():
+    """Collect detailed agent data and send to server periodically."""
+    while True:
+        try:
+            details = {
+                "summary": collect_summary(),
+                "software": collect_software(),
+                "memory": collect_memory(),
+                "storage": collect_storage(),
+                "network": collect_network(),
+            }
+            url = CONFIG.data.get("borealis_server_url", "http://localhost:5000") + "/api/agent/details"
+            async with aiohttp.ClientSession() as session:
+                await session.post(url, json={"agent_id": AGENT_ID, "details": details}, timeout=10)
+        except Exception as e:
+            print(f"[WARN] Failed to send agent details: {e}")
+        await asyncio.sleep(300)
 
 @sio.event
 async def connect():
@@ -593,6 +840,7 @@ if __name__=='__main__':
         background_tasks.append(loop.create_task(idle_task()))
         # Start periodic heartbeats
         background_tasks.append(loop.create_task(send_heartbeat()))
+        background_tasks.append(loop.create_task(send_agent_details()))
         loop.run_forever()
     except Exception as e:
         print(f"[FATAL] Event loop crashed: {e}")

--- a/Data/Agent/borealis-agent.py
+++ b/Data/Agent/borealis-agent.py
@@ -237,27 +237,42 @@ def collect_summary():
     try:
         last_reboot = "unknown"
         if psutil:
-            last_reboot = time.strftime(
-                "%Y-%m-%d %H:%M:%S",
-                time.localtime(psutil.boot_time()),
-            )
-        else:
+            try:
+                last_reboot = time.strftime(
+                    "%Y-%m-%d %H:%M:%S",
+                    time.localtime(psutil.boot_time()),
+                )
+            except Exception:
+                last_reboot = "unknown"
+        if last_reboot == "unknown":
             plat = platform.system().lower()
             if plat == "windows":
-                ps_cmd = "(Get-CimInstance Win32_OperatingSystem).LastBootUpTime"
-                out = subprocess.run(
-                    ["powershell", "-NoProfile", "-Command", ps_cmd],
-                    capture_output=True,
-                    text=True,
-                    timeout=60,
-                )
-                raw = out.stdout.strip()
-                if raw:
-                    try:
+                try:
+                    out = subprocess.run(
+                        ["wmic", "os", "get", "lastbootuptime"],
+                        capture_output=True,
+                        text=True,
+                        timeout=60,
+                    )
+                    raw = "".join(out.stdout.splitlines()[1:]).strip()
+                    if raw:
                         boot = datetime.datetime.strptime(raw.split(".")[0], "%Y%m%d%H%M%S")
                         last_reboot = boot.strftime("%Y-%m-%d %H:%M:%S")
-                    except Exception:
-                        pass
+                except FileNotFoundError:
+                    ps_cmd = "(Get-CimInstance Win32_OperatingSystem).LastBootUpTime"
+                    out = subprocess.run(
+                        ["powershell", "-NoProfile", "-Command", ps_cmd],
+                        capture_output=True,
+                        text=True,
+                        timeout=60,
+                    )
+                    raw = out.stdout.strip()
+                    if raw:
+                        try:
+                            boot = datetime.datetime.strptime(raw.split(".")[0], "%Y%m%d%H%M%S")
+                            last_reboot = boot.strftime("%Y-%m-%d %H:%M:%S")
+                        except Exception:
+                            pass
             else:
                 try:
                     out = subprocess.run(
@@ -453,32 +468,60 @@ def collect_storage():
                     "free": 100 - usage.percent,
                 })
         elif plat == "windows":
-            ps_cmd = (
-                "Get-PSDrive -PSProvider FileSystem | "
-                "Select-Object Name,Free,Used,Capacity,Root | ConvertTo-Json"
-            )
-            out = subprocess.run(
-                ["powershell", "-NoProfile", "-Command", ps_cmd],
-                capture_output=True,
-                text=True,
-                timeout=60,
-            )
-            data = json.loads(out.stdout or "[]")
-            if isinstance(data, dict):
-                data = [data]
-            for d in data:
-                total = d.get("Capacity") or 0
-                used = d.get("Used") or 0
-                usage = (used / total * 100) if total else 0
-                free = 100 - usage
-                drive = d.get("Root") or f"{d.get('Name','')}:"
-                disks.append({
-                    "drive": drive,
-                    "disk_type": "Fixed Disk",
-                    "usage": usage,
-                    "total": total,
-                    "free": free,
-                })
+            try:
+                out = subprocess.run(
+                    ["wmic", "logicaldisk", "get", "DeviceID,Size,FreeSpace"],
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                )
+                lines = [l for l in out.stdout.splitlines() if l.strip()][1:]
+                for line in lines:
+                    parts = line.split()
+                    if len(parts) >= 3:
+                        drive, free, size = parts[0], parts[1], parts[2]
+                        try:
+                            total = float(size)
+                            free_bytes = float(free)
+                            used = total - free_bytes
+                            usage = (used / total * 100) if total else 0
+                            free_pct = 100 - usage
+                            disks.append({
+                                "drive": drive,
+                                "disk_type": "Fixed Disk",
+                                "usage": usage,
+                                "total": total,
+                                "free": free_pct,
+                            })
+                        except Exception:
+                            pass
+            except FileNotFoundError:
+                ps_cmd = (
+                    "Get-PSDrive -PSProvider FileSystem | "
+                    "Select-Object Name,Free,Used,Capacity,Root | ConvertTo-Json"
+                )
+                out = subprocess.run(
+                    ["powershell", "-NoProfile", "-Command", ps_cmd],
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                )
+                data = json.loads(out.stdout or "[]")
+                if isinstance(data, dict):
+                    data = [data]
+                for d in data:
+                    total = d.get("Capacity") or 0
+                    used = d.get("Used") or 0
+                    usage = (used / total * 100) if total else 0
+                    free = 100 - usage
+                    drive = d.get("Root") or f"{d.get('Name','')}:"
+                    disks.append({
+                        "drive": drive,
+                        "disk_type": "Fixed Disk",
+                        "usage": usage,
+                        "total": total,
+                        "free": free,
+                    })
         else:
             out = subprocess.run(
                 ["df", "-kP"], capture_output=True, text=True, timeout=60
@@ -562,8 +605,13 @@ async def send_agent_details():
                 "network": collect_network(),
             }
             url = CONFIG.data.get("borealis_server_url", "http://localhost:5000") + "/api/agent/details"
+            payload = {
+                "agent_id": AGENT_ID,
+                "hostname": details.get("summary", {}).get("hostname", socket.gethostname()),
+                "details": details,
+            }
             async with aiohttp.ClientSession() as session:
-                await session.post(url, json={"agent_id": AGENT_ID, "details": details}, timeout=10)
+                await session.post(url, json=payload, timeout=10)
         except Exception as e:
             print(f"[WARN] Failed to send agent details: {e}")
         await asyncio.sleep(300)

--- a/Data/Server/WebUI/src/App.jsx
+++ b/Data/Server/WebUI/src/App.jsx
@@ -29,6 +29,7 @@ import DeviceList from "./Device_List";
 import ScriptList from "./Script_List";
 import ScheduledJobsList from "./Scheduled_Jobs_List";
 import Login from "./Login.jsx";
+import DeviceDetails from "./Device_Details";
 
 import { io } from "socket.io-client";
 
@@ -77,6 +78,7 @@ export default function App() {
   const [tabs, setTabs] = useState([{ id: "flow_1", tab_name: "Flow 1", nodes: [], edges: [] }]);
   const [activeTabId, setActiveTabId] = useState("flow_1");
   const [currentPage, setCurrentPage] = useState("devices");
+  const [selectedDevice, setSelectedDevice] = useState(null);
 
   const [aboutAnchorEl, setAboutAnchorEl] = useState(null);
   const [creditsDialogOpen, setCreditsDialogOpen] = useState(false);
@@ -288,7 +290,25 @@ export default function App() {
   const renderMainContent = () => {
     switch (currentPage) {
       case "devices":
-        return <DeviceList />;
+        return (
+          <DeviceList
+            onSelectDevice={(d) => {
+              setSelectedDevice(d);
+              setCurrentPage("device_details");
+            }}
+          />
+        );
+
+      case "device_details":
+        return (
+          <DeviceDetails
+            device={selectedDevice}
+            onBack={() => {
+              setCurrentPage("devices");
+              setSelectedDevice(null);
+            }}
+          />
+        );
 
       case "jobs":
         return <ScheduledJobsList />;

--- a/Data/Server/WebUI/src/Device_Details.jsx
+++ b/Data/Server/WebUI/src/Device_Details.jsx
@@ -1,0 +1,259 @@
+////////// PROJECT FILE SEPARATION LINE ////////// CODE AFTER THIS LINE ARE FROM: <ProjectRoot>/Data/WebUI/src/Device_Details.jsx
+
+import React, { useState, useEffect } from "react";
+import {
+  Paper,
+  Box,
+  Tabs,
+  Tab,
+  Typography,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  Button
+} from "@mui/material";
+
+export default function DeviceDetails({ device, onBack }) {
+  const [tab, setTab] = useState(0);
+  const [agent, setAgent] = useState(device || {});
+  const [details, setDetails] = useState({});
+
+  useEffect(() => {
+    if (!device || !device.id) return;
+    const load = async () => {
+      try {
+        const [agentsRes, detailsRes] = await Promise.all([
+          fetch("/api/agents"),
+          fetch(`/api/agent/details/${device.id}`)
+        ]);
+        const agentsData = await agentsRes.json();
+        if (agentsData && agentsData[device.id]) {
+          setAgent({ id: device.id, ...agentsData[device.id] });
+        }
+        const detailData = await detailsRes.json();
+        setDetails(detailData || {});
+      } catch (e) {
+        console.warn("Failed to load device info", e);
+      }
+    };
+    load();
+  }, [device]);
+
+  const formatBytes = (val) => {
+    if (val === undefined || val === null || val === "unknown") return "unknown";
+    let num = Number(val);
+    const units = ["B", "KB", "MB", "GB", "TB"];
+    let i = 0;
+    while (num >= 1024 && i < units.length - 1) {
+      num /= 1024;
+      i++;
+    }
+    return `${num.toFixed(1)} ${units[i]}`;
+  };
+
+  const summary = details.summary || {};
+  const summaryItems = [
+    { label: "Device Name", value: summary.hostname || agent.hostname || device?.hostname || "unknown" },
+    { label: "Description", value: summary.description || "unknown" },
+    { label: "Operating System", value: summary.operating_system || agent.agent_operating_system || "unknown" },
+    { label: "Last User", value: summary.last_user || "unknown" },
+    { label: "Internal IP", value: summary.internal_ip || "unknown" },
+    { label: "External IP", value: summary.external_ip || "unknown" },
+    { label: "Last Reboot", value: summary.last_reboot || "unknown" },
+    { label: "Created", value: summary.created || "unknown" }
+  ];
+
+  const renderSummary = () => (
+    <Table size="small">
+      <TableBody>
+        {summaryItems.map((item) => (
+          <TableRow key={item.label}>
+            <TableCell sx={{ fontWeight: 500 }}>{item.label}</TableCell>
+            <TableCell>{item.value}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+
+  const placeholderTable = (headers) => (
+    <Table size="small">
+      <TableHead>
+        <TableRow>
+          {headers.map((h) => (
+            <TableCell key={h}>{h}</TableCell>
+          ))}
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        <TableRow>
+          <TableCell colSpan={headers.length} sx={{ color: "#888" }}>
+            No data available.
+          </TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
+  );
+
+  const renderSoftware = () => {
+    const rows = details.software || [];
+    if (!rows.length) return placeholderTable(["Software Name", "Version", "Action"]);
+    return (
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Software Name</TableCell>
+            <TableCell>Version</TableCell>
+            <TableCell>Action</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((s, i) => (
+            <TableRow key={`${s.name}-${i}`}>
+              <TableCell>{s.name}</TableCell>
+              <TableCell>{s.version}</TableCell>
+              <TableCell></TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    );
+  };
+
+  const renderMemory = () => {
+    const rows = details.memory || [];
+    if (!rows.length) return placeholderTable(["Slot", "Speed", "Serial Number", "Capacity"]);
+    return (
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Slot</TableCell>
+            <TableCell>Speed</TableCell>
+            <TableCell>Serial Number</TableCell>
+            <TableCell>Capacity</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((m, i) => (
+            <TableRow key={`${m.slot}-${i}`}>
+              <TableCell>{m.slot}</TableCell>
+              <TableCell>{m.speed}</TableCell>
+              <TableCell>{m.serial}</TableCell>
+              <TableCell>{formatBytes(m.capacity)}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    );
+  };
+
+  const renderStorage = () => {
+    const rows = details.storage || [];
+    if (!rows.length)
+      return placeholderTable(["Drive Letter", "Disk Type", "Usage", "Total Size", "Free %"]);
+    return (
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Drive Letter</TableCell>
+            <TableCell>Disk Type</TableCell>
+            <TableCell>Usage</TableCell>
+            <TableCell>Total Size</TableCell>
+            <TableCell>Free %</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((d, i) => (
+            <TableRow key={`${d.drive}-${i}`}>
+              <TableCell>{d.drive}</TableCell>
+              <TableCell>{d.disk_type}</TableCell>
+              <TableCell>
+                {d.usage !== undefined && d.usage !== null && d.usage !== "unknown"
+                  ? `${d.usage.toFixed ? d.usage.toFixed(1) : d.usage}%`
+                  : "unknown"}
+              </TableCell>
+              <TableCell>{formatBytes(d.total)}</TableCell>
+              <TableCell>
+                {d.free !== undefined && d.free !== null && d.free !== "unknown"
+                  ? `${d.free.toFixed ? d.free.toFixed(1) : d.free}%`
+                  : "unknown"}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    );
+  };
+
+  const renderNetwork = () => {
+    const rows = details.network || [];
+    if (!rows.length) return placeholderTable(["Adapter", "IP Address", "MAC Address"]);
+    return (
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Adapter</TableCell>
+            <TableCell>IP Address</TableCell>
+            <TableCell>MAC Address</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((n, i) => (
+            <TableRow key={`${n.adapter}-${i}`}>
+              <TableCell>{n.adapter}</TableCell>
+              <TableCell>{(n.ips || []).join(", ")}</TableCell>
+              <TableCell>{n.mac}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    );
+  };
+
+  const tabs = [
+    { label: "Summary", content: renderSummary() },
+    {
+      label: "Monitors",
+      content: placeholderTable([
+        "Type",
+        "Description",
+        "Latest Value",
+        "Policy",
+        "Latest 10 Days of Alerts",
+        "Enabled/Disabled Status"
+      ])
+    },
+    { label: "Software", content: renderSoftware() },
+    { label: "Memory", content: renderMemory() },
+    { label: "Storage", content: renderStorage() },
+    { label: "Network", content: renderNetwork() }
+  ];
+
+  return (
+    <Paper sx={{ m: 2, p: 2, bgcolor: "#1e1e1e" }} elevation={2}>
+      <Box sx={{ mb: 2, display: "flex", alignItems: "center" }}>
+        {onBack && (
+          <Button variant="outlined" size="small" onClick={onBack} sx={{ mr: 2 }}>
+            Back
+          </Button>
+        )}
+        <Typography variant="h6" sx={{ color: "#58a6ff" }}>
+          {agent.hostname || "Device Details"}
+        </Typography>
+      </Box>
+      <Tabs
+        value={tab}
+        onChange={(e, v) => setTab(v)}
+        sx={{ borderBottom: 1, borderColor: "#333" }}
+      >
+        {tabs.map((t) => (
+          <Tab key={t.label} label={t.label} />
+        ))}
+      </Tabs>
+      <Box sx={{ mt: 2 }}>{tabs[tab].content}</Box>
+    </Paper>
+  );
+}
+

--- a/Data/Server/WebUI/src/Device_Details.jsx
+++ b/Data/Server/WebUI/src/Device_Details.jsx
@@ -25,14 +25,15 @@ export default function DeviceDetails({ device, onBack }) {
   const [softwareOrderBy, setSoftwareOrderBy] = useState("name");
   const [softwareOrder, setSoftwareOrder] = useState("asc");
   const [softwareSearch, setSoftwareSearch] = useState("");
+  const [description, setDescription] = useState("");
 
   useEffect(() => {
-    if (!device || !device.id) return;
+    if (!device || !device.hostname) return;
     const load = async () => {
       try {
         const [agentsRes, detailsRes] = await Promise.all([
           fetch("/api/agents"),
-          fetch(`/api/agent/details/${device.id}`)
+          fetch(`/api/device/details/${device.hostname}`)
         ]);
         const agentsData = await agentsRes.json();
         if (agentsData && agentsData[device.id]) {
@@ -40,12 +41,48 @@ export default function DeviceDetails({ device, onBack }) {
         }
         const detailData = await detailsRes.json();
         setDetails(detailData || {});
+        setDescription(detailData?.summary?.description || "");
       } catch (e) {
         console.warn("Failed to load device info", e);
       }
     };
     load();
   }, [device]);
+
+  const saveDescription = async () => {
+    if (!details.summary?.hostname) return;
+    try {
+      await fetch(`/api/device/description/${details.summary.hostname}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ description })
+      });
+      setDetails((d) => ({
+        ...d,
+        summary: { ...(d.summary || {}), description }
+      }));
+    } catch (e) {
+      console.warn("Failed to save description", e);
+    }
+  };
+
+  const formatDateTime = (str) => {
+    if (!str) return "unknown";
+    try {
+      const [datePart, timePart] = str.split(" ");
+      const [y, m, d] = datePart.split("-").map(Number);
+      let [hh, mm, ss] = timePart.split(":").map(Number);
+      const ampm = hh >= 12 ? "PM" : "AM";
+      hh = hh % 12 || 12;
+      return `${m.toString().padStart(2, "0")}/${d.toString().padStart(2, "0")}/${y} - ${hh}:${mm
+        .toString()
+        .padStart(2, "0")}${ampm}`;
+    } catch {
+      return str;
+    }
+  };
+
+  const formatMac = (mac) => (mac ? mac.replace(/-/g, ":").toUpperCase() : "unknown");
 
   const formatBytes = (val) => {
     if (val === undefined || val === null || val === "unknown") return "unknown";
@@ -84,19 +121,37 @@ export default function DeviceDetails({ device, onBack }) {
   const summary = details.summary || {};
   const summaryItems = [
     { label: "Device Name", value: summary.hostname || agent.hostname || device?.hostname || "unknown" },
-    { label: "Description", value: summary.description || "unknown" },
     { label: "Operating System", value: summary.operating_system || agent.agent_operating_system || "unknown" },
     { label: "Last User", value: summary.last_user || "unknown" },
     { label: "Internal IP", value: summary.internal_ip || "unknown" },
     { label: "External IP", value: summary.external_ip || "unknown" },
-    { label: "Last Reboot", value: summary.last_reboot || "unknown" },
-    { label: "Created", value: summary.created || "unknown" }
+    { label: "Last Reboot", value: summary.last_reboot ? formatDateTime(summary.last_reboot) : "unknown" },
+    { label: "Created", value: summary.created ? formatDateTime(summary.created) : "unknown" }
   ];
 
   const renderSummary = () => (
     <Box sx={{ maxHeight: 400, overflowY: "auto" }}>
       <Table size="small">
         <TableBody>
+          <TableRow>
+            <TableCell sx={{ fontWeight: 500 }}>Description</TableCell>
+            <TableCell>
+              <TextField
+                size="small"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                onBlur={saveDescription}
+                placeholder="Enter description"
+                sx={{
+                  input: { color: "#fff" },
+                  "& .MuiOutlinedInput-root": {
+                    "& fieldset": { borderColor: "#555" },
+                    "&:hover fieldset": { borderColor: "#888" }
+                  }
+                }}
+              />
+            </TableCell>
+          </TableRow>
           {summaryItems.map((item) => (
             <TableRow key={item.label}>
               <TableCell sx={{ fontWeight: 500 }}>{item.label}</TableCell>
@@ -302,7 +357,7 @@ export default function DeviceDetails({ device, onBack }) {
               <TableRow key={`${n.adapter}-${i}`}>
                 <TableCell>{n.adapter}</TableCell>
                 <TableCell>{(n.ips || []).join(", ")}</TableCell>
-                <TableCell>{n.mac}</TableCell>
+                <TableCell>{formatMac(n.mac)}</TableCell>
               </TableRow>
             ))}
           </TableBody>

--- a/Data/Server/WebUI/src/Device_Details.jsx
+++ b/Data/Server/WebUI/src/Device_Details.jsx
@@ -1,6 +1,6 @@
 ////////// PROJECT FILE SEPARATION LINE ////////// CODE AFTER THIS LINE ARE FROM: <ProjectRoot>/Data/WebUI/src/Device_Details.js
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import {
   Paper,
   Box,
@@ -13,13 +13,18 @@ import {
   TableCell,
   TableBody,
   Button,
-  LinearProgress
+  LinearProgress,
+  TableSortLabel,
+  TextField
 } from "@mui/material";
 
 export default function DeviceDetails({ device, onBack }) {
   const [tab, setTab] = useState(0);
   const [agent, setAgent] = useState(device || {});
   const [details, setDetails] = useState({});
+  const [softwareOrderBy, setSoftwareOrderBy] = useState("name");
+  const [softwareOrder, setSoftwareOrder] = useState("asc");
+  const [softwareSearch, setSoftwareSearch] = useState("");
 
   useEffect(() => {
     if (!device || !device.id) return;
@@ -53,6 +58,28 @@ export default function DeviceDetails({ device, onBack }) {
     }
     return `${num.toFixed(1)} ${units[i]}`;
   };
+
+  const handleSoftwareSort = (col) => {
+    if (softwareOrderBy === col) {
+      setSoftwareOrder(softwareOrder === "asc" ? "desc" : "asc");
+    } else {
+      setSoftwareOrderBy(col);
+      setSoftwareOrder("asc");
+    }
+  };
+
+  const softwareRows = useMemo(() => {
+    const rows = details.software || [];
+    const filtered = rows.filter((s) =>
+      s.name.toLowerCase().includes(softwareSearch.toLowerCase())
+    );
+    const dir = softwareOrder === "asc" ? 1 : -1;
+    return [...filtered].sort((a, b) => {
+      const A = a[softwareOrderBy] || "";
+      const B = b[softwareOrderBy] || "";
+      return String(A).localeCompare(String(B)) * dir;
+    });
+  }, [details.software, softwareSearch, softwareOrderBy, softwareOrder]);
 
   const summary = details.summary || {};
   const summaryItems = [
@@ -103,28 +130,62 @@ export default function DeviceDetails({ device, onBack }) {
   );
 
   const renderSoftware = () => {
-    const rows = details.software || [];
-    if (!rows.length) return placeholderTable(["Software Name", "Version", "Action"]);
+    if (!softwareRows.length)
+      return placeholderTable(["Software Name", "Version", "Action"]);
+
     return (
-      <Box sx={{ maxHeight: 400, overflowY: "auto" }}>
-        <Table size="small">
-          <TableHead>
-            <TableRow>
-              <TableCell>Software Name</TableCell>
-              <TableCell>Version</TableCell>
-              <TableCell>Action</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {rows.map((s, i) => (
-              <TableRow key={`${s.name}-${i}`}>
-                <TableCell>{s.name}</TableCell>
-                <TableCell>{s.version}</TableCell>
-                <TableCell></TableCell>
+      <Box>
+        <Box sx={{ mb: 1 }}>
+          <TextField
+            size="small"
+            placeholder="Search software..."
+            value={softwareSearch}
+            onChange={(e) => setSoftwareSearch(e.target.value)}
+            sx={{
+              input: { color: "#fff" },
+              "& .MuiOutlinedInput-root": {
+                "& fieldset": { borderColor: "#555" },
+                "&:hover fieldset": { borderColor: "#888" }
+              }
+            }}
+          />
+        </Box>
+        <Box sx={{ maxHeight: 400, overflowY: "auto" }}>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell sortDirection={softwareOrderBy === "name" ? softwareOrder : false}>
+                  <TableSortLabel
+                    active={softwareOrderBy === "name"}
+                    direction={softwareOrderBy === "name" ? softwareOrder : "asc"}
+                    onClick={() => handleSoftwareSort("name")}
+                  >
+                    Software Name
+                  </TableSortLabel>
+                </TableCell>
+                <TableCell sortDirection={softwareOrderBy === "version" ? softwareOrder : false}>
+                  <TableSortLabel
+                    active={softwareOrderBy === "version"}
+                    direction={softwareOrderBy === "version" ? softwareOrder : "asc"}
+                    onClick={() => handleSoftwareSort("version")}
+                  >
+                    Version
+                  </TableSortLabel>
+                </TableCell>
+                <TableCell>Action</TableCell>
               </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+            </TableHead>
+            <TableBody>
+              {softwareRows.map((s, i) => (
+                <TableRow key={`${s.name}-${i}`}>
+                  <TableCell>{s.name}</TableCell>
+                  <TableCell>{s.version}</TableCell>
+                  <TableCell></TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </Box>
       </Box>
     );
   };
@@ -159,7 +220,13 @@ export default function DeviceDetails({ device, onBack }) {
   };
 
   const renderStorage = () => {
-    const rows = details.storage || [];
+    const rows = (details.storage || []).map((d) => ({
+      drive: d.drive,
+      disk_type: d.disk_type,
+      usage: d.usage !== undefined ? Number(d.usage) : undefined,
+      total: d.total !== undefined ? Number(d.total) : undefined,
+      free: d.free !== undefined ? Number(d.free) : undefined,
+    }));
     if (!rows.length)
       return placeholderTable(["Drive Letter", "Disk Type", "Usage", "Total Size", "Free %"]);
     return (
@@ -184,7 +251,7 @@ export default function DeviceDetails({ device, onBack }) {
                     <Box sx={{ flexGrow: 1, mr: 1 }}>
                       <LinearProgress
                         variant="determinate"
-                        value={d.usage}
+                        value={d.usage ?? 0}
                         sx={{
                           height: 10,
                           bgcolor: "#333",
@@ -193,16 +260,20 @@ export default function DeviceDetails({ device, onBack }) {
                       />
                     </Box>
                     <Typography variant="body2">
-                      {d.usage !== undefined && d.usage !== null && d.usage !== "unknown"
-                        ? `${d.usage.toFixed ? d.usage.toFixed(1) : d.usage}%`
+                      {d.usage !== undefined && !Number.isNaN(d.usage)
+                        ? `${d.usage.toFixed(1)}%`
                         : "unknown"}
                     </Typography>
                   </Box>
                 </TableCell>
-                <TableCell>{formatBytes(d.total)}</TableCell>
                 <TableCell>
-                  {d.free !== undefined && d.free !== null && d.free !== "unknown"
-                    ? `${d.free.toFixed ? d.free.toFixed(1) : d.free}%`
+                  {d.total !== undefined && !Number.isNaN(d.total)
+                    ? formatBytes(d.total)
+                    : "unknown"}
+                </TableCell>
+                <TableCell>
+                  {d.free !== undefined && !Number.isNaN(d.free)
+                    ? `${d.free.toFixed(1)}%`
                     : "unknown"}
                 </TableCell>
               </TableRow>
@@ -242,17 +313,6 @@ export default function DeviceDetails({ device, onBack }) {
 
   const tabs = [
     { label: "Summary", content: renderSummary() },
-    {
-      label: "Monitors",
-      content: placeholderTable([
-        "Type",
-        "Description",
-        "Latest Value",
-        "Policy",
-        "Latest 10 Days of Alerts",
-        "Enabled/Disabled Status"
-      ])
-    },
     { label: "Software", content: renderSoftware() },
     { label: "Memory", content: renderMemory() },
     { label: "Storage", content: renderStorage() },

--- a/Data/Server/WebUI/src/Device_Details.jsx
+++ b/Data/Server/WebUI/src/Device_Details.jsx
@@ -1,4 +1,4 @@
-////////// PROJECT FILE SEPARATION LINE ////////// CODE AFTER THIS LINE ARE FROM: <ProjectRoot>/Data/WebUI/src/Device_Details.jsx
+////////// PROJECT FILE SEPARATION LINE ////////// CODE AFTER THIS LINE ARE FROM: <ProjectRoot>/Data/WebUI/src/Device_Details.js
 
 import React, { useState, useEffect } from "react";
 import {
@@ -12,7 +12,8 @@ import {
   TableRow,
   TableCell,
   TableBody,
-  Button
+  Button,
+  LinearProgress
 } from "@mui/material";
 
 export default function DeviceDetails({ device, onBack }) {
@@ -66,59 +67,65 @@ export default function DeviceDetails({ device, onBack }) {
   ];
 
   const renderSummary = () => (
-    <Table size="small">
-      <TableBody>
-        {summaryItems.map((item) => (
-          <TableRow key={item.label}>
-            <TableCell sx={{ fontWeight: 500 }}>{item.label}</TableCell>
-            <TableCell>{item.value}</TableCell>
-          </TableRow>
-        ))}
-      </TableBody>
-    </Table>
+    <Box sx={{ maxHeight: 400, overflowY: "auto" }}>
+      <Table size="small">
+        <TableBody>
+          {summaryItems.map((item) => (
+            <TableRow key={item.label}>
+              <TableCell sx={{ fontWeight: 500 }}>{item.label}</TableCell>
+              <TableCell>{item.value}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Box>
   );
 
   const placeholderTable = (headers) => (
-    <Table size="small">
-      <TableHead>
-        <TableRow>
-          {headers.map((h) => (
-            <TableCell key={h}>{h}</TableCell>
-          ))}
-        </TableRow>
-      </TableHead>
-      <TableBody>
-        <TableRow>
-          <TableCell colSpan={headers.length} sx={{ color: "#888" }}>
-            No data available.
-          </TableCell>
-        </TableRow>
-      </TableBody>
-    </Table>
+    <Box sx={{ maxHeight: 400, overflowY: "auto" }}>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            {headers.map((h) => (
+              <TableCell key={h}>{h}</TableCell>
+            ))}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          <TableRow>
+            <TableCell colSpan={headers.length} sx={{ color: "#888" }}>
+              No data available.
+            </TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    </Box>
   );
 
   const renderSoftware = () => {
     const rows = details.software || [];
     if (!rows.length) return placeholderTable(["Software Name", "Version", "Action"]);
     return (
-      <Table size="small">
-        <TableHead>
-          <TableRow>
-            <TableCell>Software Name</TableCell>
-            <TableCell>Version</TableCell>
-            <TableCell>Action</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {rows.map((s, i) => (
-            <TableRow key={`${s.name}-${i}`}>
-              <TableCell>{s.name}</TableCell>
-              <TableCell>{s.version}</TableCell>
-              <TableCell></TableCell>
+      <Box sx={{ maxHeight: 400, overflowY: "auto" }}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Software Name</TableCell>
+              <TableCell>Version</TableCell>
+              <TableCell>Action</TableCell>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+          </TableHead>
+          <TableBody>
+            {rows.map((s, i) => (
+              <TableRow key={`${s.name}-${i}`}>
+                <TableCell>{s.name}</TableCell>
+                <TableCell>{s.version}</TableCell>
+                <TableCell></TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Box>
     );
   };
 
@@ -126,26 +133,28 @@ export default function DeviceDetails({ device, onBack }) {
     const rows = details.memory || [];
     if (!rows.length) return placeholderTable(["Slot", "Speed", "Serial Number", "Capacity"]);
     return (
-      <Table size="small">
-        <TableHead>
-          <TableRow>
-            <TableCell>Slot</TableCell>
-            <TableCell>Speed</TableCell>
-            <TableCell>Serial Number</TableCell>
-            <TableCell>Capacity</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {rows.map((m, i) => (
-            <TableRow key={`${m.slot}-${i}`}>
-              <TableCell>{m.slot}</TableCell>
-              <TableCell>{m.speed}</TableCell>
-              <TableCell>{m.serial}</TableCell>
-              <TableCell>{formatBytes(m.capacity)}</TableCell>
+      <Box sx={{ maxHeight: 400, overflowY: "auto" }}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Slot</TableCell>
+              <TableCell>Speed</TableCell>
+              <TableCell>Serial Number</TableCell>
+              <TableCell>Capacity</TableCell>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+          </TableHead>
+          <TableBody>
+            {rows.map((m, i) => (
+              <TableRow key={`${m.slot}-${i}`}>
+                <TableCell>{m.slot}</TableCell>
+                <TableCell>{m.speed}</TableCell>
+                <TableCell>{m.serial}</TableCell>
+                <TableCell>{formatBytes(m.capacity)}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Box>
     );
   };
 
@@ -154,36 +163,53 @@ export default function DeviceDetails({ device, onBack }) {
     if (!rows.length)
       return placeholderTable(["Drive Letter", "Disk Type", "Usage", "Total Size", "Free %"]);
     return (
-      <Table size="small">
-        <TableHead>
-          <TableRow>
-            <TableCell>Drive Letter</TableCell>
-            <TableCell>Disk Type</TableCell>
-            <TableCell>Usage</TableCell>
-            <TableCell>Total Size</TableCell>
-            <TableCell>Free %</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {rows.map((d, i) => (
-            <TableRow key={`${d.drive}-${i}`}>
-              <TableCell>{d.drive}</TableCell>
-              <TableCell>{d.disk_type}</TableCell>
-              <TableCell>
-                {d.usage !== undefined && d.usage !== null && d.usage !== "unknown"
-                  ? `${d.usage.toFixed ? d.usage.toFixed(1) : d.usage}%`
-                  : "unknown"}
-              </TableCell>
-              <TableCell>{formatBytes(d.total)}</TableCell>
-              <TableCell>
-                {d.free !== undefined && d.free !== null && d.free !== "unknown"
-                  ? `${d.free.toFixed ? d.free.toFixed(1) : d.free}%`
-                  : "unknown"}
-              </TableCell>
+      <Box sx={{ maxHeight: 400, overflowY: "auto" }}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Drive Letter</TableCell>
+              <TableCell>Disk Type</TableCell>
+              <TableCell>Usage</TableCell>
+              <TableCell>Total Size</TableCell>
+              <TableCell>Free %</TableCell>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+          </TableHead>
+          <TableBody>
+            {rows.map((d, i) => (
+              <TableRow key={`${d.drive}-${i}`}>
+                <TableCell>{d.drive}</TableCell>
+                <TableCell>{d.disk_type}</TableCell>
+                <TableCell>
+                  <Box sx={{ display: "flex", alignItems: "center" }}>
+                    <Box sx={{ flexGrow: 1, mr: 1 }}>
+                      <LinearProgress
+                        variant="determinate"
+                        value={d.usage}
+                        sx={{
+                          height: 10,
+                          bgcolor: "#333",
+                          "& .MuiLinearProgress-bar": { bgcolor: "#58a6ff" }
+                        }}
+                      />
+                    </Box>
+                    <Typography variant="body2">
+                      {d.usage !== undefined && d.usage !== null && d.usage !== "unknown"
+                        ? `${d.usage.toFixed ? d.usage.toFixed(1) : d.usage}%`
+                        : "unknown"}
+                    </Typography>
+                  </Box>
+                </TableCell>
+                <TableCell>{formatBytes(d.total)}</TableCell>
+                <TableCell>
+                  {d.free !== undefined && d.free !== null && d.free !== "unknown"
+                    ? `${d.free.toFixed ? d.free.toFixed(1) : d.free}%`
+                    : "unknown"}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Box>
     );
   };
 
@@ -191,24 +217,26 @@ export default function DeviceDetails({ device, onBack }) {
     const rows = details.network || [];
     if (!rows.length) return placeholderTable(["Adapter", "IP Address", "MAC Address"]);
     return (
-      <Table size="small">
-        <TableHead>
-          <TableRow>
-            <TableCell>Adapter</TableCell>
-            <TableCell>IP Address</TableCell>
-            <TableCell>MAC Address</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {rows.map((n, i) => (
-            <TableRow key={`${n.adapter}-${i}`}>
-              <TableCell>{n.adapter}</TableCell>
-              <TableCell>{(n.ips || []).join(", ")}</TableCell>
-              <TableCell>{n.mac}</TableCell>
+      <Box sx={{ maxHeight: 400, overflowY: "auto" }}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Adapter</TableCell>
+              <TableCell>IP Address</TableCell>
+              <TableCell>MAC Address</TableCell>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+          </TableHead>
+          <TableBody>
+            {rows.map((n, i) => (
+              <TableRow key={`${n.adapter}-${i}`}>
+                <TableCell>{n.adapter}</TableCell>
+                <TableCell>{(n.ips || []).join(", ")}</TableCell>
+                <TableCell>{n.mac}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Box>
     );
   };
 

--- a/Data/Server/WebUI/src/Device_List.jsx
+++ b/Data/Server/WebUI/src/Device_List.jsx
@@ -35,7 +35,7 @@ function statusFromHeartbeat(tsSec, offlineAfter = 15) {
   return now - tsSec <= offlineAfter ? "Online" : "Offline";
 }
 
-export default function DeviceList() {
+export default function DeviceList({ onSelectDevice }) {
   const [rows, setRows] = useState([]);
   const [orderBy, setOrderBy] = useState("status");
   const [order, setOrder] = useState("desc");
@@ -165,7 +165,12 @@ export default function DeviceList() {
         </TableHead>
         <TableBody>
           {sorted.map((r, i) => (
-            <TableRow key={r.id || i} hover>
+            <TableRow
+              key={r.id || i}
+              hover
+              onClick={() => onSelectDevice && onSelectDevice(r)}
+              sx={{ cursor: onSelectDevice ? "pointer" : "default" }}
+            >
               <TableCell>
                 <span
                   style={{

--- a/Data/Server/server.py
+++ b/Data/Server/server.py
@@ -379,6 +379,7 @@ def rename_workflow():
 registered_agents: Dict[str, Dict] = {}
 agent_configurations: Dict[str, Dict] = {}
 latest_images: Dict[str, Dict] = {}
+DEVICES_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "Devices"))
 
 @app.route("/api/agents")
 def get_agents():
@@ -386,6 +387,35 @@ def get_agents():
     Return a dict keyed by agent_id with hostname, os, last_seen, status.
     """
     return jsonify(registered_agents)
+
+
+@app.route("/api/agent/details", methods=["POST"])
+def save_agent_details():
+    data = request.get_json(silent=True) or {}
+    agent_id = data.get("agent_id")
+    details = data.get("details")
+    if not agent_id or not isinstance(details, dict):
+        return jsonify({"error": "invalid payload"}), 400
+    os.makedirs(DEVICES_ROOT, exist_ok=True)
+    path = os.path.join(DEVICES_ROOT, f"{agent_id}.json")
+    try:
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(details, fh, indent=2)
+        return jsonify({"status": "ok"})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@app.route("/api/agent/details/<agent_id>", methods=["GET"])
+def get_agent_details(agent_id: str):
+    path = os.path.join(DEVICES_ROOT, f"{agent_id}.json")
+    if os.path.isfile(path):
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                return jsonify(json.load(fh))
+        except Exception:
+            pass
+    return jsonify({})
 
 
 @app.route("/api/agent/<agent_id>", methods=["DELETE"])

--- a/Data/Server/server.py
+++ b/Data/Server/server.py
@@ -391,7 +391,7 @@ def init_db():
     conn = sqlite3.connect(DB_PATH)
     cur = conn.cursor()
     cur.execute(
-        "CREATE TABLE IF NOT EXISTS device_details (agent_id TEXT PRIMARY KEY, details TEXT)"
+        "CREATE TABLE IF NOT EXISTS device_details (hostname TEXT PRIMARY KEY, description TEXT, details TEXT)"
     )
     conn.commit()
     conn.close()
@@ -409,16 +409,24 @@ def get_agents():
 @app.route("/api/agent/details", methods=["POST"])
 def save_agent_details():
     data = request.get_json(silent=True) or {}
-    agent_id = data.get("agent_id")
+    hostname = data.get("hostname")
     details = data.get("details")
-    if not agent_id or not isinstance(details, dict):
+    if not hostname and isinstance(details, dict):
+        hostname = details.get("summary", {}).get("hostname")
+    if not hostname or not isinstance(details, dict):
         return jsonify({"error": "invalid payload"}), 400
     try:
         conn = sqlite3.connect(DB_PATH)
         cur = conn.cursor()
         cur.execute(
-            "REPLACE INTO device_details (agent_id, details) VALUES (?, ?)",
-            (agent_id, json.dumps(details)),
+            "SELECT description FROM device_details WHERE hostname = ?",
+            (hostname,),
+        )
+        row = cur.fetchone()
+        description = row[0] if row else ""
+        cur.execute(
+            "REPLACE INTO device_details (hostname, description, details) VALUES (?, ?, ?)",
+            (hostname, description, json.dumps(details)),
         )
         conn.commit()
         conn.close()
@@ -427,24 +435,48 @@ def save_agent_details():
         return jsonify({"error": str(e)}), 500
 
 
-@app.route("/api/agent/details/<agent_id>", methods=["GET"])
-def get_agent_details(agent_id: str):
+@app.route("/api/device/details/<hostname>", methods=["GET"])
+def get_device_details(hostname: str):
     try:
         conn = sqlite3.connect(DB_PATH)
         cur = conn.cursor()
         cur.execute(
-            "SELECT details FROM device_details WHERE agent_id = ?", (agent_id,)
+            "SELECT details, description FROM device_details WHERE hostname = ?",
+            (hostname,),
         )
         row = cur.fetchone()
         conn.close()
         if row:
             try:
-                return jsonify(json.loads(row[0]))
+                details = json.loads(row[0])
             except Exception:
-                pass
+                details = {}
+            description = row[1] if len(row) > 1 else ""
+            if description:
+                details.setdefault("summary", {})["description"] = description
+            return jsonify(details)
     except Exception:
         pass
     return jsonify({})
+
+
+@app.route("/api/device/description/<hostname>", methods=["POST"])
+def set_device_description(hostname: str):
+    data = request.get_json(silent=True) or {}
+    description = (data.get("description") or "").strip()
+    try:
+        conn = sqlite3.connect(DB_PATH)
+        cur = conn.cursor()
+        cur.execute(
+            "INSERT INTO device_details(hostname, description, details) VALUES (?, ?, COALESCE((SELECT details FROM device_details WHERE hostname = ?), '{}')) "
+            "ON CONFLICT(hostname) DO UPDATE SET description=excluded.description",
+            (hostname, description, hostname),
+        )
+        conn.commit()
+        conn.close()
+        return jsonify({"status": "ok"})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
 
 
 @app.route("/api/agent/<agent_id>", methods=["DELETE"])

--- a/Data/Server/server.py
+++ b/Data/Server/server.py
@@ -14,6 +14,7 @@ import os  # To Read Production ReactJS Server Folder
 import json  # For reading workflow JSON files
 import shutil  # For moving workflow files and folders
 from typing import List, Dict
+import sqlite3
 
 # Borealis Python API Endpoints
 from Python_API_Endpoints.ocr_engines import run_ocr_on_base64
@@ -379,7 +380,23 @@ def rename_workflow():
 registered_agents: Dict[str, Dict] = {}
 agent_configurations: Dict[str, Dict] = {}
 latest_images: Dict[str, Dict] = {}
-DEVICES_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "Devices"))
+
+# Device database initialization
+DB_PATH = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "Databases", "devices.db")
+)
+os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
+
+def init_db():
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        "CREATE TABLE IF NOT EXISTS device_details (agent_id TEXT PRIMARY KEY, details TEXT)"
+    )
+    conn.commit()
+    conn.close()
+
+init_db()
 
 @app.route("/api/agents")
 def get_agents():
@@ -396,11 +413,15 @@ def save_agent_details():
     details = data.get("details")
     if not agent_id or not isinstance(details, dict):
         return jsonify({"error": "invalid payload"}), 400
-    os.makedirs(DEVICES_ROOT, exist_ok=True)
-    path = os.path.join(DEVICES_ROOT, f"{agent_id}.json")
     try:
-        with open(path, "w", encoding="utf-8") as fh:
-            json.dump(details, fh, indent=2)
+        conn = sqlite3.connect(DB_PATH)
+        cur = conn.cursor()
+        cur.execute(
+            "REPLACE INTO device_details (agent_id, details) VALUES (?, ?)",
+            (agent_id, json.dumps(details)),
+        )
+        conn.commit()
+        conn.close()
         return jsonify({"status": "ok"})
     except Exception as e:
         return jsonify({"error": str(e)}), 500
@@ -408,13 +429,21 @@ def save_agent_details():
 
 @app.route("/api/agent/details/<agent_id>", methods=["GET"])
 def get_agent_details(agent_id: str):
-    path = os.path.join(DEVICES_ROOT, f"{agent_id}.json")
-    if os.path.isfile(path):
-        try:
-            with open(path, "r", encoding="utf-8") as fh:
-                return jsonify(json.load(fh))
-        except Exception:
-            pass
+    try:
+        conn = sqlite3.connect(DB_PATH)
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT details FROM device_details WHERE agent_id = ?", (agent_id,)
+        )
+        row = cur.fetchone()
+        conn.close()
+        if row:
+            try:
+                return jsonify(json.loads(row[0]))
+            except Exception:
+                pass
+    except Exception:
+        pass
     return jsonify({})
 
 


### PR DESCRIPTION
## Summary
- collect device summary, software, memory, storage, and network info in agent and send to server
- server persists agent detail JSON and serves to client
- device details React page fetches stored data and renders software, memory, storage, and network tables
- use PowerShell fallback when collecting Windows software and memory inventory

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: vite: not found)
- `npm install` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_689c0ced66c4832f8d2000c64f6b55a9