### PR TITLE
issue/cleanup-engine-docker-storage

### DIFF
--- a/Docs/Engine/deploying-the-engine.md
+++ b/Docs/Engine/deploying-the-engine.md
@@ -83,6 +83,14 @@ During deployment, Borealis will install missing dependencies, prepare runtime c
     curl -fsSL https://raw.githubusercontent.com/bunny-lab-io/Borealis/refs/heads/main/Engine.sh | sudo bash -s -- --repo-branch optimization/agent-context-socket-consolidation deploy prod
     ```
 
+### Docker Storage Cleanup
+Every Engine deploy cleans Docker storage after the stack has reconciled successfully. Borealis prunes inactive Docker images, clears Docker builder cache, and removes Engine Buildx cache exports so old image tags and build snapshots do not fill root storage over time.
+
+`site-worker` images are handled carefully because the scheduler may need the current image even when no site-worker container is running. Borealis keeps the current site-worker image available and removes stale site-worker tags separately.
+
+!!! warning "Shared Docker Hosts"
+    Engine hosts should be dedicated to Borealis. Docker cleanup removes unused images and build cache from the host, which may affect unrelated Docker workloads if you co-host them. Set `BOREALIS_SKIP_DOCKER_PRUNE=1` before deploy only when you intentionally need to preserve unused Docker images or build cache.
+
 ### Configure the Engine
 You will be asked as series of questions during initial setup for a new engine.  The questions will be generally straight-forward and not too complicated.
 

--- a/Docs/Reference/Core Runtimes/Stack_Breakdown.md
+++ b/Docs/Reference/Core Runtimes/Stack_Breakdown.md
@@ -150,6 +150,7 @@ Engine/Services/webui-frontend/data/web-interface/vite.config.mts -> /opt/Boreal
 16. Run scoped Compose `up -d --no-deps --no-build <service...>` when only service images changed or when switching prod/dev WebUI mode.
 17. Run full Compose `up -d --no-build` when compose config, shared runtime env, or container state requires it.
 18. Write `Engine/Deploy/deploy-manifest.json`.
+19. Prune inactive Docker images, Docker builder cache, and Engine Buildx cache exports after successful reconciliation.
 
 Build order follows `Engine.sh` local build roles. `docker-proxy` is an external image and is not locally built.
 ```text
@@ -176,9 +177,11 @@ borealis-engine/<service>:sha-<inputhash12>
 Build cache:
 - Docker Buildx uses `Engine/Deploy/cache/buildkit/<service>/` when available.
 - Hosts without usable Buildx fall back to `DOCKER_BUILDKIT=1 docker build`.
+- Successful deploys prune inactive Docker images with `docker image prune -a`, clear Docker builder cache with `docker builder prune --all`, and clear Engine Buildx cache exports under `Engine/Deploy/cache/buildkit/`. Set `BOREALIS_SKIP_DOCKER_PRUNE=1` to skip this cleanup on a shared Docker host.
 - `api-backend` keeps repo-root build context because it packages `Data/Agent` and `Agent.exe`.
 - Service input hashes come from declared build inputs, not the repo-wide Git commit. A WebUI-only commit should not invalidate `api-backend` or `job-scheduler`.
 - `api-backend` and `job-scheduler` share the Go api-backend binary. `Engine.sh` builds that binary only when one of those images needs a Docker rebuild, then reuses it for the rest of that deploy pass.
+- `site-worker` is built as a local image but may not have a running container. Deploy cleanup protects the current site-worker image and removes stale site-worker tags separately.
 - `webui-frontend`, `traefik-edge`, `postgres-db`, `remote-desktop-guacd`, and `wireguard-tunnel` use service-local build contexts.
 - Service-local build contexts carry their own `.dockerignore` files so `node_modules`, WebUI build output, Python bytecode, pytest caches, logs, and local test output stay out of image contexts.
 - Deploy mode is part of the image hash only for services with explicit mode targets, currently `webui-frontend`. Switching between prod and dev should not make PostgreSQL, guacd, WireGuard, Traefik, or the API image appear changed unless their own inputs changed.

--- a/Docs/Reference/Core Runtimes/engine-runtime.md
+++ b/Docs/Reference/Core Runtimes/engine-runtime.md
@@ -49,6 +49,8 @@ Describe the Borealis Engine runtime, its services, configuration, and operation
     - `api-backend` and `job-scheduler` share the Go api-backend binary. `Engine.sh` prepares that binary only after one of those images is known to need a Docker rebuild, then reuses it within the same deploy pass.
     - Mode inputs affect image hashes only for services with mode-specific build targets. Today that means `webui-frontend`; DB, guacd, WireGuard, Traefik, and API images do not rebuild merely because the operator switches `prod`/`dev`.
     - Docker Buildx cache is stored under `Engine/Deploy/cache/buildkit/<service>/` when usable; plain Docker build remains the fallback.
+    - After successful deploy or service rebuild reconciliation, `Engine.sh` prunes inactive Docker images, Docker builder cache, and Engine Buildx cache exports. Set `BOREALIS_SKIP_DOCKER_PRUNE=1` to skip cleanup.
+    - The current `site-worker` image is preserved even when no site-worker container is running. Stale site-worker tags are removed separately so scheduler-launched workers can still start after cleanup.
     - Deploy output uses compact colored service status lines in interactive terminals; set `NO_COLOR=1` to force plain text.
     - No-op redeploys reuse existing image tags and skip Compose when deploy manifest, runtime env, image hashes, and container state already match.
     - Image tag changes and WebUI mode changes are kept out of shared service state hashes; a WebUI-only image change or prod/dev mode flip should run scoped Compose reconciliation for `webui-frontend` only when the rest of the stack is healthy.

--- a/Engine.sh
+++ b/Engine.sh
@@ -1407,6 +1407,98 @@ build_images() {
   done
 }
 
+engine_docker_cleanup_enabled() {
+  case "${BOREALIS_SKIP_DOCKER_PRUNE:-0}" in
+    1|true|TRUE|yes|YES|on|ON)
+      return 1
+      ;;
+  esac
+  return 0
+}
+
+prune_stale_site_worker_images() {
+  local active_tag="${IMAGE_TAGS[site-worker]:-}"
+  [[ -n "${active_tag}" ]] || return 0
+  local stale_images=()
+  mapfile -t stale_images < <(
+    docker image ls \
+      --filter "label=io.borealis.service=site-worker" \
+      --format '{{.Repository}}:{{.Tag}}' \
+      | awk -v active="${active_tag}" 'NF && $0 != active && $0 != "<none>:<none>" {print}'
+  )
+  ((${#stale_images[@]} > 0)) || return 0
+  log_status "Docker cleanup" "Pruning stale site-worker images" "${C_YELLOW}"
+  local image=""
+  for image in "${stale_images[@]}"; do
+    if ! docker image rm "${image}" >> "${BUILD_LOG}" 2>&1; then
+      printf '[%s] Failed to remove stale site-worker image %s\n' "$(date +%FT%T)" "${image}" >> "${BUILD_LOG}"
+    fi
+  done
+}
+
+restore_required_engine_images() {
+  local mode="$1"
+  local missing_services=()
+  local service=""
+  for service in "${BUILD_ROLES[@]}"; do
+    local tag="${IMAGE_TAGS[${service}]:-}"
+    [[ -n "${tag}" ]] || continue
+    if ! docker image inspect "${tag}" >/dev/null 2>&1; then
+      missing_services+=("${service}")
+    fi
+  done
+  ((${#missing_services[@]} > 0)) || return 0
+
+  log_status "Docker cleanup" "Restoring required images" "${C_YELLOW}"
+  GO_API_BACKEND_BINARY_PREPARED=0
+  for service in "${missing_services[@]}"; do
+    build_service_image "${service}" "${mode}"
+  done
+}
+
+prune_engine_build_cache_exports() {
+  local cache_root="${DEPLOY_DIR}/cache/buildkit"
+  [[ -d "${cache_root}" ]] || return 0
+  log_status "Docker cleanup" "Clearing Engine build cache" "${C_YELLOW}"
+  if ! find "${cache_root}" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} + >> "${BUILD_LOG}" 2>&1; then
+    log_status "Docker cleanup" "Engine build cache cleanup failed" "${C_RED}"
+    printf '[%s] Failed to clear Engine Buildx cache export directory %s\n' "$(date +%FT%T)" "${cache_root}" >> "${BUILD_LOG}"
+  fi
+}
+
+prune_engine_docker_storage() {
+  local mode="$1"
+  if ! engine_docker_cleanup_enabled; then
+    log_status "Docker cleanup" "Skipped" "${C_DIM}"
+    printf '[%s] Docker cleanup skipped because BOREALIS_SKIP_DOCKER_PRUNE is set\n' "$(date +%FT%T)" >> "${BUILD_LOG}"
+    return 0
+  fi
+
+  local cleanup_failed=0
+  log_status "Docker cleanup" "Pruning inactive images" "${C_YELLOW}"
+  if ! docker image prune -a --force --filter "label!=io.borealis.service=site-worker" >> "${BUILD_LOG}" 2>&1; then
+    cleanup_failed=1
+    log_status "Docker cleanup" "Image prune failed" "${C_RED}"
+  fi
+
+  prune_stale_site_worker_images
+  restore_required_engine_images "${mode}"
+
+  log_status "Docker cleanup" "Pruning builder cache" "${C_YELLOW}"
+  if ! docker builder prune --all --force >> "${BUILD_LOG}" 2>&1; then
+    cleanup_failed=1
+    log_status "Docker cleanup" "Builder prune failed" "${C_RED}"
+  fi
+
+  prune_engine_build_cache_exports
+
+  if [[ "${cleanup_failed}" -eq 0 ]]; then
+    log_status "Docker cleanup" "Complete" "${C_GREEN}"
+  else
+    log_status "Docker cleanup" "Completed with warnings" "${C_YELLOW}"
+  fi
+}
+
 write_image_manifest() {
   local mode="$1"
   python3 - "${IMAGE_MANIFEST}" "${mode}" "${BUILD_ROLES[@]}" <<PY
@@ -1877,6 +1969,7 @@ deploy_engine() {
   if deploy_state_matches "${mode}" && all_engine_containers_running; then
     log_status "Compose" "Already Up-to-Date" "${C_GREEN}"
     write_deploy_manifest "${mode}" "skipped"
+    prune_engine_docker_storage "${mode}"
     log_webui_url
     return 0
   fi
@@ -1884,12 +1977,14 @@ deploy_engine() {
     log_status "Compose" "Reconciling ${target_services[*]}" "${C_YELLOW}"
     compose_base up -d --no-deps --no-build "${target_services[@]}"
     write_deploy_manifest "${mode}" "up-scoped" "${target_services[@]}"
+    prune_engine_docker_storage "${mode}"
     log_webui_url
     return 0
   fi
   log_status "Compose" "Reconciling Stack" "${C_YELLOW}"
   compose_base up -d --no-build
   write_deploy_manifest "${mode}" "up" "${changed_services[@]}"
+  prune_engine_docker_storage "${mode}"
   log_webui_url
 }
 
@@ -1921,6 +2016,7 @@ service_action() {
       log_status "${service}" "Recreating Container" "${C_YELLOW}"
       compose_base up -d --no-deps --no-build "$(service_compose_name "${service}")"
       write_deploy_manifest "${mode}" "up-scoped" "${service}"
+      prune_engine_docker_storage "${mode}"
       log_webui_url
       ;;
     reload)


### PR DESCRIPTION
## Issue
Resolves #271

## Summary
- adds post-reconciliation Docker storage cleanup to `Engine.sh deploy` and service rebuilds
- runs inactive image pruning, Docker builder cache pruning, and Engine Buildx cache export cleanup after successful reconciliation
- preserves/restores required Engine image tags so the current `site-worker` image remains available even when no site-worker container is running
- documents cleanup behavior and `BOREALIS_SKIP_DOCKER_PRUNE=1` for shared Docker hosts

## Validation
- `bash -n Engine.sh`
- `git diff --check`
- `docker compose --env-file Data/Engine/Containers/compose.env.example -f Data/Engine/Containers/compose.yaml config`
- static review confirmed cleanup runs only after successful deploy/rebuild reconciliation

## Deferred validation
- did not run live `Engine.sh deploy` because that would execute Docker image/cache prune on this host.