### PR TITLE
issue/device-list-health-status

### DIFF
--- a/Data/Engine/Containers/api-backend/cmd/api-backend/agent_sockets.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/agent_sockets.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type agentSocketConnectionStore interface {
+	listAgentSocketRoutes(ctx context.Context, profile operatorProfile) ([]agentWorkerRoute, error)
+}
+
+func agentSocketConnectionHandler(auth *authService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			writeMethodNotAllowed(w, http.MethodGet)
+			return
+		}
+		profile, err := auth.currentProfile(r.Context(), r)
+		if err != nil {
+			if isUnauthorizedAuthError(err) {
+				writeJSON(w, http.StatusUnauthorized, map[string]any{"error": "unauthorized"})
+				return
+			}
+			writeJSON(w, http.StatusBadGateway, map[string]any{"error": "auth_unavailable", "detail": err.Error()})
+			return
+		}
+		store, ok := auth.store.(agentSocketConnectionStore)
+		if !ok {
+			writeJSON(w, http.StatusBadGateway, map[string]any{"error": "agent_socket_connections_unavailable"})
+			return
+		}
+		timeout := auth.timeout
+		if timeout <= 0 {
+			timeout = defaultAuthTimeout
+		}
+		ctx, cancel := context.WithTimeout(r.Context(), timeout)
+		defer cancel()
+
+		routes, err := store.listAgentSocketRoutes(ctx, profile)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]any{"error": err.Error()})
+			return
+		}
+		agents := collectAgentSocketConnections(ctx, auth, routes)
+		writeJSON(w, http.StatusOK, map[string]any{"count": len(agents), "agents": agents})
+	}
+}
+
+func (s *postgresOperatorStore) listAgentSocketRoutes(ctx context.Context, profile operatorProfile) ([]agentWorkerRoute, error) {
+	allowedSiteIDs, err := s.siteIDsForProfile(ctx, profile)
+	if err != nil {
+		return nil, err
+	}
+	if allowedSiteIDs != nil && len(allowedSiteIDs) == 0 {
+		return []agentWorkerRoute{}, nil
+	}
+
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return nil, errors.Join(errOperatorStoreDown, err)
+	}
+	defer conn.Close()
+
+	sqlText := `
+		SELECT worker_guid, site_id, route_path_prefix, upstream_scheme, upstream_host, upstream_port, generation
+		  FROM engine.job_scheduler_worker_routes
+		 WHERE status=$1
+		   AND retired_at IS NULL
+	`
+	params := []any{schedulerRouteStatusActive}
+	if allowedSiteIDs != nil {
+		placeholders := make([]string, 0, len(allowedSiteIDs))
+		for _, siteID := range allowedSiteIDs {
+			params = append(params, siteID)
+			placeholders = append(placeholders, "$"+strconv.Itoa(len(params)))
+		}
+		sqlText += " AND site_id IN (" + strings.Join(placeholders, ",") + ")"
+	}
+	sqlText += " ORDER BY site_id, updated_at DESC, generation DESC"
+
+	rows, err := conn.QueryContext(ctx, sqlText, params...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	routes := []agentWorkerRoute{}
+	seenSites := map[int64]bool{}
+	for rows.Next() {
+		var route agentWorkerRoute
+		if err := rows.Scan(
+			&route.WorkerGUID,
+			&route.SiteID,
+			&route.RoutePathPrefix,
+			&route.UpstreamScheme,
+			&route.UpstreamHost,
+			&route.UpstreamPort,
+			&route.Generation,
+		); err != nil {
+			return nil, err
+		}
+		if route.SiteID <= 0 || seenSites[route.SiteID] {
+			continue
+		}
+		seenSites[route.SiteID] = true
+		routes = append(routes, route)
+	}
+	return routes, rows.Err()
+}
+
+func collectAgentSocketConnections(ctx context.Context, auth *authService, routes []agentWorkerRoute) []map[string]any {
+	client := &http.Client{Timeout: 2 * time.Second}
+	results := make(chan []map[string]any, len(routes))
+	for _, route := range routes {
+		route := route
+		go func() {
+			results <- fetchAgentSocketConnectionsForRoute(ctx, auth, client, route)
+		}()
+	}
+
+	connections := []map[string]any{}
+	seen := map[string]bool{}
+	for range routes {
+		for _, connection := range <-results {
+			hostMode := ""
+			if hostname := cleanText(connection["hostname"]); hostname != "" {
+				hostMode = hostname + "|" + cleanText(connection["service_mode"])
+			}
+			identity := firstText(
+				cleanText(connection["agent_id"]),
+				cleanText(connection["agent_guid"]),
+				hostMode,
+			)
+			if identity == "" {
+				continue
+			}
+			seenKey := strings.ToLower(strconv.FormatInt(coerceInt64(connection["site_id"]), 10) + "|" + identity)
+			if seen[seenKey] {
+				continue
+			}
+			seen[seenKey] = true
+			connections = append(connections, connection)
+		}
+	}
+	sort.Slice(connections, func(i, j int) bool {
+		return agentSocketConnectionSortKey(connections[i]) < agentSocketConnectionSortKey(connections[j])
+	})
+	return connections
+}
+
+func agentSocketConnectionSortKey(connection map[string]any) string {
+	return strconv.FormatInt(coerceInt64(connection["site_id"]), 10) +
+		"|" + strings.ToLower(cleanText(connection["hostname"])) +
+		"|" + strings.ToLower(cleanText(connection["agent_id"]))
+}
+
+func fetchAgentSocketConnectionsForRoute(ctx context.Context, auth *authService, client *http.Client, route agentWorkerRoute) []map[string]any {
+	connections := []map[string]any{}
+	if client == nil {
+		client = &http.Client{Timeout: 2 * time.Second}
+	}
+	target := workerInternalURL(&route, "/agents")
+	if target == "" {
+		return connections
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return connections
+	}
+	req.Header.Set("Accept", "application/json")
+	if auth != nil {
+		req.Header.Set(internalTokenHeader, goInternalToken(auth.verifier.secret))
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return connections
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return connections
+	}
+	var payload map[string]any
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&payload); err != nil {
+		return connections
+	}
+	agents, _ := payload["agents"].(map[string]any)
+	for key, raw := range agents {
+		record, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		agentID := firstText(cleanText(record["agent_id"]), cleanText(key))
+		hostname := cleanText(record["hostname"])
+		serviceMode := normalizeServiceMode(record["service_mode"], agentID)
+		guid := normalizeGUID(record["guid"])
+		if guid == "" {
+			guid = normalizeGUID(record["agent_guid"])
+		}
+		connections = append(connections, map[string]any{
+			"agent_id":        agentID,
+			"agent_guid":      guid,
+			"hostname":        hostname,
+			"service_mode":    serviceMode,
+			"helper_contexts": anySlice(record["helper_contexts"]),
+			"site_id":         route.SiteID,
+			"worker_guid":     route.WorkerGUID,
+			"connected":       true,
+		})
+	}
+	return connections
+}

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/agent_sockets.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/agent_sockets.go
@@ -92,7 +92,6 @@ func (s *postgresOperatorStore) listAgentSocketRoutes(ctx context.Context, profi
 	defer rows.Close()
 
 	routes := []agentWorkerRoute{}
-	seenSites := map[int64]bool{}
 	for rows.Next() {
 		var route agentWorkerRoute
 		if err := rows.Scan(
@@ -106,10 +105,9 @@ func (s *postgresOperatorStore) listAgentSocketRoutes(ctx context.Context, profi
 		); err != nil {
 			return nil, err
 		}
-		if route.SiteID <= 0 || seenSites[route.SiteID] {
+		if route.SiteID <= 0 {
 			continue
 		}
-		seenSites[route.SiteID] = true
 		routes = append(routes, route)
 	}
 	return routes, rows.Err()

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/devices.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/devices.go
@@ -81,6 +81,7 @@ type deviceRow struct {
 
 func registerDeviceRoutes(mux *http.ServeMux, auth *authService, runtime devicePurgeRuntime, broadcaster watchdogIncidentBroadcaster) {
 	mux.HandleFunc("GET /api/agents", agentListHandler(auth))
+	mux.HandleFunc("GET /api/agent-sockets", agentSocketConnectionHandler(auth))
 	mux.HandleFunc("GET /api/devices", deviceListHandler(auth))
 	mux.HandleFunc("GET /api/devices/{device_id}/watchdogs", deviceWatchdogsHandler(auth))
 	mux.HandleFunc("POST /api/devices/{device_id}/watchdogs/overrides", deviceWatchdogOverrideHandler(auth, broadcaster))

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/main_test.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/main_test.go
@@ -137,6 +137,9 @@ type fakeOperatorStore struct {
 	serverWorkerErr      error
 	workerHistory        int
 	workerContainers     bool
+	agentSocketRoutes    []agentWorkerRoute
+	agentSocketProfile   operatorProfile
+	agentSocketErr       error
 	githubToken          map[string]any
 	githubTokenRecord    githubTokenRecord
 	githubTokenErr       error
@@ -204,6 +207,16 @@ func (s *fakeOperatorStore) listDevices(_ context.Context, profile operatorProfi
 		devices = append(devices, copyDevice)
 	}
 	return devices, nil
+}
+
+func (s *fakeOperatorStore) listAgentSocketRoutes(_ context.Context, profile operatorProfile) ([]agentWorkerRoute, error) {
+	s.agentSocketProfile = profile
+	if s.agentSocketErr != nil {
+		return nil, s.agentSocketErr
+	}
+	routes := make([]agentWorkerRoute, len(s.agentSocketRoutes))
+	copy(routes, s.agentSocketRoutes)
+	return routes, nil
 }
 
 func (s *fakeOperatorStore) getDeviceByGUID(_ context.Context, profile operatorProfile, guid string) (map[string]any, int, error) {
@@ -1813,6 +1826,59 @@ func TestAgentListHandlerReturnsLegacyMapping(t *testing.T) {
 	}
 	if got := userAgent["service_mode"]; got != "currentuser" {
 		t.Fatalf("expected currentuser mode, got %#v", got)
+	}
+}
+
+func TestAgentSocketConnectionHandlerAggregatesSiteWorkerSnapshots(t *testing.T) {
+	worker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/agents" {
+			t.Fatalf("unexpected worker path %s", r.URL.Path)
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"agents": map[string]any{
+				"LAB-OPERATOR-01_2540DA38-E2B1-45B9-9113-BF7CF0E1778A_SYSTEM": map[string]any{
+					"agent_id":        "LAB-OPERATOR-01_2540DA38-E2B1-45B9-9113-BF7CF0E1778A_SYSTEM",
+					"guid":            "2540DA38-E2B1-45B9-9113-BF7CF0E1778A",
+					"hostname":        "lab-operator-01",
+					"service_mode":    "system",
+					"helper_contexts": []any{"currentuser"},
+				},
+			},
+		})
+	}))
+	defer worker.Close()
+
+	auth, store := testAuthServiceWithStore(operatorProfile{Username: "operator", Role: "Operator"})
+	route := routeForTestWorker(t, worker.URL)
+	store.agentSocketRoutes = []agentWorkerRoute{*route}
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/api/agent-sockets", nil)
+	request.Header.Set("Authorization", "Bearer "+testAuthToken)
+	agentSocketConnectionHandler(auth).ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if store.agentSocketProfile.Username != "operator" {
+		t.Fatalf("expected operator profile, got %+v", store.agentSocketProfile)
+	}
+	var payload struct {
+		Count  int              `json:"count"`
+		Agents []map[string]any `json:"agents"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload.Count != 1 || len(payload.Agents) != 1 {
+		t.Fatalf("unexpected socket payload %+v", payload)
+	}
+	agent := payload.Agents[0]
+	if agent["agent_guid"] != "2540DA38-E2B1-45B9-9113-BF7CF0E1778A" || agent["hostname"] != "lab-operator-01" {
+		t.Fatalf("unexpected agent socket row %+v", agent)
+	}
+	if agent["connected"] != true || agent["service_mode"] != "system" {
+		t.Fatalf("expected connected system socket, got %+v", agent)
 	}
 }
 

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/main_test.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/main_test.go
@@ -1847,10 +1847,28 @@ func TestAgentSocketConnectionHandlerAggregatesSiteWorkerSnapshots(t *testing.T)
 		})
 	}))
 	defer worker.Close()
+	workerTwo := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/agents" {
+			t.Fatalf("unexpected worker path %s", r.URL.Path)
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"agents": map[string]any{
+				"LAB-DOCKER-02_18CAE439-2849-472B-A799-6814C32A210B_SYSTEM": map[string]any{
+					"agent_id":     "LAB-DOCKER-02_18CAE439-2849-472B-A799-6814C32A210B_SYSTEM",
+					"guid":         "18CAE439-2849-472B-A799-6814C32A210B",
+					"hostname":     "lab-docker-02",
+					"service_mode": "system",
+				},
+			},
+		})
+	}))
+	defer workerTwo.Close()
 
 	auth, store := testAuthServiceWithStore(operatorProfile{Username: "operator", Role: "Operator"})
 	route := routeForTestWorker(t, worker.URL)
-	store.agentSocketRoutes = []agentWorkerRoute{*route}
+	routeTwo := routeForTestWorker(t, workerTwo.URL)
+	routeTwo.WorkerGUID = "worker-2"
+	store.agentSocketRoutes = []agentWorkerRoute{*route, *routeTwo}
 
 	recorder := httptest.NewRecorder()
 	request := httptest.NewRequest(http.MethodGet, "/api/agent-sockets", nil)
@@ -1870,12 +1888,20 @@ func TestAgentSocketConnectionHandlerAggregatesSiteWorkerSnapshots(t *testing.T)
 	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
 		t.Fatal(err)
 	}
-	if payload.Count != 1 || len(payload.Agents) != 1 {
+	if payload.Count != 2 || len(payload.Agents) != 2 {
 		t.Fatalf("unexpected socket payload %+v", payload)
 	}
-	agent := payload.Agents[0]
-	if agent["agent_guid"] != "2540DA38-E2B1-45B9-9113-BF7CF0E1778A" || agent["hostname"] != "lab-operator-01" {
-		t.Fatalf("unexpected agent socket row %+v", agent)
+	byHost := map[string]map[string]any{}
+	for _, agent := range payload.Agents {
+		byHost[cleanText(agent["hostname"])] = agent
+	}
+	agent := byHost["lab-operator-01"]
+	if agent == nil || agent["agent_guid"] != "2540DA38-E2B1-45B9-9113-BF7CF0E1778A" {
+		t.Fatalf("unexpected agent socket rows %+v", payload.Agents)
+	}
+	secondAgent := byHost["lab-docker-02"]
+	if secondAgent == nil || secondAgent["agent_guid"] != "18CAE439-2849-472B-A799-6814C32A210B" {
+		t.Fatalf("expected second same-site worker socket row, got %+v", payload.Agents)
 	}
 	if agent["connected"] != true || agent["service_mode"] != "system" {
 		t.Fatalf("expected connected system socket, got %+v", agent)

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Device_List.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Device_List.jsx
@@ -351,6 +351,7 @@ const ROLE_HEALTHY_STATUS_CODES = Object.freeze(
     "complete",
     "completed",
     "not_applicable",
+    "no_desktop_environment_active",
     "unsupported",
   ])
 );

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Device_List.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Device_List.jsx
@@ -334,6 +334,118 @@ function statusFromHeartbeat(tsSec, offlineAfter = 300) {
   return now - tsSec <= offlineAfter ? "Online" : "Offline";
 }
 
+const DEVICE_HEALTH_STATUSES = Object.freeze({
+  healthy: "Healthy",
+  unhealthy: "Unhealthy",
+  offline: "Offline",
+});
+
+const ROLE_HEALTHY_STATUS_CODES = Object.freeze(
+  new Set([
+    "healthy",
+    "loaded",
+    "ok",
+    "online",
+    "running",
+    "ready",
+    "complete",
+    "completed",
+    "not_applicable",
+    "unsupported",
+  ])
+);
+
+function normalizeDeviceHealthLabel(value) {
+  const normalized = String(value || "").trim().toLowerCase().replace(/[_\s-]+/g, "_");
+  if (!normalized) return "";
+  if (normalized === "healthy" || normalized === "online") return DEVICE_HEALTH_STATUSES.healthy;
+  if (normalized === "unhealthy" || normalized === "degraded" || normalized === "recovering") {
+    return DEVICE_HEALTH_STATUSES.unhealthy;
+  }
+  if (normalized === "offline" || normalized === "down") return DEVICE_HEALTH_STATUSES.offline;
+  return "";
+}
+
+function normalizeAgentSocketMode(value) {
+  const normalized = String(value || "").trim().toLowerCase().replace(/[_\s-]+/g, "");
+  if (["system", "service", "svc", "systemservice"].includes(normalized)) return "system";
+  if (["currentuser", "interactive", "user"].includes(normalized)) return "currentuser";
+  return "";
+}
+
+function createAgentSocketLookup(records, available = true) {
+  const lookup = {
+    available,
+    agentIds: new Set(),
+    guids: new Set(),
+    hostnames: new Set(),
+    hostModes: new Set(),
+  };
+  (Array.isArray(records) ? records : []).forEach((record) => {
+    if (!record || typeof record !== "object") return;
+    const agentId = String(record.agent_id || "").trim().toLowerCase();
+    const guid = String(record.agent_guid || record.guid || "").trim().toLowerCase();
+    const hostname = String(record.hostname || "").trim().toLowerCase();
+    const serviceMode = normalizeAgentSocketMode(record.service_mode) || "system";
+    if (agentId) lookup.agentIds.add(agentId);
+    if (guid) lookup.guids.add(guid);
+    if (hostname) {
+      lookup.hostnames.add(hostname);
+      lookup.hostModes.add(`${hostname}|${serviceMode}`);
+      const helperContexts = Array.isArray(record.helper_contexts) ? record.helper_contexts : [];
+      helperContexts.forEach((context) => {
+        const helperMode = normalizeAgentSocketMode(context);
+        if (helperMode) lookup.hostModes.add(`${hostname}|${helperMode}`);
+      });
+    }
+  });
+  return lookup;
+}
+
+function resolveAgentSocketConnected(lookup, { agentId = "", guid = "", hostname = "", serviceMode = "system" } = {}) {
+  if (!lookup || lookup.available === false) return null;
+  const agentKey = String(agentId || "").trim().toLowerCase();
+  const guidKey = String(guid || "").trim().toLowerCase();
+  const hostKey = String(hostname || "").trim().toLowerCase();
+  const modeKey = normalizeAgentSocketMode(serviceMode) || "system";
+  if (agentKey && lookup.agentIds?.has(agentKey)) return true;
+  if (guidKey && lookup.guids?.has(guidKey)) return true;
+  if (hostKey && lookup.hostModes?.has(`${hostKey}|${modeKey}`)) return true;
+  if (hostKey && lookup.hostnames?.has(hostKey)) return true;
+  return false;
+}
+
+function agentRoleHealthNeedsAttention(agentRoleHealth) {
+  const roles = Array.isArray(agentRoleHealth?.roles) ? agentRoleHealth.roles : [];
+  if (!roles.length) return true;
+  return roles.some((role) => {
+    const status = String(role?.status_code || role?.status || "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+    if (!status) return true;
+    return !ROLE_HEALTHY_STATUS_CODES.has(status);
+  });
+}
+
+function resolveDeviceHealthStatus({ device, summary, lastSeen, connectionType, agentSocketConnected }) {
+  const explicit = normalizeDeviceHealthLabel(
+    device?.device_health_status ||
+      device?.agent_health_status ||
+      summary?.device_health_status ||
+      summary?.agent_health_status
+  );
+  if (explicit) return explicit;
+  const heartbeatStatus = statusFromHeartbeat(lastSeen);
+  if (heartbeatStatus === "Offline") return DEVICE_HEALTH_STATUSES.offline;
+  if (connectionType) return DEVICE_HEALTH_STATUSES.healthy;
+  if (agentSocketConnected === false) return DEVICE_HEALTH_STATUSES.unhealthy;
+  const roleHealth =
+    device?.agent_role_health ||
+    summary?.agent_role_health ||
+    device?.details?.summary?.agent_role_health ||
+    null;
+  if (agentRoleHealthNeedsAttention(roleHealth)) return DEVICE_HEALTH_STATUSES.unhealthy;
+  return DEVICE_HEALTH_STATUSES.healthy;
+}
+
 function extractGuidFromAgentId(value) {
   const text = typeof value === "string" ? value.trim() : value == null ? "" : String(value).trim();
   if (!text) return "";
@@ -371,6 +483,7 @@ function normalizeDeviceCollection(
   {
     tunnelLookup = new Map(),
     tunnelStatusLookup = new Map(),
+    agentSocketLookup = createAgentSocketLookup([], false),
   } = {}
 ) {
   const safeList = Array.isArray(list) ? list : [];
@@ -392,7 +505,6 @@ function normalizeDeviceCollection(
     const guidRaw = (device.agent_guid || summary.agent_guid || "").trim();
     const rowKey = guidRaw || agentId || hostname || `device-${index + 1}`;
     const lastSeen = Number(device.last_seen || summary.last_seen || 0) || 0;
-    const status = device.status || statusFromHeartbeat(lastSeen);
 
     if (guidRaw && !summary.agent_guid) {
       summary.agent_guid = guidRaw;
@@ -456,6 +568,20 @@ function normalizeDeviceCollection(
     const connectionLabel =
       connectionType === "ssh" ? "SSH" : connectionType === "winrm" ? "WinRM" : "";
     const connectionEndpoint = (device.connection_endpoint || summary.connection_endpoint || "").trim();
+    const agentSocketConnected = resolveAgentSocketConnected(agentSocketLookup, {
+      agentId,
+      guid: guidRaw,
+      hostname,
+      serviceMode: "system",
+    });
+    const status = device.status || summary.status || statusFromHeartbeat(lastSeen);
+    const healthStatus = resolveDeviceHealthStatus({
+      device,
+      summary,
+      lastSeen,
+      connectionType,
+      agentSocketConnected,
+    });
 
     const memoryList = Array.isArray(device.memory) ? device.memory : [];
     const networkList = Array.isArray(device.network) ? device.network : [];
@@ -477,6 +603,7 @@ function normalizeDeviceCollection(
       id: rowKey,
       hostname,
       status,
+      healthStatus,
       lastSeen,
       lastSeenDisplay: formatLastSeen(lastSeen),
       os: osName,
@@ -491,6 +618,13 @@ function normalizeDeviceCollection(
       createdIso: device.created_at_iso || "",
       agentGuid: guidRaw,
       agentId,
+      agentSocketConnected,
+      agentSocketStatus:
+        agentSocketConnected === null
+          ? "Unknown"
+          : agentSocketConnected
+            ? "Connected"
+            : "Disconnected",
       domain,
       internalIp,
       externalIp,
@@ -537,14 +671,17 @@ export async function loadDeviceListPageData(request) {
   const progress = createRouteRequestPlan(request, 5);
   try {
     await requireAuthenticatedRequest(request, progress);
-    const [devicesPayload, viewsPayload, sitesPayload] = await Promise.all([
+    const [devicesPayload, socketPayload, viewsPayload, sitesPayload] = await Promise.all([
       progress.fetchJson("/api/devices"),
+      progress.fetchJson("/api/agent-sockets").catch(() => ({ agents: [], unavailable: true })),
       progress.fetchJson("/api/device_list_views").catch(() => ({ views: [] })),
       progress.fetchJson("/api/sites").catch(() => ({ sites: [] })),
     ]);
 
     return {
-      rows: normalizeDeviceCollection(devicesPayload?.devices || []),
+      rows: normalizeDeviceCollection(devicesPayload?.devices || [], {
+        agentSocketLookup: createAgentSocketLookup(socketPayload?.agents || [], !socketPayload?.unavailable),
+      }),
       views: Array.isArray(viewsPayload?.views) ? viewsPayload.views : [],
       sites: Array.isArray(sitesPayload?.sites) ? sitesPayload.sites : [],
       initialError: "",
@@ -835,7 +972,8 @@ export default function DeviceList({
   const heroStats = useMemo(() => {
     const now = Date.now() / 1000;
     const siteSet = new Set();
-    let online = 0;
+    let healthy = 0;
+    let unhealthy = 0;
     let offline = 0;
     let stale = 0;
     rows.forEach((row) => {
@@ -852,15 +990,18 @@ export default function DeviceList({
         siteSet.add(siteName);
       }
       const statusRaw =
-        row.status ||
-        row.summary?.status ||
+        row.healthStatus ||
+        row.summary?.health_status ||
         statusFromHeartbeat(lastSeen);
-      if ((statusRaw || "").toLowerCase() === "online") online += 1;
+      const normalizedStatus = normalizeDeviceHealthLabel(statusRaw);
+      if (normalizedStatus === DEVICE_HEALTH_STATUSES.healthy) healthy += 1;
+      else if (normalizedStatus === DEVICE_HEALTH_STATUSES.unhealthy) unhealthy += 1;
       else offline += 1;
     });
     return {
       total: rows.length,
-      online,
+      healthy,
+      unhealthy,
       offline,
       sites: siteSet.size,
       stale,
@@ -916,6 +1057,21 @@ export default function DeviceList({
     return { fetched, peerByAgent, statusByAgent };
   }, []);
 
+  const fetchAgentSocketLookup = useCallback(async () => {
+    try {
+      const resp = await fetch('/api/agent-sockets', {
+        cache: "no-store",
+        credentials: "include",
+      });
+      if (!resp.ok) return createAgentSocketLookup([], false);
+      const payload = await resp.json();
+      return createAgentSocketLookup(payload?.agents || [], true);
+    } catch (err) {
+      console.warn('Failed to fetch agent socket list', err);
+      return createAgentSocketLookup([], false);
+    }
+  }, []);
+
   const applyTunnelTelemetry = useCallback((telemetry) => {
     const fetched = Boolean(telemetry?.fetched);
     const peerByAgent = telemetry?.peerByAgent instanceof Map ? telemetry.peerByAgent : new Map();
@@ -948,7 +1104,10 @@ export default function DeviceList({
     if (showLoading) setLoading(true);
 
     try {
-      const tunnelTelemetry = await fetchTunnelTelemetry();
+      const [tunnelTelemetry, agentSocketLookup] = await Promise.all([
+        fetchTunnelTelemetry(),
+        fetchAgentSocketLookup(),
+      ]);
       const tunnelLookup = tunnelTelemetry.fetched
         ? tunnelTelemetry.peerByAgent
         : tunnelPeerCacheRef.current || new Map();
@@ -967,6 +1126,7 @@ export default function DeviceList({
       const normalized = normalizeDeviceCollection(payload?.devices || [], {
         tunnelLookup,
         tunnelStatusLookup,
+        agentSocketLookup,
       });
       setRows(filterDeviceRowsByMode(normalized, filterMode));
       setRouteLoadError("");
@@ -978,7 +1138,7 @@ export default function DeviceList({
     } finally {
       if (showLoading) setLoading(false);
     }
-  }, [filterMode, fetchTunnelTelemetry, applyTunnelTelemetry]);
+  }, [filterMode, fetchTunnelTelemetry, fetchAgentSocketLookup, applyTunnelTelemetry]);
 
   const hasWireguardColumn = useMemo(
     () => columns.some((col) => col.id === "wireguardPeerIp"),
@@ -1195,6 +1355,18 @@ export default function DeviceList({
 
   const statusTokenTheme = useMemo(
     () => ({
+      Healthy: {
+        text: "#00d18c",
+        background: "rgba(0, 209, 140, 0.16)",
+        border: "1px solid rgba(0, 209, 140, 0.45)",
+        dot: "#00d18c",
+      },
+      Unhealthy: {
+        text: "#ffb347",
+        background: "rgba(255, 179, 71, 0.16)",
+        border: "1px solid rgba(255, 179, 71, 0.45)",
+        dot: "#ffb347",
+      },
       Online: {
         text: "#00d18c",
         background: "rgba(0, 209, 140, 0.16)",
@@ -1707,12 +1879,13 @@ export default function DeviceList({
       switch (col.id) {
         case "status":
           return {
-            field: "status",
+            colId: "status",
+            field: "healthStatus",
             headerName: col.label,
             cellRenderer: statusCellRenderer,
             cellClass: "status-pill-cell",
-            width: 112,
-            minWidth: 112,
+            width: 128,
+            minWidth: 128,
             flex: 0,
           };
         case "site":

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Device_List.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Device_List.jsx
@@ -416,11 +416,35 @@ function resolveAgentSocketConnected(lookup, { agentId = "", guid = "", hostname
   return false;
 }
 
+function compactRoleHealthKey(value) {
+  return String(value || "").trim().toLowerCase().replace(/[^a-z0-9]+/g, "");
+}
+
+function roleHealthStatusCode(role) {
+  return String(role?.status_code || role?.status || "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+}
+
+function isEngineSocketRole(role) {
+  const keys = [
+    role?.role_id,
+    role?.role_name,
+    role?.role_label,
+    role?.label,
+    role?.name,
+  ].map(compactRoleHealthKey);
+  return keys.some((key) => key === "systemenginesocket" || key === "enginesocket");
+}
+
+function agentRoleHealthReportsSocketConnected(agentRoleHealth) {
+  const roles = Array.isArray(agentRoleHealth?.roles) ? agentRoleHealth.roles : [];
+  return roles.some((role) => isEngineSocketRole(role) && roleHealthStatusCode(role) === "healthy");
+}
+
 function agentRoleHealthNeedsAttention(agentRoleHealth) {
   const roles = Array.isArray(agentRoleHealth?.roles) ? agentRoleHealth.roles : [];
   if (!roles.length) return true;
   return roles.some((role) => {
-    const status = String(role?.status_code || role?.status || "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+    const status = roleHealthStatusCode(role);
     if (!status) return true;
     return !ROLE_HEALTHY_STATUS_CODES.has(status);
   });
@@ -437,12 +461,14 @@ function resolveDeviceHealthStatus({ device, summary, lastSeen, connectionType, 
   const heartbeatStatus = statusFromHeartbeat(lastSeen);
   if (heartbeatStatus === "Offline") return DEVICE_HEALTH_STATUSES.offline;
   if (connectionType) return DEVICE_HEALTH_STATUSES.healthy;
-  if (agentSocketConnected === false) return DEVICE_HEALTH_STATUSES.unhealthy;
   const roleHealth =
     device?.agent_role_health ||
     summary?.agent_role_health ||
     device?.details?.summary?.agent_role_health ||
     null;
+  if (agentSocketConnected === false && !agentRoleHealthReportsSocketConnected(roleHealth)) {
+    return DEVICE_HEALTH_STATUSES.unhealthy;
+  }
   if (agentRoleHealthNeedsAttention(roleHealth)) return DEVICE_HEALTH_STATUSES.unhealthy;
   return DEVICE_HEALTH_STATUSES.healthy;
 }

--- a/Docs/Reference/Data and Schema/api-reference.md
+++ b/Docs/Reference/Data and Schema/api-reference.md
@@ -67,6 +67,7 @@ Provide a consolidated, human-readable list of Borealis Engine API endpoints gro
     - `POST /api/agent/vpn/ready` (Device Authenticated) - report active WireGuard tunnel, local service, and firewall readiness for scheduled SSH/WinRM dispatch.
     - `GET /api/agent/metadata/<field_number>` (Device Authenticated) - read one decoded metadata field for local Agent CLI.
     - `GET /api/agents` (Token Authenticated) - list online collectors, with upgraded hosts advertising helper-backed current-user capability on their SYSTEM record via `helper_contexts`.
+    - `GET /api/agent-sockets` (Token Authenticated) - list active Agent management sockets from visible site-workers for Device List health status.
     - `GET /api/devices` (Token Authenticated) - device summary list, scoped to the operator's assigned sites unless the operator is an admin.
     - `GET /api/devices/search?hostname=<query>` (Token Authenticated) - hostname search matches for the shared header search, scoped to the operator's assigned sites unless the operator is an admin.
     - `GET /api/devices/<guid>` (Token Authenticated) - device summary by GUID, site-scoped for operators.

--- a/Docs/Using the Platform/device-auditing.md
+++ b/Docs/Using the Platform/device-auditing.md
@@ -81,6 +81,7 @@ Device Summary collects the last-known inventory and action tabs for one endpoin
     - Device List status is derived from `devices.last_seen`, normalized `agent_role_health`, and `/api/agent-sockets` site-worker socket state.
     - `GET /api/devices` still keeps `status` as heartbeat-derived `Online` or `Offline` for API compatibility; Device List maps that data into `Healthy`, `Unhealthy`, or `Offline`.
     - `/api/agent-sockets` queries each active site-worker route for visible sites and reads every worker `/agents` registry snapshot.
+    - The `system:engine_socket` role-health row can confirm site-worker socket connectivity when it reports `healthy`, even if `/api/agent-sockets` misses the device during a refresh race.
     - Heavy inventory lands through `/api/agent/details`; heartbeat carries lightweight metrics and metadata deltas.
     - Session inventory includes helper readiness fields so current-user execution can distinguish a logged-in user from a helper-ready session.
     - Software data is stored both in `devices.software` for UI detail and `device_software_inventory` for reliable filter matching.

--- a/Docs/Using the Platform/device-auditing.md
+++ b/Docs/Using the Platform/device-auditing.md
@@ -80,7 +80,7 @@ Device Summary collects the last-known inventory and action tabs for one endpoin
 
     - Device List status is derived from `devices.last_seen`, normalized `agent_role_health`, and `/api/agent-sockets` site-worker socket state.
     - `GET /api/devices` still keeps `status` as heartbeat-derived `Online` or `Offline` for API compatibility; Device List maps that data into `Healthy`, `Unhealthy`, or `Offline`.
-    - `/api/agent-sockets` queries the active site-worker route for each visible site and reads the worker `/agents` registry snapshot once per site.
+    - `/api/agent-sockets` queries each active site-worker route for visible sites and reads every worker `/agents` registry snapshot.
     - Heavy inventory lands through `/api/agent/details`; heartbeat carries lightweight metrics and metadata deltas.
     - Session inventory includes helper readiness fields so current-user execution can distinguish a logged-in user from a helper-ready session.
     - Software data is stored both in `devices.software` for UI detail and `device_software_inventory` for reliable filter matching.

--- a/Docs/Using the Platform/device-auditing.md
+++ b/Docs/Using the Platform/device-auditing.md
@@ -1,6 +1,6 @@
 # Device Auditing
 
-Device Auditing is the normal starting point for understanding a managed endpoint. Use it to read current inventory, online state, role health, software, services, sessions, activity history, and device-specific operational tabs.
+Device Auditing is the normal starting point for understanding a managed endpoint. Use it to read current inventory, health status, role health, software, services, sessions, activity history, and device-specific operational tabs.
 
 <figure class="bo-screenshot">
   <img src="../Reference/images/repo_screenshots/Device_List.png" alt="Borealis Device Inventory page" loading="lazy">
@@ -23,14 +23,15 @@ Device Summary collects the last-known inventory and action tabs for one endpoin
 - `Services`, `Processes`, `File Management`, `Remote Shell`, and `Remote Desktop` are live operations tabs.
 - `Activity History` shows quick job and automation output tied to the device.
 - `Watchdogs` shows active incidents, effective watchdog assignments, and device-level suppressions.
-- `Agent Health` shows startup flow and role health separately from online/offline status.
+- `Agent Health` shows startup flow and role health behind the Device List status.
 
 ## Understand Status
 
-- `Online` means the Engine saw a recent heartbeat.
+- `Healthy` means the Agent has a recent heartbeat, is connected to its site-worker management socket, and all applicable roles report healthy or not-applicable state.
+- `Unhealthy` means the Agent has a recent heartbeat, but the management socket is disconnected, role health is stale or degraded, or no role-health report is available yet.
 - `Offline` means heartbeat age exceeded the online window.
-- Agent Health explains startup and role state; it does not replace online/offline status.
-- Stale inventory means the device may be online but a specific role has not published fresh data yet.
+- Agent Health explains the role or startup signal behind an unhealthy status.
+- Stale inventory means the device may have a recent heartbeat but a specific role has not published fresh data yet.
 
 !!! tip
 
@@ -48,6 +49,7 @@ Device Summary collects the last-known inventory and action tabs for one endpoin
     ### API endpoints
 
     - `GET /api/devices` - device list scoped to operator site access.
+    - `GET /api/agent-sockets` - active site-worker Agent socket snapshot scoped to operator site access.
     - `GET /api/devices/search?hostname=<query>` - shared hostname search.
     - `GET /api/devices/<guid>` - device summary by GUID.
     - `GET /api/device/details/<hostname>` - detailed device payload.
@@ -66,14 +68,19 @@ Device Summary collects the last-known inventory and action tabs for one endpoin
 
     ### Source map
 
-    - Device APIs: `Data/Engine/Containers/api-backend/data/services/API/devices/`
+    - Device APIs: `Data/Engine/Containers/api-backend/cmd/api-backend/devices.go`
+    - Agent socket API: `Data/Engine/Containers/api-backend/cmd/api-backend/agent_sockets.go`
+    - Device List UI: `Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Device_List.jsx`
     - Device Summary UI: `Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Device_Summary.jsx`
     - Agent Health UI: `Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Agent_Health.jsx`
     - Agent audit role: `Data/Agent/internal/roles/device_audit/`
+    - Site-worker socket registry: `Data/Engine/Containers/api-backend/data/services/remote_ops/agent_socket_registry.py`
 
     ### Runtime behavior
 
-    - Online/offline status is derived from `devices.last_seen`.
+    - Device List status is derived from `devices.last_seen`, normalized `agent_role_health`, and `/api/agent-sockets` site-worker socket state.
+    - `GET /api/devices` still keeps `status` as heartbeat-derived `Online` or `Offline` for API compatibility; Device List maps that data into `Healthy`, `Unhealthy`, or `Offline`.
+    - `/api/agent-sockets` queries the active site-worker route for each visible site and reads the worker `/agents` registry snapshot once per site.
     - Heavy inventory lands through `/api/agent/details`; heartbeat carries lightweight metrics and metadata deltas.
     - Session inventory includes helper readiness fields so current-user execution can distinguish a logged-in user from a helper-ready session.
     - Software data is stored both in `devices.software` for UI detail and `device_software_inventory` for reliable filter matching.


### PR DESCRIPTION
## Issue
Resolves #256

## Summary
- Adds `GET /api/agent-sockets` to aggregate active Agent management sockets from visible site-workers.
- Updates Device List status column to display `Healthy`, `Unhealthy`, or `Offline` from heartbeat freshness, site-worker socket connectivity, and role health.
- Preserves `/api/devices.status` as heartbeat `Online`/`Offline` for existing API consumers and Device Summary navigation.
- Fixes same-site multi-worker aggregation so every active site-worker route contributes connected agents.
- Treats no-desktop/current-user-not-applicable role state as healthy/not-applicable for list-level health.
- Trusts the `system:engine_socket` role when it reports healthy, so socket snapshot races do not mark otherwise healthy devices unhealthy.
- Documents Device List health semantics and the new socket endpoint.

## Health semantics
Agent build mismatch does not make Device List status `Unhealthy`. Device Summary reports `Installed agent build does not match desired state` as an update warning. Device List health only uses heartbeat freshness, management socket connectivity, and role-health status.

## Root cause for unhealthy false positives
The first implementation queried only one active site-worker route per site. Production can run multiple site-worker tasks for the same site, so devices connected to other workers appeared disconnected and became `Unhealthy` even though Device Summary showed healthy management and role state. A second false-positive path existed when `/api/agent-sockets` missed a device during refresh even though its `system:engine_socket` role was healthy; Device List now accepts that role-health proof.

## Validation
- `git diff --check` passed.
- `go test ./cmd/api-backend -run 'TestAgentSocketConnectionHandlerAggregatesSiteWorkerSnapshots|TestAgentListHandlerReturnsLegacyMapping'` could not run: `go` not installed in this environment.
- `bash Engine_Unit_Tests.sh --domain webui` could not run: runtime WebUI Unit_Tests cache missing at `Engine/Services/webui-frontend/cache/web-interface/Unit_Tests`.