### PR TITLE
feat: show device status and dedupe agents

### DIFF
--- a/Data/Server/WebUI/src/Device_Details.jsx
+++ b/Data/Server/WebUI/src/Device_Details.jsx
@@ -27,6 +27,14 @@ export default function DeviceDetails({ device, onBack }) {
   const [softwareSearch, setSoftwareSearch] = useState("");
   const [description, setDescription] = useState("");
 
+  const statusFromHeartbeat = (tsSec, offlineAfter = 15) => {
+    if (!tsSec) return "Offline";
+    const now = Date.now() / 1000;
+    return now - tsSec <= offlineAfter ? "Online" : "Offline";
+  };
+
+  const statusColor = (s) => (s === "Online" ? "#00d18c" : "#ff4f4f");
+
   useEffect(() => {
     if (!device || !device.hostname) return;
     const load = async () => {
@@ -373,6 +381,7 @@ export default function DeviceDetails({ device, onBack }) {
     { label: "Storage", content: renderStorage() },
     { label: "Network", content: renderNetwork() }
   ];
+  const status = statusFromHeartbeat(agent.last_seen || device?.lastSeen);
 
   return (
     <Paper sx={{ m: 2, p: 2, bgcolor: "#1e1e1e" }} elevation={2}>
@@ -382,7 +391,20 @@ export default function DeviceDetails({ device, onBack }) {
             Back
           </Button>
         )}
-        <Typography variant="h6" sx={{ color: "#58a6ff" }}>
+        <Typography
+          variant="h6"
+          sx={{ color: "#58a6ff", display: "flex", alignItems: "center" }}
+        >
+          <span
+            style={{
+              display: "inline-block",
+              width: 10,
+              height: 10,
+              borderRadius: 10,
+              background: statusColor(status),
+              marginRight: 8,
+            }}
+          />
           {agent.hostname || "Device Details"}
         </Typography>
       </Box>

--- a/Data/Server/server.py
+++ b/Data/Server/server.py
@@ -640,11 +640,18 @@ def on_agent_heartbeat(data):
     agent_id = data.get("agent_id")
     if not agent_id:
         return
+    hostname = data.get("hostname")
+
+    if hostname:
+        for aid, info in list(registered_agents.items()):
+            if aid != agent_id and info.get("hostname") == hostname:
+                registered_agents.pop(aid, None)
+                agent_configurations.pop(aid, None)
 
     rec = registered_agents.setdefault(agent_id, {})
     rec["agent_id"] = agent_id
-    if data.get("hostname"):
-        rec["hostname"] = data.get("hostname")
+    if hostname:
+        rec["hostname"] = hostname
     if data.get("agent_operating_system"):
         rec["agent_operating_system"] = data.get("agent_operating_system")
     rec["last_seen"] = int(data.get("last_seen") or time.time())


### PR DESCRIPTION
## Summary
- add online/offline indicator to device details header
- consolidate agents by hostname so new agents revive existing devices

## Testing
- ⚠️ `npm test` (missing script)
- ⚠️ `npm run build` (vite not found)
- ✅ `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_689c37508078832fb22a52f8ed2b00bd