### PR TITLE
[codex] Scope Engine deploy rebuild decisions

### DIFF
--- a/Docs/Reference/Core Runtimes/Stack_Breakdown.md
+++ b/Docs/Reference/Core Runtimes/Stack_Breakdown.md
@@ -141,7 +141,7 @@ Engine/Services/webui-frontend/data/web-interface/vite.config.mts -> /opt/Boreal
 7. Prune empty legacy runtime paths.
 8. Resolve public hostname and ACME email.
 9. Detect deployment profile from vCPU/RAM and render `Engine/Deploy/runtime.env` for shared container runtime settings, mode-scoped `webui-frontend.env`, and `Engine/Deploy/compose.env` for Compose interpolation plus profile-managed DB/site-worker tuning.
-10. Compute service input hashes from source, Dockerfile, build context, target mode, and dependency inputs.
+10. Compute service input hashes from each service's declared source, Dockerfile, build context, target mode, and dependency inputs.
 11. Build changed local images as `borealis-engine/<service>:sha-<hash>`.
 12. Write `Engine/Deploy/image-manifest.json`.
 13. Re-render `compose.env` with resolved image tags while keeping service runtime env files free of image tag variables.
@@ -177,6 +177,8 @@ Build cache:
 - Docker Buildx uses `Engine/Deploy/cache/buildkit/<service>/` when available.
 - Hosts without usable Buildx fall back to `DOCKER_BUILDKIT=1 docker build`.
 - `api-backend` keeps repo-root build context because it packages `Data/Agent` and `Agent.exe`.
+- Service input hashes come from declared build inputs, not the repo-wide Git commit. A WebUI-only commit should not invalidate `api-backend` or `job-scheduler`.
+- `api-backend` and `job-scheduler` share the Go api-backend binary. `Engine.sh` builds that binary only when one of those images needs a Docker rebuild, then reuses it for the rest of that deploy pass.
 - `webui-frontend`, `traefik-edge`, `postgres-db`, `remote-desktop-guacd`, and `wireguard-tunnel` use service-local build contexts.
 - Service-local build contexts carry their own `.dockerignore` files so `node_modules`, WebUI build output, Python bytecode, pytest caches, logs, and local test output stay out of image contexts.
 - Deploy mode is part of the image hash only for services with explicit mode targets, currently `webui-frontend`. Switching between prod and dev should not make PostgreSQL, guacd, WireGuard, Traefik, or the API image appear changed unless their own inputs changed.

--- a/Docs/Reference/Core Runtimes/engine-runtime.md
+++ b/Docs/Reference/Core Runtimes/engine-runtime.md
@@ -45,7 +45,8 @@ Describe the Borealis Engine runtime, its services, configuration, and operation
     - TLS and signing certificates live under `Engine/Services/api-backend/secrets/Certificates/`.
     - Bundled official assemblies live under `Data/Engine/Containers/api-backend/data/Official_Assemblies/`; managed Aurora checkout lives under `Engine/Services/api-backend/cache/Aurora/`.
     - The Compose project name is `borealis-engine`.
-    - `Engine.sh` computes input hashes from Dockerfiles, build context, container entrypoints, source files, dependency manifests, and mode inputs, then builds images as `borealis-engine/<service>:sha-<hash>`.
+    - `Engine.sh` computes input hashes from Dockerfiles, build context, container entrypoints, source files, dependency manifests, and mode inputs, then builds images as `borealis-engine/<service>:sha-<hash>`. Hashes use declared service inputs, not the repo-wide Git commit.
+    - `api-backend` and `job-scheduler` share the Go api-backend binary. `Engine.sh` prepares that binary only after one of those images is known to need a Docker rebuild, then reuses it within the same deploy pass.
     - Mode inputs affect image hashes only for services with mode-specific build targets. Today that means `webui-frontend`; DB, guacd, WireGuard, Traefik, and API images do not rebuild merely because the operator switches `prod`/`dev`.
     - Docker Buildx cache is stored under `Engine/Deploy/cache/buildkit/<service>/` when usable; plain Docker build remains the fallback.
     - Deploy output uses compact colored service status lines in interactive terminals; set `NO_COLOR=1` to force plain text.

--- a/Engine.sh
+++ b/Engine.sh
@@ -89,6 +89,7 @@ declare -A IMAGE_HASHES
 declare -A DOCKERFILES
 declare -A BUILD_CONTEXTS
 declare -A BUILD_STATUSES
+GO_API_BACKEND_BINARY_PREPARED=0
 
 log() {
   printf '[%s] %s\n' "$(date +%FT%T)" "$*"
@@ -1160,7 +1161,6 @@ compute_service_hash() {
 import hashlib
 import json
 import pathlib
-import subprocess
 import sys
 
 root = pathlib.Path(sys.argv[1])
@@ -1213,16 +1213,6 @@ digest.update(
     f"context={entry.get('context')}\n"
     f"target={targets.get(mode) or ''}\n".encode("utf-8")
 )
-if service == "api-backend":
-    try:
-        commit = subprocess.check_output(
-            ["git", "-C", str(root), "rev-parse", "HEAD"],
-            text=True,
-            stderr=subprocess.DEVNULL,
-        ).strip()
-    except Exception:
-        commit = ""
-    digest.update(f"api_backend_version={commit}\n".encode("utf-8"))
 for rel in sorted(files, key=lambda p: str(p)):
     path = root / rel
     digest.update(str(rel).encode("utf-8") + b"\0")
@@ -1295,9 +1285,14 @@ prepare_service_build_artifacts() {
   local service="$1"
   case "${service}" in
     api-backend|job-scheduler)
+      if [[ "${GO_API_BACKEND_BINARY_PREPARED}" == "1" ]]; then
+        printf '[%s] %s reusing prepared Go api-backend binary\n' "$(date +%FT%T)" "${service}" >> "${BUILD_LOG}"
+        return 0
+      fi
       log_status "${service}" "Building Go binary" "${C_YELLOW}"
       BOREALIS_GO_API_BACKEND_OUTPUT_ROOT="${SCRIPT_DIR}/Data/Engine/Containers/api-backend/dist" \
         "${SCRIPT_DIR}/Data/Engine/Containers/api-backend/build-api-backend.sh" >> "${BUILD_LOG}" 2>&1
+      GO_API_BACKEND_BINARY_PREPARED=1
       ;;
   esac
 }
@@ -1305,7 +1300,6 @@ prepare_service_build_artifacts() {
 build_service_image() {
   local service="$1"
   local mode="$2"
-  prepare_service_build_artifacts "${service}"
   local image_hash
   image_hash="$(compute_service_hash "${service}" "${mode}")"
   local tag="borealis-engine/${service}:sha-${image_hash:0:12}"
@@ -1341,6 +1335,20 @@ build_service_image() {
     fi
   fi
 
+  prepare_service_build_artifacts "${service}"
+  local prepared_hash
+  prepared_hash="$(compute_service_hash "${service}" "${mode}")"
+  if [[ "${prepared_hash}" != "${image_hash}" ]]; then
+    image_hash="${prepared_hash}"
+    tag="borealis-engine/${service}:sha-${image_hash:0:12}"
+    IMAGE_HASHES["${service}"]="${image_hash}"
+    IMAGE_TAGS["${service}"]="${tag}"
+    if [[ "${previous}" == "${image_hash}" ]] && docker image inspect "${tag}" >/dev/null 2>&1; then
+      log_status "${service}" "Already Up-to-Date" "${C_GREEN}"
+      printf '[%s] %s unchanged after artifact preparation as %s; build skipped\n' "$(date +%FT%T)" "${service}" "${tag}" >> "${BUILD_LOG}"
+      return 0
+    fi
+  fi
   log_status "${service}" "(Re)Building" "${C_YELLOW}"
   {
     printf '[%s] Building %s as %s\n' "$(date +%FT%T)" "${service}" "${tag}"
@@ -1392,6 +1400,7 @@ build_images() {
   fi
   local service=""
   : > "${BUILD_LOG}"
+  GO_API_BACKEND_BINARY_PREPARED=0
   for service in "${selected[@]}"; do
     validate_build_role "${service}"
     build_service_image "${service}" "${mode}"


### PR DESCRIPTION
## Summary
- remove repo-wide Git HEAD from api-backend image hash so WebUI-only commits do not invalidate API image tags
- defer Go api-backend binary preparation until api-backend or job-scheduler actually needs a Docker rebuild
- reuse the prepared Go binary across api-backend/job-scheduler builds during one deploy pass
- document scoped hash/build behavior in Engine runtime docs

## Root Cause
`Engine.sh` salted the `api-backend` input hash with `git rev-parse HEAD`, so any commit in the repo changed the API image tag even when only WebUI files changed. It also built the Go api-backend binary before checking whether the existing image was already current.

## Validation
- `bash -n Engine.sh`
- `git diff --check`
- static check confirmed no `api_backend_version` / `git rev-parse HEAD` hash salt and no eager `prepare_service_build_artifacts "${service}"` call remain
- hash-scope simulation confirmed a WebUI-only file changes `webui-frontend` hash while `api-backend` and `job-scheduler` hashes remain unchanged
- `docker compose --env-file Data/Engine/Containers/compose.env.example -f Data/Engine/Containers/compose.yaml config`

## Blocked Validation
- `./Engine_Unit_Tests.sh --domain core` could not run because current host Python lacks `pytest` and no Engine venv is present (`/usr/bin/python3: No module named pytest`).
