### PR TITLE
Update architecture overview in AGENTS documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ Today the stable core focuses on workflow-driven API and automation scenarios. R
 ## Agent Responsibilities
 
 ### Communication Channels
-Agents establish REST calls to the Flask backend on port 5000 and keep a WebSocket session for interactive features such as screenshot capture. Future plans include WebRTC for higher-performance remote desktop. No authentication or enrollment handshake exists yet, so agents are implicitly trusted once launched.
+Agents establish REST calls to the Flask backend on port 5000 and keep a WebSocket session for interactive features such as screenshot capture. Future plans include WebRTC for higher-performance remote desktop. No authentication or enrollment handshake exists yet, so agents are implicitly trusted once launched.  This will be secured in future updates to Borealis.
 
 ### Execution Contexts
 The agent runs in the interactive user session. SYSTEM-level script execution is provided by the ScriptExec SYSTEM role using ephemeral scheduled tasks; no separate supervisor or watchdog is required.


### PR DESCRIPTION
## Summary
- remove the outdated note about prioritising the server orchestrator and agent heartbeat
- refresh the Architecture At A Glance bullets to describe the current bootstrap flow and document the unused script_engines helper

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f18cd62ad0832f8862a9015f1bd7e2