### PR TITLE
Kill lingering Python processes during agent update

### DIFF
--- a/Update.ps1
+++ b/Update.ps1
@@ -145,6 +145,44 @@ function Start-AgentScheduledTasks {
     }
 }
 
+function Stop-AgentPythonProcesses {
+    param(
+        [string[]]$ProcessNames = @('python', 'pythonw')
+    )
+
+    foreach ($name in ($ProcessNames | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)) {
+        $name = $name.Trim()
+        if (-not $name) { continue }
+
+        $processes = @()
+        try {
+            $processes = Get-Process -Name $name -ErrorAction Stop
+        } catch {
+            $processes = @()
+        }
+
+        foreach ($proc in $processes) {
+            $pid = $null
+            $procName = $null
+            try {
+                $pid = $proc.Id
+                $procName = $proc.ProcessName
+            } catch {}
+
+            if ($pid -eq $null) { continue }
+
+            if (-not $procName) { $procName = $name }
+
+            try {
+                Write-Host "Stopping process: $procName (PID $pid)" -ForegroundColor Yellow
+                Stop-Process -Id $pid -Force -ErrorAction Stop
+            } catch {
+                Write-Host "Unable to stop process: $procName (PID $pid). $_" -ForegroundColor DarkYellow
+            }
+        }
+    }
+}
+
 function Get-BorealisServerUrl {
     param(
         [string]$AgentRoot
@@ -704,6 +742,7 @@ function Invoke-BorealisAgentUpdate {
         $staging = Join-Path $scriptDir 'Update_Staging'
 
         $managedTasks = Stop-AgentScheduledTasks -TaskNames @('Borealis Agent','Borealis Agent (UserHelper)')
+        Run-Step "Updating: Terminate Running Python Processes" { Stop-AgentPythonProcesses }
 
         $updateSucceeded = $false
         try {


### PR DESCRIPTION
## Summary
- add a helper that forcefully stops python.exe and pythonw.exe processes during agent updates
- invoke the new cleanup step before copying update payloads so ghost agent processes are removed

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f1df59d320832f9020e9fd090d45fe