### PR TITLE
issue/enforce-alert-suppression-reason

### DIFF
--- a/Data/Engine/Containers/api-backend/cmd/api-backend/watchdogs.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/watchdogs.go
@@ -513,14 +513,20 @@ func watchdogIncidentStateUpdate(w http.ResponseWriter, r *http.Request, auth *a
 	}
 	body := map[string]any{}
 	_ = json.NewDecoder(http.MaxBytesReader(w, r.Body, 64<<10)).Decode(&body)
+	requestedState := firstText(cleanText(body["state"]), "open")
+	requestedReason := cleanText(body["reason"])
+	if normalizeIncidentMutationState(requestedState) == "suppressed" && cleanSingleLine(requestedReason) == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"errors": []string{"Suppression reason is required."}})
+		return
+	}
 	ctx, cancel := watchdogTimeoutContext(r.Context(), auth)
 	defer cancel()
 	incident, validationErrors, err := store.updateWatchdogIncidentState(
 		ctx,
 		profile,
 		incidentID,
-		firstText(cleanText(body["state"]), "open"),
-		cleanText(body["reason"]),
+		requestedState,
+		requestedReason,
 	)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": err.Error()})
@@ -1243,7 +1249,10 @@ func (s *postgresOperatorStore) upsertDeviceWatchdogOverride(ctx context.Context
 	if state == "" {
 		state = "suppressed"
 	}
-	reason := cleanSingleLine(firstText(cleanText(body["reason"]), fmt.Sprintf("Temporarily %s by operator.", state)))
+	reason := cleanSingleLine(cleanText(body["reason"]))
+	if !clearOverride && reason == "" {
+		return nil, []string{"Suppression reason is required."}, nil
+	}
 	now := time.Now().Unix()
 	conn, err := s.db.Conn(ctx)
 	if err != nil {
@@ -1332,7 +1341,7 @@ func upsertWatchdogOverrideStateTx(ctx context.Context, tx *sql.Tx, watchdogID i
 			       resolution_reason=$1,
 			       updated_at=$2
 			 WHERE id=$3
-		`, state, now, incidentID.Int64); err != nil {
+		`, reason, now, incidentID.Int64); err != nil {
 			return err
 		}
 	}
@@ -1479,6 +1488,9 @@ func (s *postgresOperatorStore) updateWatchdogIncidentState(ctx context.Context,
 	desiredState := normalizeIncidentMutationState(state)
 	if desiredState == "" {
 		return nil, []string{"Unsupported incident state transition."}, nil
+	}
+	if desiredState == "suppressed" && cleanSingleLine(reason) == "" {
+		return nil, []string{"Suppression reason is required."}, nil
 	}
 	target, found, err := s.findVisibleWatchdogIncident(ctx, profile, incidentID, "all")
 	if err != nil {

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/watchdogs_test.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/watchdogs_test.go
@@ -524,6 +524,16 @@ func TestDeviceWatchdogOverrideHandlerReturnsValidationErrors(t *testing.T) {
 	}
 }
 
+func TestDeviceWatchdogOverrideHandlerRequiresSuppressionReason(t *testing.T) {
+	store := &fakeWatchdogStore{overrideErrors: []string{"Suppression reason is required."}}
+	recorder := httptest.NewRecorder()
+	deviceWatchdogTestMux(store).ServeHTTP(recorder, watchdogJSONRequest(http.MethodPost, "/api/devices/LAB-OPERATOR-01/watchdogs/overrides", `{"watchdog_id":7,"state":"suppressed","reason":"  "}`))
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
 func TestWatchdogIncidentAcknowledgeUsesGoRoute(t *testing.T) {
 	store := &fakeWatchdogStore{
 		ackIncident: map[string]any{"id": int64(12), "watchdog_id": int64(4), "hostname": "host-1"},
@@ -559,6 +569,21 @@ func TestWatchdogIncidentStateUpdatePassesPayload(t *testing.T) {
 	}
 	if store.stateID != 12 || store.stateValue != "suppressed" || store.stateReason != "maintenance" {
 		t.Fatalf("unexpected state update id=%d state=%q reason=%q", store.stateID, store.stateValue, store.stateReason)
+	}
+}
+
+func TestWatchdogIncidentStateUpdateRequiresSuppressionReason(t *testing.T) {
+	store := &fakeWatchdogStore{
+		stateIncident: map[string]any{"id": int64(12), "watchdog_id": int64(4), "hostname": "host-1", "state": "suppressed"},
+	}
+	recorder := httptest.NewRecorder()
+	watchdogTestMux(store).ServeHTTP(recorder, watchdogJSONRequest(http.MethodPost, "/api/watchdogs/incidents/12/state", `{"state":"suppressed","reason":"  "}`))
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if store.stateID != 0 {
+		t.Fatalf("blank suppression reason should be rejected before store call, got id=%d", store.stateID)
 	}
 }
 

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Alerting/Active_Alerts.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Alerting/Active_Alerts.jsx
@@ -27,6 +27,7 @@ import {
   GRID_WRAPPER_SX,
   formatTimestamp,
   gridTheme,
+  promptRequiredSuppressionReason,
   severityColor,
 } from "../Automation/Watchdogs/shared.jsx";
 
@@ -257,13 +258,18 @@ export default function ActiveAlerts() {
   const toggleSelectedQueue = useCallback(async () => {
     if (!selectedRows.length || !queueToggleMode) return;
     const desiredState = queueToggleMode === "reopen" ? "open" : "suppressed";
-    const reason =
-      desiredState === "suppressed"
-        ? window.prompt("Optional suppression reason for the selected alerts:", "Temporarily suppressed from Alerts.") ||
-          "Temporarily suppressed from Alerts."
-        : "";
-    setActionBusy(true);
     setError("");
+    let reason = "";
+    if (desiredState === "suppressed") {
+      const promptedReason = promptRequiredSuppressionReason("Suppression reason required for the selected alerts:");
+      if (promptedReason === null) return;
+      if (!promptedReason) {
+        setError("Enter a suppression reason before suppressing selected alerts.");
+        return;
+      }
+      reason = promptedReason;
+    }
+    setActionBusy(true);
     try {
       await Promise.all(
         selectedRows.map((row) =>

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Automation/Watchdogs/shared.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Automation/Watchdogs/shared.jsx
@@ -139,6 +139,15 @@ export function severityColor(severity) {
   return "#fcd34d";
 }
 
+export function promptRequiredSuppressionReason(message) {
+  const promptFn =
+    typeof window !== "undefined" && typeof window.prompt === "function" ? window.prompt.bind(window) : null;
+  if (!promptFn) return "";
+  const value = promptFn(message, "");
+  if (value === null) return null;
+  return String(value || "").trim();
+}
+
 export function summarizeRuleResults(sample) {
   const entries = Array.isArray(sample?.results) ? sample.results : [];
   return entries

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Device_Watchdogs.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Device_Watchdogs.jsx
@@ -21,7 +21,12 @@ import {
 } from "@mui/icons-material";
 
 import { APP_PATHS } from "../../app/routes/paths.js";
-import { formatTimestamp, severityColor, summarizeRuleResults } from "../../Automation/Watchdogs/shared.jsx";
+import {
+  formatTimestamp,
+  promptRequiredSuppressionReason,
+  severityColor,
+  summarizeRuleResults,
+} from "../../Automation/Watchdogs/shared.jsx";
 
 function SectionShell({ title, subtitle, action, children }) {
   return (
@@ -192,12 +197,18 @@ export default function DeviceWatchdogsTab({
   const saveOverride = useCallback(
     async ({ watchdogId, clear = false }) => {
       if (!resolvedDeviceKey || !watchdogId) return;
-      const reason = clear
-        ? ""
-        : window.prompt("Optional suppression reason for this device:", "Temporarily suppressed for this device.") ||
-          "Temporarily suppressed for this device.";
-      setActionBusy(true);
       setError("");
+      let reason = "";
+      if (!clear) {
+        const promptedReason = promptRequiredSuppressionReason("Suppression reason required for this device:");
+        if (promptedReason === null) return;
+        if (!promptedReason) {
+          setError("Enter a suppression reason before suppressing this watchdog for the device.");
+          return;
+        }
+        reason = promptedReason;
+      }
+      setActionBusy(true);
       try {
         const response = await fetch(`/api/devices/${encodeURIComponent(resolvedDeviceKey)}/watchdogs/overrides`, {
           method: "POST",

--- a/Docs/Using the Platform/alerts.md
+++ b/Docs/Using the Platform/alerts.md
@@ -23,11 +23,15 @@ Clicking the same status pill again clears that filter back to all alerts.
 - `Suppressed`: operator muted current incident without marking condition fixed.
 - `Resolved`: condition cleared, policy disabled/archived, target disappeared, or telemetry became stale long enough to auto-resolve.
 
+Suppressing alerts requires a reason. If the reason prompt is cancelled or left blank, Borealis leaves the alert open and does not change incident state.
+
 Offline-only incidents are purged when the device checks back in.
 
 ## Device-Level Alerts
 
 Device Summary has a `Watchdogs` tab for active incidents, effective watchdog assignments, and device-level overrides. Use it when one device needs local context or a one-device suppression.
+
+Device-level suppressions also require a reason so other operators can tell why the shared watchdog policy was muted for one endpoint.
 
 ??? example "Detailed Codex Breakdown"
 
@@ -55,5 +59,6 @@ Device Summary has a `Watchdogs` tab for active incidents, effective watchdog as
     ### Runtime behavior
 
     - Queue-level suppression is an incident state transition.
+    - Queue-level suppression and device-level watchdog override suppression require non-empty `reason` values.
     - Device-level suppressions live separately in `watchdog_device_overrides`.
     - Incident rows include watchdog, device, site, severity, title, sampled data, acknowledgement metadata, and timestamps.


### PR DESCRIPTION
## Summary
- Require a non-empty reason before suppressing alert queue incidents.
- Treat cancelled or blank suppression prompts as cancel/no-op in Alerts and Device Watchdogs UI.
- Reject blank suppressed-state API mutations server-side and persist the supplied device override reason into incident `resolution_reason`.
- Document required alert and device-level suppression reasons.

## Issue
- Closes #258

## Validation
- `git diff --check`
- `PATH=/opt/Borealis/Dependencies/Go/go1.22.12/bin:$PATH go test ./cmd/api-backend -run 'Test(WatchdogIncidentStateUpdatePassesPayload|WatchdogIncidentStateUpdateRequiresSuppressionReason|DeviceWatchdogOverrideHandlerUsesGoRoute|DeviceWatchdogOverrideHandlerRequiresSuppressionReason)'`
- `PATH=/opt/Borealis/Dependencies/Go/go1.22.12/bin:$PATH go test ./cmd/api-backend`

## Not Run
- `./Engine_Unit_Tests.sh --domain watchdogs` returned no Engine Python tests for that domain.
- `./Engine_Unit_Tests.sh --domain webui` blocked because runtime WebUI unit tests are missing at `/opt/Borealis/Engine/Services/webui-frontend/cache/web-interface/Unit_Tests`; redeploy Engine then rerun.