### PR TITLE
Sort assembly trees alphabetically

### DIFF
--- a/Data/Server/WebUI/src/Assemblies/Assembly_List.jsx
+++ b/Data/Server/WebUI/src/Assemblies/Assembly_List.jsx
@@ -62,11 +62,14 @@ const Island = ({ title, description, icon, actions, children, sx }) => (
 // ---------------- Workflows Island -----------------
 const sortTree = (node) => {
   if (!node || !Array.isArray(node.children)) return;
-  node.children.sort((a, b) =>
-    String(a.label || "").localeCompare(String(b.label || ""), undefined, {
+  node.children.sort((a, b) => {
+    const aFolder = Boolean(a.isFolder);
+    const bFolder = Boolean(b.isFolder);
+    if (aFolder !== bFolder) return aFolder ? -1 : 1;
+    return String(a.label || "").localeCompare(String(b.label || ""), undefined, {
       sensitivity: "base"
-    })
-  );
+    });
+  });
   node.children.forEach(sortTree);
 };
 

--- a/Data/Server/WebUI/src/Assemblies/Assembly_List.jsx
+++ b/Data/Server/WebUI/src/Assemblies/Assembly_List.jsx
@@ -60,6 +60,16 @@ const Island = ({ title, description, icon, actions, children, sx }) => (
 );
 
 // ---------------- Workflows Island -----------------
+const sortTree = (node) => {
+  if (!node || !Array.isArray(node.children)) return;
+  node.children.sort((a, b) =>
+    String(a.label || "").localeCompare(String(b.label || ""), undefined, {
+      sensitivity: "base"
+    })
+  );
+  node.children.forEach(sortTree);
+};
+
 function buildWorkflowTree(workflows, folders) {
   const map = {};
   const rootNode = { id: "root", label: "Workflows", path: "", isFolder: true, children: [] };
@@ -107,6 +117,7 @@ function buildWorkflowTree(workflows, folders) {
       }
     });
   });
+  sortTree(rootNode);
   return { root: [rootNode], map };
 }
 
@@ -439,6 +450,7 @@ function buildFileTree(rootLabel, items, folders) {
       }
     });
   });
+  sortTree(rootNode);
   return { root: [rootNode], map };
 }
 


### PR DESCRIPTION
## Summary
- add a shared helper to alphabetically sort assembly tree nodes
- apply the sorting to workflow, script, and playbook trees so folders and files render in A-to-Z order

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0d0282d00832fa45493192d70dc5a