### PR TITLE
Fix Update.ps1 Join-Path usage when locating agent settings

### DIFF
--- a/Update.ps1
+++ b/Update.ps1
@@ -118,8 +118,8 @@ function Get-AgentServiceId {
     if (-not $AgentRoot) { $AgentRoot = $scriptDir }
     $settingsDir = Join-Path $AgentRoot 'Settings'
     $candidates = @(
-        Join-Path $settingsDir 'agent_settings_svc.json',
-        Join-Path $settingsDir 'agent_settings.json'
+        (Join-Path $settingsDir 'agent_settings_svc.json')
+        (Join-Path $settingsDir 'agent_settings.json')
     )
 
     foreach ($path in $candidates) {


### PR DESCRIPTION
## Summary
- fix Join-Path calls when collecting agent settings candidates to avoid passing array arguments on Windows PowerShell

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2fa1d1718832fb430bf6b0bf130f3