### PR TITLE
issue/fix-scheduled-job-timezone

### DIFF
--- a/Data/Engine/Containers/api-backend/cmd/api-backend/scheduled_jobs.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/scheduled_jobs.go
@@ -1956,20 +1956,25 @@ func computeScheduledNextRun(scheduleType string, startTS int64, lastRun *int64,
 		"every_15_minutes": 900,
 		"every_30_minutes": 1800,
 		"every_hour":       3600,
-		"daily":            86400,
-		"weekly":           7 * 86400,
 	}
 	if period, ok := periods[st]; ok {
 		next := last + period
 		return &next
 	}
-	t := time.Unix(last, 0)
+	if st == "daily" {
+		next := schedulerAddDays(last, 1)
+		return &next
+	}
+	if st == "weekly" {
+		next := schedulerAddDays(last, 7)
+		return &next
+	}
 	if st == "monthly" {
-		next := t.AddDate(0, 1, 0).Unix()
+		next := schedulerAddMonths(last, 1)
 		return &next
 	}
 	if st == "yearly" {
-		next := t.AddDate(1, 0, 0).Unix()
+		next := schedulerAddYears(last, 1)
 		return &next
 	}
 	return nil

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/scheduled_jobs_mutations.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/scheduled_jobs_mutations.go
@@ -890,10 +890,10 @@ func scheduledParseTS(value any) sql.NullInt64 {
 	if parsed, err := time.Parse(time.RFC3339, strings.ReplaceAll(text, "Z", "+00:00")); err == nil {
 		return sql.NullInt64{Int64: parsed.Unix(), Valid: true}
 	}
-	if parsed, err := time.Parse("2006-01-02T15:04", text); err == nil {
+	if parsed, err := time.ParseInLocation("2006-01-02T15:04", text, engineScheduleLocation()); err == nil {
 		return sql.NullInt64{Int64: parsed.Unix(), Valid: true}
 	}
-	if parsed, err := time.Parse("2006-01-02 15:04:05", text); err == nil {
+	if parsed, err := time.ParseInLocation("2006-01-02 15:04:05", text, engineScheduleLocation()); err == nil {
 		return sql.NullInt64{Int64: parsed.Unix(), Valid: true}
 	}
 	if value, ok := int64Value(text); ok {

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/scheduler_manager.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/scheduler_manager.go
@@ -2133,8 +2133,6 @@ func schedulerComputeNextRun(scheduleType string, startTS *int64, lastRunTS *int
 		"every_15_minutes": 15 * 60,
 		"every_30_minutes": 30 * 60,
 		"every_hour":       60 * 60,
-		"daily":            86400,
-		"weekly":           7 * 86400,
 	}
 	if period, ok := periods[st]; ok {
 		if last == nil {
@@ -2147,6 +2145,12 @@ func schedulerComputeNextRun(scheduleType string, startTS *int64, lastRunTS *int
 		return start
 	}
 	switch st {
+	case "daily":
+		value := schedulerAddDays(*last, 1)
+		return &value
+	case "weekly":
+		value := schedulerAddDays(*last, 7)
+		return &value
 	case "monthly":
 		value := schedulerAddMonths(*last, 1)
 		return &value
@@ -2158,33 +2162,54 @@ func schedulerComputeNextRun(scheduleType string, startTS *int64, lastRunTS *int
 	}
 }
 
+func engineScheduleLocation() *time.Location {
+	timezoneID := strings.TrimSpace(currentTimezoneID())
+	if timezoneID != "" {
+		if loc, err := time.LoadLocation(timezoneID); err == nil {
+			return loc
+		}
+	}
+	if time.Local != nil {
+		return time.Local
+	}
+	return time.UTC
+}
+
+func schedulerAddDays(ts int64, days int) int64 {
+	loc := engineScheduleLocation()
+	base := time.Unix(ts, 0).In(loc)
+	return base.AddDate(0, 0, days).Unix()
+}
+
 func schedulerAddMonths(ts int64, months int) int64 {
-	base := time.Unix(ts, 0).UTC()
+	loc := engineScheduleLocation()
+	base := time.Unix(ts, 0).In(loc)
 	year, month, day := base.Date()
 	hour, min, sec := base.Clock()
 	targetMonth := int(month) + months
 	year += (targetMonth - 1) / 12
 	targetMonth = ((targetMonth - 1) % 12) + 1
-	lastDay := daysInMonth(year, time.Month(targetMonth))
+	lastDay := daysInMonth(year, time.Month(targetMonth), loc)
 	if day > lastDay {
 		day = lastDay
 	}
-	return time.Date(year, time.Month(targetMonth), day, hour, min, sec, 0, time.UTC).Unix()
+	return time.Date(year, time.Month(targetMonth), day, hour, min, sec, 0, loc).Unix()
 }
 
 func schedulerAddYears(ts int64, years int) int64 {
-	base := time.Unix(ts, 0).UTC()
+	loc := engineScheduleLocation()
+	base := time.Unix(ts, 0).In(loc)
 	year, month, day := base.Date()
 	hour, min, sec := base.Clock()
 	year += years
-	if month == time.February && day == 29 && daysInMonth(year, month) < day {
+	if month == time.February && day == 29 && daysInMonth(year, month, loc) < day {
 		day = 28
 	}
-	return time.Date(year, month, day, hour, min, sec, 0, time.UTC).Unix()
+	return time.Date(year, month, day, hour, min, sec, 0, loc).Unix()
 }
 
-func daysInMonth(year int, month time.Month) int {
-	return time.Date(year, month+1, 0, 0, 0, 0, 0, time.UTC).Day()
+func daysInMonth(year int, month time.Month, loc *time.Location) int {
+	return time.Date(year, month+1, 0, 0, 0, 0, 0, loc).Day()
 }
 
 func schedulerFloorMinute(ts int64) int64 {

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/scheduler_manager_test.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/scheduler_manager_test.go
@@ -35,6 +35,60 @@ func TestSchedulerManagerComputeNextRunMatchesPythonIntervals(t *testing.T) {
 	}
 }
 
+func TestScheduledParseTSUsesEngineTimezoneForWallClockInput(t *testing.T) {
+	t.Setenv("BOREALIS_ENGINE_HOST_TIMEZONE", "America/Denver")
+	loc, err := time.LoadLocation("America/Denver")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := scheduledParseTS("2026-06-25T00:00")
+	want := time.Date(2026, time.June, 25, 0, 0, 0, 0, loc).Unix()
+	if !got.Valid || got.Int64 != want {
+		t.Fatalf("expected Denver wall clock epoch %d, got %#v", want, got)
+	}
+
+	absolute := scheduledParseTS("2026-06-25T00:00:00Z")
+	wantUTC := time.Date(2026, time.June, 25, 0, 0, 0, 0, time.UTC).Unix()
+	if !absolute.Valid || absolute.Int64 != wantUTC {
+		t.Fatalf("expected RFC3339 UTC epoch %d, got %#v", wantUTC, absolute)
+	}
+}
+
+func TestSchedulerManagerCalendarNextRunPreservesLocalMidnightAcrossDST(t *testing.T) {
+	t.Setenv("BOREALIS_ENGINE_HOST_TIMEZONE", "America/Denver")
+	loc, err := time.LoadLocation("America/Denver")
+	if err != nil {
+		t.Fatal(err)
+	}
+	start := time.Date(2026, time.March, 8, 0, 0, 0, 0, loc).Unix()
+	last := time.Date(2026, time.March, 8, 0, 0, 0, 0, loc).Unix()
+	now := time.Date(2026, time.March, 9, 0, 0, 0, 0, loc).Unix()
+
+	got := schedulerComputeNextRun("daily", &start, &last, now)
+	want := time.Date(2026, time.March, 9, 0, 0, 0, 0, loc).Unix()
+	if got == nil || *got != want {
+		t.Fatalf("expected next Denver midnight %d, got %v", want, got)
+	}
+}
+
+func TestSchedulerManagerMonthlyNextRunPreservesLocalWallClockAcrossDST(t *testing.T) {
+	t.Setenv("BOREALIS_ENGINE_HOST_TIMEZONE", "America/Denver")
+	loc, err := time.LoadLocation("America/Denver")
+	if err != nil {
+		t.Fatal(err)
+	}
+	start := time.Date(2026, time.October, 25, 0, 0, 0, 0, loc).Unix()
+	last := time.Date(2026, time.October, 25, 0, 0, 0, 0, loc).Unix()
+	now := time.Date(2026, time.November, 25, 0, 0, 0, 0, loc).Unix()
+
+	got := schedulerComputeNextRun("monthly", &start, &last, now)
+	want := time.Date(2026, time.November, 25, 0, 0, 0, 0, loc).Unix()
+	if got == nil || *got != want {
+		t.Fatalf("expected next Denver monthly wall clock %d, got %v", want, got)
+	}
+}
+
 func TestSchedulerManagerOnboardingSiteID(t *testing.T) {
 	siteID := schedulerOnboardingSiteID([]any{
 		map[string]any{"kind": "device", "hostname": "ignored"},

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Scheduling/Create_Job.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Scheduling/Create_Job.jsx
@@ -58,6 +58,11 @@ import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { DateTimePicker } from "@mui/x-date-pickers/DateTimePicker";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import dayjs from "dayjs";
+import {
+  dayjsFromEpochInTimezone,
+  fetchEngineScheduleClock,
+  wallClockStringFromDayjs,
+} from "./scheduleTime.js";
 import Prism from "prismjs";
 import "prismjs/components/prism-yaml";
 import "prismjs/components/prism-bash";
@@ -1562,6 +1567,21 @@ export default function CreateJob() {
   const [assembliesError, setAssembliesError] = useState("");
   const assemblyExportCacheRef = useRef(new Map());
   const quickDraftAppliedRef = useRef(null);
+  const [engineTimezone, setEngineTimezone] = useState("");
+
+  useEffect(() => {
+    let canceled = false;
+    fetchEngineScheduleClock()
+      .then(({ timezone }) => {
+        if (!canceled && timezone) {
+          setEngineTimezone(timezone);
+        }
+      })
+      .catch(() => {});
+    return () => {
+      canceled = true;
+    };
+  }, []);
 
   useEffect(() => {
     setQuickJobDraft(location.state?.quickJobDraft || null);
@@ -3948,7 +3968,11 @@ export default function CreateJob() {
         );
         setStartDateTime(
           resolvedInitialJob.start_ts
-            ? dayjs(Number(resolvedInitialJob.start_ts) * 1000).second(0)
+            ? dayjsFromEpochInTimezone(
+                resolvedInitialJob.start_ts,
+                engineTimezone,
+                dayjs().add(5, "minute").second(0)
+              )
             : resolvedInitialJob.schedule?.start
               ? dayjs(resolvedInitialJob.schedule.start).second(0)
               : dayjs().add(5, "minute").second(0)
@@ -3984,7 +4008,7 @@ export default function CreateJob() {
     return () => {
       canceled = true;
     };
-  }, [hydrateExistingComponents, initialJob, normalizeTargetList, resolvedInitialJob]);
+  }, [engineTimezone, hydrateExistingComponents, initialJob, normalizeTargetList, resolvedInitialJob]);
 
   const openAddComponent = async () => {
     setAddCompOpen(true);
@@ -4226,7 +4250,7 @@ export default function CreateJob() {
       name: jobName,
       components: payloadComponents,
       targets: workflowMode ? [] : serializeTargetsForSave(targets),
-      schedule: { type: scheduleType, start: scheduleType !== "immediately" ? (() => { try { const d = startDateTime?.toDate?.() || new Date(startDateTime); d.setSeconds(0,0); return d.toISOString(); } catch { return startDateTime; } })() : null },
+      schedule: { type: scheduleType, start: scheduleType !== "immediately" ? wallClockStringFromDayjs(startDateTime) : null },
       duration: { stopAfterEnabled: expiration !== "no_expire", expiration },
       execution_context: workflowMode ? "system" : execContext,
       credential_id: workflowMode ? null : (remoteExec && !useSvcAccount && selectedCredentialId ? Number(selectedCredentialId) : null),

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Scheduling/Create_Job.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Scheduling/Create_Job.jsx
@@ -59,6 +59,7 @@ import { DateTimePicker } from "@mui/x-date-pickers/DateTimePicker";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import dayjs from "dayjs";
 import {
+  dayjsFromEngineClock,
   dayjsFromEpochInTimezone,
   fetchEngineScheduleClock,
   wallClockStringFromDayjs,
@@ -1567,21 +1568,40 @@ export default function CreateJob() {
   const [assembliesError, setAssembliesError] = useState("");
   const assemblyExportCacheRef = useRef(new Map());
   const quickDraftAppliedRef = useRef(null);
-  const [engineTimezone, setEngineTimezone] = useState("");
+  const startDateTimeTouchedRef = useRef(false);
+  const hydratedFormKeyRef = useRef("");
+  const [engineScheduleClock, setEngineScheduleClock] = useState({
+    timezone: "",
+    epoch: null,
+    loaded: false,
+  });
+  const engineTimezone = engineScheduleClock.timezone || "";
 
   useEffect(() => {
     let canceled = false;
     fetchEngineScheduleClock()
-      .then(({ timezone }) => {
-        if (!canceled && timezone) {
-          setEngineTimezone(timezone);
+      .then((clock) => {
+        if (canceled) return;
+        const nextClock = { ...clock, loaded: true };
+        setEngineScheduleClock(nextClock);
+        if (!initialJob && !quickJobDraft && !startDateTimeTouchedRef.current) {
+          setStartDateTime(dayjsFromEngineClock(nextClock, 5 * 60, dayjs().add(5, "minute").second(0)));
         }
       })
-      .catch(() => {});
+      .catch(() => {
+        if (!canceled) {
+          setEngineScheduleClock((prev) => ({ ...prev, loaded: true }));
+        }
+      });
     return () => {
       canceled = true;
     };
   }, []);
+
+  useEffect(() => {
+    hydratedFormKeyRef.current = "";
+    startDateTimeTouchedRef.current = false;
+  }, [initialJob?.id]);
 
   useEffect(() => {
     setQuickJobDraft(location.state?.quickJobDraft || null);
@@ -3954,10 +3974,18 @@ export default function CreateJob() {
     let canceled = false;
     const hydrate = async () => {
       if (initialJob && initialJob.id) {
+        const formKey = String(initialJob.id);
+        if (hydratedFormKeyRef.current === formKey) {
+          return;
+        }
         if (!hasHydratedJobPayload(resolvedInitialJob)) {
           return;
         }
+        if (resolvedInitialJob.start_ts && !engineScheduleClock.loaded) {
+          return;
+        }
 
+        hydratedFormKeyRef.current = formKey;
         setJobName(resolvedInitialJob.name || "");
         setPageTitleJobName(
           typeof resolvedInitialJob.name === "string" ? resolvedInitialJob.name.trim() : ""
@@ -3995,20 +4023,24 @@ export default function CreateJob() {
           setComponents(hydrated);
           setComponentVarErrors({});
         }
-      } else if (!initialJob) {
+      } else if (!initialJob && hydratedFormKeyRef.current !== "new") {
+        hydratedFormKeyRef.current = "new";
         setPageTitleJobName("");
         setComponents([]);
         setComponentVarErrors({});
         setSelectedCredentialId("");
         setUseSvcAccount(true);
         setExpiration("1h");
+        if (engineScheduleClock.loaded && !startDateTimeTouchedRef.current) {
+          setStartDateTime(dayjsFromEngineClock(engineScheduleClock, 5 * 60, dayjs().add(5, "minute").second(0)));
+        }
       }
     };
     hydrate();
     return () => {
       canceled = true;
     };
-  }, [engineTimezone, hydrateExistingComponents, initialJob, normalizeTargetList, resolvedInitialJob]);
+  }, [engineScheduleClock, engineTimezone, hydrateExistingComponents, initialJob, normalizeTargetList, resolvedInitialJob]);
 
   const openAddComponent = async () => {
     setAddCompOpen(true);
@@ -4628,7 +4660,10 @@ export default function CreateJob() {
                 <LocalizationProvider dateAdapter={AdapterDayjs}>
                   <DateTimePicker
                     value={startDateTime}
-                    onChange={(val) => setStartDateTime(val?.second ? val.second(0) : val)}
+                    onChange={(val) => {
+                      startDateTimeTouchedRef.current = true;
+                      setStartDateTime(val?.second ? val.second(0) : val);
+                    }}
                     views={["year", "month", "day", "hours", "minutes"]}
                     format="YYYY-MM-DD hh:mm A"
                     slotProps={{

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Scheduling/Create_Job.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Scheduling/Create_Job.jsx
@@ -62,7 +62,7 @@ import {
   dayjsFromEngineClock,
   dayjsFromEpochInTimezone,
   fetchEngineScheduleClock,
-  wallClockStringFromDayjs,
+  wallClockStringFromEnginePickerValue,
 } from "./scheduleTime.js";
 import Prism from "prismjs";
 import "prismjs/components/prism-yaml";
@@ -4282,7 +4282,7 @@ export default function CreateJob() {
       name: jobName,
       components: payloadComponents,
       targets: workflowMode ? [] : serializeTargetsForSave(targets),
-      schedule: { type: scheduleType, start: scheduleType !== "immediately" ? wallClockStringFromDayjs(startDateTime) : null },
+      schedule: { type: scheduleType, start: scheduleType !== "immediately" ? wallClockStringFromEnginePickerValue(startDateTime) : null },
       duration: { stopAfterEnabled: expiration !== "no_expire", expiration },
       execution_context: workflowMode ? "system" : execContext,
       credential_id: workflowMode ? null : (remoteExec && !useSvcAccount && selectedCredentialId ? Number(selectedCredentialId) : null),

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Scheduling/Create_Onboarding_Job.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Scheduling/Create_Onboarding_Job.jsx
@@ -51,7 +51,7 @@ import {
   dayjsFromEngineClock,
   fetchEngineScheduleClock,
   wallClockStringFromDatetimeLocal,
-  wallClockStringFromDayjs,
+  wallClockStringFromEnginePickerValue,
   wallClockStringFromEpoch,
 } from "./scheduleTime.js";
 import { AgGridReact } from "ag-grid-react";
@@ -661,7 +661,7 @@ function dateTimePickerValue(value, clock = null) {
 }
 
 function datetimeLocalValueFromDayjs(value) {
-  return wallClockStringFromDayjs(value) || "";
+  return wallClockStringFromEnginePickerValue(value) || "";
 }
 
 function targetOutputContent(target, mode) {

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Scheduling/Create_Onboarding_Job.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Scheduling/Create_Onboarding_Job.jsx
@@ -47,6 +47,12 @@ import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { DateTimePicker } from "@mui/x-date-pickers/DateTimePicker";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import dayjs from "dayjs";
+import {
+  fetchEngineScheduleClock,
+  wallClockStringFromDatetimeLocal,
+  wallClockStringFromDayjs,
+  wallClockStringFromEpoch,
+} from "./scheduleTime.js";
 import { AgGridReact } from "ag-grid-react";
 import { ModuleRegistry, AllCommunityModule, themeQuartz } from "ag-grid-community";
 import {
@@ -638,19 +644,8 @@ function compareOnboardingTargets(left, right) {
   return String(left?.targetLabel || "").localeCompare(String(right?.targetLabel || ""), undefined, { numeric: true, sensitivity: "base" });
 }
 
-function datetimeLocalValue(epochSeconds) {
-  if (!epochSeconds) return "";
-  const date = new Date(Number(epochSeconds) * 1000);
-  if (Number.isNaN(date.getTime())) return "";
-  const offsetMs = date.getTimezoneOffset() * 60000;
-  return new Date(date.getTime() - offsetMs).toISOString().slice(0, 16);
-}
-
-function isoFromDatetimeLocal(value) {
-  if (!value) return null;
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return null;
-  return date.toISOString();
+function datetimeLocalValue(epochSeconds, timeZone = "") {
+  return wallClockStringFromEpoch(epochSeconds, timeZone);
 }
 
 function defaultStartDateTime() {
@@ -664,8 +659,7 @@ function dateTimePickerValue(value) {
 }
 
 function datetimeLocalValueFromDayjs(value) {
-  const parsed = value?.second ? value.second(0) : dayjs(value).second(0);
-  return parsed?.isValid?.() ? parsed.format("YYYY-MM-DDTHH:mm") : "";
+  return wallClockStringFromDayjs(value) || "";
 }
 
 function targetOutputContent(target, mode) {
@@ -1559,10 +1553,11 @@ export default function CreateOnboardingJob() {
     setLoading(true);
     setError("");
     try {
-      const [sitesResp, credentialsResp, jobResp] = await Promise.all([
+      const [sitesResp, credentialsResp, jobResp, clock] = await Promise.all([
         fetch("/api/sites", { credentials: "include" }),
         fetch("/api/credentials", { credentials: "include" }),
         editing ? fetch(`/api/scheduled_jobs/${jobId}`, { credentials: "include" }) : Promise.resolve(null),
+        fetchEngineScheduleClock().catch(() => ({ timezone: "", epoch: null })),
       ]);
       const sitesData = await sitesResp.json().catch(() => ({}));
       if (!sitesResp.ok) throw new Error(sitesData?.error || `Unable to load sites (${sitesResp.status})`);
@@ -1628,7 +1623,7 @@ export default function CreateOnboardingJob() {
               DEFAULT_ONBOARDING_CONCURRENCY
           ),
           scheduleType: job.schedule_type || "immediately",
-          start: datetimeLocalValue(job.start_ts),
+          start: datetimeLocalValue(job.start_ts, clock?.timezone || ""),
           enabled: Boolean(job.enabled),
         });
         setNameTouched(Boolean(job.name));
@@ -2288,7 +2283,7 @@ export default function CreateOnboardingJob() {
         ],
         schedule: {
           type: form.scheduleType || "immediately",
-          start: form.scheduleType === "immediately" ? null : isoFromDatetimeLocal(form.start),
+          start: form.scheduleType === "immediately" ? null : wallClockStringFromDatetimeLocal(form.start),
         },
         duration: { expiration: "no_expire" },
         execution_context: "onboarding_local_network",

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Scheduling/Create_Onboarding_Job.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Scheduling/Create_Onboarding_Job.jsx
@@ -48,6 +48,7 @@ import { DateTimePicker } from "@mui/x-date-pickers/DateTimePicker";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import dayjs from "dayjs";
 import {
+  dayjsFromEngineClock,
   fetchEngineScheduleClock,
   wallClockStringFromDatetimeLocal,
   wallClockStringFromDayjs,
@@ -648,14 +649,15 @@ function datetimeLocalValue(epochSeconds, timeZone = "") {
   return wallClockStringFromEpoch(epochSeconds, timeZone);
 }
 
-function defaultStartDateTime() {
-  return dayjs().add(5, "minute").second(0);
+function defaultStartDateTime(clock = null) {
+  return dayjsFromEngineClock(clock, 5 * 60, dayjs().add(5, "minute").second(0));
 }
 
-function dateTimePickerValue(value) {
+function dateTimePickerValue(value, clock = null) {
   const text = String(value || "").trim();
-  const parsed = text ? dayjs(text).second(0) : defaultStartDateTime();
-  return parsed?.isValid?.() ? parsed : defaultStartDateTime();
+  const fallback = defaultStartDateTime(clock);
+  const parsed = text ? dayjs(text).second(0) : fallback;
+  return parsed?.isValid?.() ? parsed : fallback;
 }
 
 function datetimeLocalValueFromDayjs(value) {
@@ -1380,6 +1382,11 @@ export default function CreateOnboardingJob() {
   const [nameTouched, setNameTouched] = useState(false);
   const [selectedTargetId, setSelectedTargetId] = useState("");
   const [progressionClock, setProgressionClock] = useState(() => Date.now());
+  const [engineScheduleClock, setEngineScheduleClock] = useState({
+    timezone: "",
+    epoch: null,
+    loaded: false,
+  });
   const targetGridApiRef = useRef(null);
   const progressionGridApiRef = useRef(null);
   const targetsLoadingRef = useRef(false);
@@ -1479,9 +1486,9 @@ export default function CreateOnboardingJob() {
       start:
         normalizedType === "immediately"
           ? prev.start
-          : prev.start || datetimeLocalValueFromDayjs(defaultStartDateTime()),
+          : prev.start || datetimeLocalValueFromDayjs(defaultStartDateTime(engineScheduleClock)),
     }));
-  }, []);
+  }, [engineScheduleClock]);
 
   const fetchInstallBranches = useCallback(async () => {
     setBranchesLoading(true);
@@ -1559,6 +1566,8 @@ export default function CreateOnboardingJob() {
         editing ? fetch(`/api/scheduled_jobs/${jobId}`, { credentials: "include" }) : Promise.resolve(null),
         fetchEngineScheduleClock().catch(() => ({ timezone: "", epoch: null })),
       ]);
+      const nextClock = { ...clock, loaded: true };
+      setEngineScheduleClock(nextClock);
       const sitesData = await sitesResp.json().catch(() => ({}));
       if (!sitesResp.ok) throw new Error(sitesData?.error || `Unable to load sites (${sitesResp.status})`);
       const credentialsData = await credentialsResp.json().catch(() => ({}));
@@ -1623,7 +1632,7 @@ export default function CreateOnboardingJob() {
               DEFAULT_ONBOARDING_CONCURRENCY
           ),
           scheduleType: job.schedule_type || "immediately",
-          start: datetimeLocalValue(job.start_ts, clock?.timezone || ""),
+          start: datetimeLocalValue(job.start_ts, nextClock.timezone || ""),
           enabled: Boolean(job.enabled),
         });
         setNameTouched(Boolean(job.name));
@@ -2616,7 +2625,7 @@ export default function CreateOnboardingJob() {
                       <LocalizationProvider dateAdapter={AdapterDayjs}>
                         <DateTimePicker
                           label="Start"
-                          value={dateTimePickerValue(form.start)}
+                          value={dateTimePickerValue(form.start, engineScheduleClock)}
                           onChange={(value) => setField("start", datetimeLocalValueFromDayjs(value))}
                           views={["year", "month", "day", "hours", "minutes"]}
                           format="YYYY-MM-DD hh:mm A"

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Scheduling/scheduleTime.js
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Scheduling/scheduleTime.js
@@ -53,7 +53,7 @@ export function dayjsFromEngineClock(clock, offsetSeconds = 0, fallback = dayjs(
   return dayjsFromEpochInTimezone(epoch + Number(offsetSeconds || 0), clock?.timezone, fallback);
 }
 
-export function wallClockStringFromDayjs(value) {
+export function wallClockStringFromEnginePickerValue(value) {
   const parsed = value?.second ? value.second(0) : dayjs(value).second(0);
   return parsed?.isValid?.() ? parsed.format(WALL_CLOCK_FORMAT) : null;
 }

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Scheduling/scheduleTime.js
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Scheduling/scheduleTime.js
@@ -1,0 +1,73 @@
+import dayjs from "dayjs";
+
+const WALL_CLOCK_FORMAT = "YYYY-MM-DDTHH:mm";
+
+export function normalizeEngineTimezone(value) {
+  const text = String(value || "").trim();
+  if (!text) return "";
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: text }).format(new Date());
+    return text;
+  } catch {
+    return "";
+  }
+}
+
+function localDatetimeValue(date) {
+  const offsetMs = date.getTimezoneOffset() * 60000;
+  return new Date(date.getTime() - offsetMs).toISOString().slice(0, 16);
+}
+
+function datetimeValueInTimezone(date, timeZone) {
+  const timezone = normalizeEngineTimezone(timeZone);
+  if (!timezone) return localDatetimeValue(date);
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(date);
+  const lookup = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+  return `${lookup.year}-${lookup.month}-${lookup.day}T${lookup.hour}:${lookup.minute}`;
+}
+
+export function wallClockStringFromEpoch(epochSeconds, timeZone = "") {
+  if (!epochSeconds) return "";
+  const date = new Date(Number(epochSeconds) * 1000);
+  if (Number.isNaN(date.getTime())) return "";
+  return datetimeValueInTimezone(date, timeZone);
+}
+
+export function dayjsFromEpochInTimezone(epochSeconds, timeZone = "", fallback = dayjs()) {
+  const text = wallClockStringFromEpoch(epochSeconds, timeZone);
+  const parsed = text ? dayjs(text).second(0) : fallback;
+  return parsed?.isValid?.() ? parsed : fallback;
+}
+
+export function wallClockStringFromDayjs(value) {
+  const parsed = value?.second ? value.second(0) : dayjs(value).second(0);
+  return parsed?.isValid?.() ? parsed.format(WALL_CLOCK_FORMAT) : null;
+}
+
+export function wallClockStringFromDatetimeLocal(value) {
+  const text = String(value || "").trim();
+  if (!text) return null;
+  const parsed = dayjs(text).second(0);
+  return parsed?.isValid?.() ? parsed.format(WALL_CLOCK_FORMAT) : null;
+}
+
+export async function fetchEngineScheduleClock() {
+  const response = await fetch("/api/server/time", {
+    credentials: "include",
+    cache: "no-store",
+  });
+  if (!response.ok) return { timezone: "", epoch: null };
+  const body = await response.json().catch(() => ({}));
+  return {
+    timezone: normalizeEngineTimezone(body?.timezone_id),
+    epoch: Number.isFinite(Number(body?.epoch)) ? Number(body.epoch) : null,
+  };
+}

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Scheduling/scheduleTime.js
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Scheduling/scheduleTime.js
@@ -47,6 +47,12 @@ export function dayjsFromEpochInTimezone(epochSeconds, timeZone = "", fallback =
   return parsed?.isValid?.() ? parsed : fallback;
 }
 
+export function dayjsFromEngineClock(clock, offsetSeconds = 0, fallback = dayjs()) {
+  const epoch = Number(clock?.epoch);
+  if (!Number.isFinite(epoch) || epoch <= 0) return fallback;
+  return dayjsFromEpochInTimezone(epoch + Number(offsetSeconds || 0), clock?.timezone, fallback);
+}
+
 export function wallClockStringFromDayjs(value) {
   const parsed = value?.second ? value.second(0) : dayjs(value).second(0);
   return parsed?.isValid?.() ? parsed.format(WALL_CLOCK_FORMAT) : null;

--- a/Docs/Using the Platform/scheduled-jobs.md
+++ b/Docs/Using the Platform/scheduled-jobs.md
@@ -24,6 +24,8 @@ Script jobs can target SYSTEM or current user. Ansible jobs target SSH or WinRM.
 
 Common schedule types include immediate, once, every 5/10/15/30 minutes, hourly, daily, weekly, monthly, and yearly.
 
+Scheduled wall-clock times use the Engine host timezone. If the Engine host is configured for `America/Denver`, a daily job set for `12:00 AM` runs at midnight in that timezone even when an operator browser or API client is in another timezone.
+
 ## Read Results
 
 - Current Run shows live or latest run state.
@@ -76,6 +78,8 @@ Sites can launch local-network onboarding jobs that appear in Scheduled Jobs. Th
     ### Runtime behavior
 
     - `job-scheduler` owns scheduled ticks, queue leases, service actions, and site-worker lifecycle.
+    - Schedule create/update accepts offsetless wall-clock values such as `2026-06-25T00:00` as Engine-local time. Offset-bearing RFC3339 values remain absolute instants.
+    - Daily, weekly, monthly, and yearly recurrence preserves Engine-local wall-clock time across daylight saving changes.
     - Site workers execute site-scoped pressure work outside `api-backend`.
     - Each due occurrence resolves targets once and freezes membership in run target rows.
     - Filter targets preserve allowed site scope from creation/edit time.


### PR DESCRIPTION
## Summary
- Fixed scheduled-job wall-clock handling so offsetless schedule inputs are interpreted in the Engine host timezone.
- Updated scheduler recurrence to preserve Engine-local daily, weekly, monthly, and yearly times across daylight saving changes.
- Updated Scheduled Job and onboarding WebUI save/load paths to seed picker values from Engine clock and send Engine-local wall-clock schedule strings.
- Documented that scheduled jobs use the Engine host timezone.

## Root Cause
- The API parsed offsetless schedule strings with `time.Parse`, which treats them as UTC. `2026-06-25T00:00` became midnight UTC, which displays and fires as 6:00 PM previous day on an `America/Denver` Engine.
- Scheduler calendar recurrences used fixed seconds or UTC calendar helpers where Engine-local wall-clock behavior was expected.
- WebUI schedule pickers needed Engine-clock seeding so browser timezone does not become schedule intent.

## Review Feedback Addressed
- Seed/display picker values from `/api/server/time` Engine clock before saving offsetless schedule strings.
- Avoid edit-form rehydration after the clock request by waiting for clock before first hydration and guarding hydration with a per-job ref.

## Validation
- `git diff --check`
- `/opt/Borealis/Dependencies/Go/go1.22.12/bin/gofmt -w ...`
- `PATH=/opt/Borealis/Dependencies/Go/go1.22.12/bin:$PATH go test ./cmd/api-backend -run 'Test(ScheduledParseTSUsesEngineTimezoneForWallClockInput|SchedulerManagerCalendarNextRunPreservesLocalMidnightAcrossDST|SchedulerManagerMonthlyNextRunPreservesLocalWallClockAcrossDST|SchedulerManagerComputeNextRunMatchesPythonIntervals)'`
- `PATH=/opt/Borealis/Dependencies/Go/go1.22.12/bin:$PATH go test ./cmd/api-backend`
- `BOREALIS_ENGINE_UNIT_TEST_DOMAIN=scheduler ./Engine_Unit_Tests.sh` using a temporary venv with `engine-requirements.txt`

## Deferred Validation
- `BOREALIS_ENGINE_UNIT_TEST_DOMAIN=webui ./Engine_Unit_Tests.sh` could not run because runtime WebUI tests are missing at `Engine/Services/webui-frontend/cache/web-interface/Unit_Tests`. Redeploy Engine/WebUI runtime cache, then rerun the WebUI lane for browser-side coverage.

## Risk
- Runtime code and API behavior covered by Go tests plus scheduler Python lane.
- WebUI changes are source-reviewed but not Vitest-verified in this checkout due missing runtime cache.
