### PR TITLE
Fix device list container overflow

### DIFF
--- a/Data/Server/WebUI/src/Devices/Device_List.jsx
+++ b/Data/Server/WebUI/src/Devices/Device_List.jsx
@@ -1063,7 +1063,7 @@ export default function DeviceList({
         display: "flex",
         flexDirection: "column",
         flexGrow: 1,
-        width: "100%",
+        minWidth: 0,
         height: "100%",
       }}
       elevation={2}


### PR DESCRIPTION
## Summary
- allow the device list paper container to shrink within its parent without forcing extra width

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f0aea57674832fabdfbf7c7b1f5826