### PR TITLE
Fix conditional logic for Test-Path checks

### DIFF
--- a/Update.ps1
+++ b/Update.ps1
@@ -150,7 +150,7 @@ function Get-RepositoryCommitHash {
     if ($AgentRoot -and ($candidates -notcontains $AgentRoot)) { $candidates += $AgentRoot }
     if ($ProjectRoot) {
         $agentRootCandidate = Join-Path $ProjectRoot 'Agent\Borealis'
-        if (Test-Path $agentRootCandidate -PathType Container -and ($candidates -notcontains $agentRootCandidate)) {
+        if ((Test-Path $agentRootCandidate -PathType Container) -and ($candidates -notcontains $agentRootCandidate)) {
             $candidates += $agentRootCandidate
         }
     }


### PR DESCRIPTION
## Summary
- correct the logical check that adds the agent root candidate when building repository hash candidates

## Testing
- not run (PowerShell update script requires Windows-specific environment)

------
https://chatgpt.com/codex/tasks/task_e_68e6fbcbbc9c832fb477c2926fb4ccef