### PR TITLE
issue/fix-remote-shell-syntax-highlighting

### DIFF
--- a/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/Devices/Tabs/remoteShellFormatting.test.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/Devices/Tabs/remoteShellFormatting.test.jsx
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  cleanShellOutput,
+  highlightShellOutput,
+  inferShellKind,
+  shellLanguageForKind,
+} from "@/Devices/Tabs/remoteShellFormatting.js";
+
+describe("remote shell output formatting", () => {
+  it("infers PowerShell for Windows devices and Bash for Linux devices", () => {
+    expect(inferShellKind({ operating_system: "Microsoft Windows 11 Pro" })).toBe("powershell");
+    expect(inferShellKind({ summary: { operating_system: "Ubuntu 24.04 LTS" } })).toBe("bash");
+    expect(inferShellKind({})).toBe("powershell");
+  });
+
+  it("normalizes terminal output before display and copy", () => {
+    const output = "one\r\n\u001b[31mred\u001b[0m\r\ntwo\rthree\u0007";
+
+    expect(cleanShellOutput(output)).toBe("one\nred\ntwothree");
+  });
+
+  it("maps shell kinds to Prism languages", () => {
+    expect(shellLanguageForKind("bash")).toBe("bash");
+    expect(shellLanguageForKind("powershell")).toBe("powershell");
+    expect(shellLanguageForKind("unknown")).toBe("powershell");
+  });
+
+  it("highlights PowerShell and Bash output with Prism token markup", () => {
+    const powershell = highlightShellOutput(
+      'Get-Process | Where-Object { $_.Name -eq "svchost" }',
+      "powershell"
+    );
+    const bash = highlightShellOutput('sudo systemctl status nginx && echo "ok"', "bash");
+
+    expect(powershell).toContain("token");
+    expect(powershell).toContain("Get-Process");
+    expect(bash).toContain("token");
+    expect(bash).toContain("systemctl");
+  });
+});

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Remote_Shell.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Remote_Shell.jsx
@@ -16,6 +16,15 @@ import {
   RefreshRounded as RefreshIcon,
 } from "@mui/icons-material";
 import { io } from "socket.io-client";
+import "prismjs/themes/prism-okaidia.css";
+import {
+  clampOutput,
+  cleanShellOutput,
+  highlightShellOutput,
+  inferShellKind,
+  normalizeText,
+  shellLanguageForKind,
+} from "./remoteShellFormatting.js";
 
 const MAGIC_UI = {
   panelBorder: "rgba(148, 163, 184, 0.35)",
@@ -40,12 +49,6 @@ const gradientButtonSx = {
 
 const fontFamilyMono =
   'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace';
-const OUTPUT_LIMIT = 40000;
-const ANSI_OSC_PATTERN = /\u001B\][^\u0007]*(?:\u0007|\u001B\\)/g;
-const ANSI_ST_PATTERN = /\u001B[P^_][\s\S]*?\u001B\\/g;
-const ANSI_CSI_PATTERN = /\u001B\[[0-?]*[ -/]*[@-~]/g;
-const ANSI_ESC_PATTERN = /\u001B[@-Z\\-_]/g;
-const ANSI_C1_CSI_PATTERN = /\u009B[0-?]*[ -/]*[@-~]/g;
 
 const emitAsync = (socket, event, payload, timeoutMs = 4000) =>
   new Promise((resolve) => {
@@ -98,51 +101,6 @@ const waitForSocketConnect = (socket, timeoutMs = 10000) =>
     socket.on("disconnect", handleDisconnect);
   });
 
-function normalizeText(value) {
-  if (value == null) return "";
-  try {
-    return String(value).trim();
-  } catch {
-    return "";
-  }
-}
-
-function clampOutput(value) {
-  return value.length > OUTPUT_LIMIT ? value.slice(value.length - OUTPUT_LIMIT) : value;
-}
-
-function inferShellKind(device) {
-  const fingerprint = [
-    device?.operating_system,
-    device?.agent_operating_system,
-    device?.os,
-    device?.summary?.operating_system,
-    device?.summary?.agent_operating_system,
-    device?.summary?.os,
-  ]
-    .map(normalizeText)
-    .join(" ")
-    .toLowerCase();
-
-  if (!fingerprint) return "powershell";
-  if (fingerprint.includes("windows")) return "powershell";
-  if (
-    fingerprint.includes("linux") ||
-    fingerprint.includes("ubuntu") ||
-    fingerprint.includes("debian") ||
-    fingerprint.includes("rocky") ||
-    fingerprint.includes("centos") ||
-    fingerprint.includes("red hat") ||
-    fingerprint.includes("rhel") ||
-    fingerprint.includes("fedora") ||
-    fingerprint.includes("suse") ||
-    fingerprint.includes("alpine")
-  ) {
-    return "bash";
-  }
-  return "powershell";
-}
-
 function shellSocketConfig(remoteOpsSession) {
   const routePrefix = normalizeText(remoteOpsSession?.worker?.route_path_prefix);
   if (routePrefix) {
@@ -174,23 +132,6 @@ function shellTunnelPayload(data) {
   return payload;
 }
 
-function cleanShellOutput(value) {
-  if (value == null) return "";
-  try {
-    return String(value)
-      .replace(/\r\n/g, "\n")
-      .replace(/\r(?!\n)/g, "")
-      .replace(ANSI_OSC_PATTERN, "")
-      .replace(ANSI_ST_PATTERN, "")
-      .replace(ANSI_CSI_PATTERN, "")
-      .replace(ANSI_C1_CSI_PATTERN, "")
-      .replace(ANSI_ESC_PATTERN, "")
-      .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "");
-  } catch {
-    return "";
-  }
-}
-
 export default function ReverseTunnelRemoteShell({ device }) {
   const [sessionState, setSessionState] = useState("idle");
   const [shellState, setShellState] = useState("idle");
@@ -210,8 +151,13 @@ export default function ReverseTunnelRemoteShell({ device }) {
   const previousAgentIdRef = useRef("");
   const connectAttemptRef = useRef(0);
   const shellKind = useMemo(() => inferShellKind(device), [device]);
+  const shellLanguage = useMemo(() => shellLanguageForKind(shellKind), [shellKind]);
   const promptLabel = shellKind === "bash" ? "#" : "PS>";
   const displayOutput = useMemo(() => cleanShellOutput(output), [output]);
+  const highlightedOutput = useMemo(
+    () => highlightShellOutput(displayOutput, shellKind),
+    [displayOutput, shellKind]
+  );
 
   const agentId = useMemo(() => {
     return (
@@ -623,20 +569,44 @@ export default function ReverseTunnelRemoteShell({ device }) {
         >
           <Box
             component="pre"
+            className={`language-${shellLanguage}`}
             sx={{
               margin: 0,
               minHeight: "100%",
               whiteSpace: "pre-wrap",
               wordBreak: "break-word",
-              background: "transparent",
+              background: "transparent !important",
+              backgroundColor: "transparent !important",
               color: "#e6edf3",
               fontFamily: fontFamilyMono,
               fontSize: 13,
               lineHeight: 1.5,
               pr: 4,
+              "& code": {
+                display: "block",
+                fontFamily: "inherit",
+                fontSize: "inherit",
+                lineHeight: "inherit",
+                color: "inherit",
+                whiteSpace: "inherit",
+                background: "transparent !important",
+                backgroundColor: "transparent !important",
+              },
+              "&[class*='language-']": {
+                background: "transparent !important",
+                backgroundColor: "transparent !important",
+              },
+              "& code[class*='language-']": {
+                background: "transparent !important",
+                backgroundColor: "transparent !important",
+              },
             }}
           >
-            {displayOutput}
+            <Box
+              component="code"
+              className={`language-${shellLanguage}`}
+              dangerouslySetInnerHTML={{ __html: highlightedOutput }}
+            />
           </Box>
           <Box sx={{ position: "absolute", top: 8, right: 8, display: "flex", gap: 0.5 }}>
             <Tooltip title="Copy output">

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/remoteShellFormatting.js
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/remoteShellFormatting.js
@@ -1,0 +1,94 @@
+import Prism from "prismjs";
+import "prismjs/components/prism-bash";
+import "prismjs/components/prism-powershell";
+
+export const OUTPUT_LIMIT = 40000;
+
+const ANSI_OSC_PATTERN = /\u001B\][^\u0007]*(?:\u0007|\u001B\\)/g;
+const ANSI_ST_PATTERN = /\u001B[P^_][\s\S]*?\u001B\\/g;
+const ANSI_CSI_PATTERN = /\u001B\[[0-?]*[ -/]*[@-~]/g;
+const ANSI_ESC_PATTERN = /\u001B[@-Z\\-_]/g;
+const ANSI_C1_CSI_PATTERN = /\u009B[0-?]*[ -/]*[@-~]/g;
+
+export function normalizeText(value) {
+  if (value == null) return "";
+  try {
+    return String(value).trim();
+  } catch {
+    return "";
+  }
+}
+
+export function clampOutput(value) {
+  return value.length > OUTPUT_LIMIT ? value.slice(value.length - OUTPUT_LIMIT) : value;
+}
+
+export function inferShellKind(device) {
+  const fingerprint = [
+    device?.operating_system,
+    device?.agent_operating_system,
+    device?.os,
+    device?.summary?.operating_system,
+    device?.summary?.agent_operating_system,
+    device?.summary?.os,
+  ]
+    .map(normalizeText)
+    .join(" ")
+    .toLowerCase();
+
+  if (!fingerprint) return "powershell";
+  if (fingerprint.includes("windows")) return "powershell";
+  if (
+    fingerprint.includes("linux") ||
+    fingerprint.includes("ubuntu") ||
+    fingerprint.includes("debian") ||
+    fingerprint.includes("rocky") ||
+    fingerprint.includes("centos") ||
+    fingerprint.includes("red hat") ||
+    fingerprint.includes("rhel") ||
+    fingerprint.includes("fedora") ||
+    fingerprint.includes("suse") ||
+    fingerprint.includes("alpine")
+  ) {
+    return "bash";
+  }
+  return "powershell";
+}
+
+export function shellLanguageForKind(shellKind) {
+  return shellKind === "bash" ? "bash" : "powershell";
+}
+
+export function cleanShellOutput(value) {
+  if (value == null) return "";
+  try {
+    return String(value)
+      .replace(/\r\n/g, "\n")
+      .replace(/\r(?!\n)/g, "")
+      .replace(ANSI_OSC_PATTERN, "")
+      .replace(ANSI_ST_PATTERN, "")
+      .replace(ANSI_CSI_PATTERN, "")
+      .replace(ANSI_C1_CSI_PATTERN, "")
+      .replace(ANSI_ESC_PATTERN, "")
+      .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "");
+  } catch {
+    return "";
+  }
+}
+
+function escapeHtml(value) {
+  return String(value || "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+export function highlightShellOutput(output, shellKind) {
+  const raw = String(output || "");
+  const language = shellLanguageForKind(shellKind);
+  try {
+    return Prism.highlight(raw, Prism.languages[language] || Prism.languages.markup, language);
+  } catch {
+    return escapeHtml(raw);
+  }
+}


### PR DESCRIPTION
Tracks #264.

## Summary
- Restores Prism-based syntax highlighting inside Remote Shell output for PowerShell and Bash sessions.
- Moves Remote Shell output cleanup and highlighting helpers into a testable module.
- Adds WebUI unit coverage for shell kind inference, ANSI cleanup, language mapping, and Prism token markup.

## Root cause
- Remote Shell rendered cleaned terminal text directly in a plain pre block after the Go backend rewrite, while Scheduled Jobs StdOut/StdErr still passed output through Prism.

## Validation
- PASS: git diff --check
- BLOCKED: ./Engine_Unit_Tests.sh --domain webui stopped because runtime unit test cache is missing at Engine/Services/webui-frontend/cache/web-interface/Unit_Tests. Result: Unit_Test_Results/engine-20260625T120656Z/

## Risk
- WebUI Vitest lane was not executed in this checkout because runtime cache/dependencies are absent. Redeploy Engine or prepare WebUI runtime cache, then rerun ./Engine_Unit_Tests.sh --domain webui before merge.