### PR TITLE
issue/webui-breadcrumb-navigation

### DIFF
--- a/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/app/hooks/useRoutePageChrome.test.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/app/hooks/useRoutePageChrome.test.jsx
@@ -38,7 +38,12 @@ describe("useRoutePageChrome", () => {
         }}
       >
         <Harness
-          meta={{ title: "Devices", subtitle: "Inventory" }}
+          meta={{
+            title: "Devices",
+            subtitle: "Inventory",
+            breadcrumbs: [{ id: "inventory", label: "Inventory" }],
+            breadcrumbMenuItems: [{ id: "devices", label: "Devices", to: "/devices" }],
+          }}
           onValue={() => {}}
         />
       </PageChromeContext.Provider>
@@ -52,8 +57,12 @@ describe("useRoutePageChrome", () => {
         subtitle: "Inventory",
         Icon: null,
         breadcrumbLabel: "",
+        breadcrumbs: [{ id: "inventory", label: "Inventory" }],
+        breadcrumbsReplace: false,
+        breadcrumbMenuItems: [{ id: "devices", label: "Devices", to: "/devices" }],
         actions: [],
         controls: [],
+        navigationSidebar: null,
       },
       EMPTY_PAGE_CHROME,
     ]);

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/app/routes/breadcrumbs.test.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/app/routes/breadcrumbs.test.jsx
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
   APP_DOCUMENT_TITLE,
+  buildBreadcrumbDisplayItems,
   buildBreadcrumbItems,
   formatDocumentTitle,
   resolveActiveNavKey,
   resolveCurrentPageKey,
   resolvePageChromeDefaults,
+  resolveRememberedBreadcrumbTargetKey,
 } from "@/app/routes/breadcrumbs.js";
 
 describe("breadcrumb and nav helpers", () => {
@@ -45,9 +47,142 @@ describe("breadcrumb and nav helpers", () => {
         breadcrumbLabel: "Workflow: Device Sync",
       })
     ).toEqual([
-      { id: "assemblies", label: "Assemblies", to: "/assemblies" },
-      { id: "workflow", label: "Workflow: Device Sync", to: null },
+      { id: "assemblies", label: "Assemblies", to: "/assemblies", menuItems: [] },
+      { id: "workflow", label: "Workflow: Device Sync", to: null, menuItems: [] },
     ]);
+  });
+
+  it("uses remembered collection URLs for parent breadcrumbs", () => {
+    const deviceMatches = [
+      {
+        id: "devices",
+        pathname: "/devices",
+        handle: {
+          title: "Devices",
+          breadcrumb: "Devices",
+          navKey: "devices",
+          pageKey: "devices",
+        },
+      },
+      {
+        id: "device",
+        pathname: "/devices/agent-1",
+        handle: {
+          title: "Device Details",
+          breadcrumb: "Device",
+          navKey: "devices",
+          pageKey: "device",
+        },
+      },
+    ];
+
+    expect(
+      buildBreadcrumbItems(
+        deviceMatches,
+        { title: "lab-docker-02", breadcrumbLabel: "lab-docker-02" },
+        { rememberedTargets: { devices: "/devices?site=3&view=servers" } }
+      )
+    ).toEqual([
+      { id: "devices", label: "Devices", to: "/devices?site=3&view=servers", menuItems: [] },
+      { id: "device", label: "lab-docker-02", to: null, menuItems: [] },
+    ]);
+  });
+
+  it("appends page-supplied breadcrumbs and makes the route leaf navigable", () => {
+    const deviceMatches = [
+      {
+        id: "devices",
+        pathname: "/devices",
+        handle: { breadcrumb: "Devices", navKey: "devices", pageKey: "devices" },
+      },
+      {
+        id: "device",
+        pathname: "/devices/agent-1",
+        handle: { breadcrumb: "Device", navKey: "devices", pageKey: "device" },
+      },
+    ];
+
+    expect(
+      buildBreadcrumbItems(deviceMatches, {
+        title: "lab-docker-02",
+        breadcrumbLabel: "lab-docker-02",
+        breadcrumbs: [
+          {
+            id: "workspace",
+            label: "Backend Tools",
+            to: "/devices/agent-1?tab=remote_ops&view=shell",
+          },
+          {
+            id: "view",
+            label: "Files",
+            menuItems: [{ id: "shell", label: "Shell", to: "/devices/agent-1?tab=remote_ops&view=shell" }],
+          },
+        ],
+      })
+    ).toEqual([
+      { id: "devices", label: "Devices", to: "/devices", menuItems: [] },
+      { id: "device", label: "lab-docker-02", to: "/devices/agent-1", menuItems: [] },
+      {
+        id: "workspace",
+        label: "Backend Tools",
+        to: "/devices/agent-1?tab=remote_ops&view=shell",
+        menuItems: [],
+      },
+      {
+        id: "view",
+        label: "Files",
+        to: null,
+        menuItems: [
+          { id: "shell", label: "Shell", to: "/devices/agent-1?tab=remote_ops&view=shell", onClick: null, disabled: false },
+        ],
+      },
+    ]);
+  });
+
+  it("collapses middle breadcrumbs behind an overflow menu", () => {
+    expect(
+      buildBreadcrumbDisplayItems(
+        [
+          { id: "one", label: "One", to: "/one" },
+          { id: "two", label: "Two", to: "/two" },
+          { id: "three", label: "Three", to: "/three" },
+          { id: "four", label: "Four", to: "/four" },
+          { id: "five", label: "Five" },
+        ],
+        { maxItems: 3 }
+      )
+    ).toEqual([
+      { id: "one", label: "One", to: "/one", menuItems: [] },
+      {
+        id: "breadcrumb-overflow",
+        label: "More",
+        to: null,
+        menuItems: [
+          { id: "two", label: "Two", to: "/two", disabled: false },
+          { id: "three", label: "Three", to: "/three", disabled: false },
+          { id: "four", label: "Four", to: "/four", disabled: false },
+        ],
+        overflow: true,
+      },
+      { id: "five", label: "Five", to: null, menuItems: [] },
+    ]);
+  });
+
+  it("identifies collection routes that should be remembered", () => {
+    expect(resolveRememberedBreadcrumbTargetKey(matches)).toBe("");
+    expect(
+      resolveRememberedBreadcrumbTargetKey([
+        {
+          id: "devices",
+          pathname: "/devices",
+          handle: {
+            breadcrumb: "Devices",
+            navKey: "devices",
+            pageKey: "devices",
+          },
+        },
+      ])
+    ).toBe("devices");
   });
 
   it("uses route-handle defaults when the page has not published chrome yet", () => {

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/app/shell/AppShell.navigation.test.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/app/shell/AppShell.navigation.test.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import { RouterProvider, createMemoryRouter } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 import { AuthContext } from "@/app/providers/AuthContext.jsx";
@@ -57,6 +57,49 @@ function buildAuthValue() {
 }
 
 describe("AppShell buffered navigation", () => {
+  it("renders breadcrumbs in the page header instead of the top app bar", () => {
+    const router = createMemoryRouter(
+      [
+        {
+          path: "/",
+          element: (
+            <AuthContext.Provider value={buildAuthValue()}>
+              <PageChromeProvider>
+                <AppShell />
+              </PageChromeProvider>
+            </AuthContext.Provider>
+          ),
+          children: [
+            {
+              index: true,
+              element: <div>Home Page</div>,
+              handle: {
+                title: "Home",
+                breadcrumb: "Home",
+                navKey: "home",
+                pageKey: "home",
+              },
+            },
+          ],
+        },
+      ],
+      {
+        initialEntries: ["/"],
+      }
+    );
+
+    render(<RouterProvider router={router} />);
+
+    const topBar = screen.getByTestId("app-top-bar");
+    expect(within(topBar).queryByRole("navigation", { name: "Page breadcrumb" })).not.toBeInTheDocument();
+
+    const pageHeaderBreadcrumbs = screen.getByTestId("page-header-breadcrumbs");
+    expect(
+      within(pageHeaderBreadcrumbs).getAllByRole("navigation", { name: "Page breadcrumb" }).length
+    ).toBeGreaterThan(0);
+    expect(within(pageHeaderBreadcrumbs).getAllByText("Home").length).toBeGreaterThan(0);
+  });
+
   it("keeps the current page visible while the next route loader is pending", async () => {
     let resolveSlowRoute;
     const router = createMemoryRouter(

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Device_Summary.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Device_Summary.jsx
@@ -290,6 +290,21 @@ const WORKSPACE_VIEW_OPTIONS = Object.freeze({
   inventory: ["summary", "software"],
   config: ["metadata"],
 });
+const WORKSPACE_VIEW_LABELS = Object.freeze({
+  remote_ops: {
+    shell: "Shell",
+    files: "Files",
+    processes: "Processes",
+    services: "Services",
+  },
+  inventory: {
+    summary: "Overview",
+    software: "Installed Software",
+  },
+  config: {
+    metadata: "Metadata",
+  },
+});
 const LEGACY_TAB_TO_WORKSPACE = Object.freeze({
   command: { workspace: "inventory", view: "summary" },
   device_summary: { workspace: "inventory", view: "summary" },
@@ -340,6 +355,19 @@ const createDeviceWorkspaceSearch = (currentSearch, workspaceKey, viewKey = "") 
     params.delete("view");
   }
   return params.toString() ? `?${params.toString()}` : "";
+};
+
+const getWorkspaceLabel = (workspaceKey) =>
+  WORKSPACES.find((workspace) => workspace.key === workspaceKey)?.label || "Workspace";
+
+const getWorkspaceViewLabel = (workspaceKey, viewKey) =>
+  WORKSPACE_VIEW_LABELS[workspaceKey]?.[viewKey] || "";
+
+const buildDeviceWorkspaceTarget = (deviceId, currentSearch, workspaceKey, viewKey = "") => {
+  if (!deviceId) {
+    return "";
+  }
+  return `${APP_PATHS.device(deviceId)}${createDeviceWorkspaceSearch(currentSearch, workspaceKey, viewKey)}`;
 };
 
 const resolveDeviceId = (device) =>
@@ -4374,11 +4402,80 @@ export default function DeviceSummary() {
       workspaceBadges,
     ]
   );
+  const deviceWorkspaceMenuItems = useMemo(() => {
+    const menuItems = [];
+    WORKSPACES.forEach((workspace) => {
+      const viewOptions = WORKSPACE_VIEW_OPTIONS[workspace.key] || [];
+      if (!viewOptions.length) {
+        menuItems.push({
+          id: `device-workspace-${workspace.key}`,
+          label: workspace.label,
+          to: buildDeviceWorkspaceTarget(deviceId, location.search, workspace.key),
+          disabled: activeWorkspaceKey === workspace.key,
+        });
+        return;
+      }
+      viewOptions.forEach((viewKey) => {
+        menuItems.push({
+          id: `device-workspace-${workspace.key}-${viewKey}`,
+          label: `${workspace.label} - ${getWorkspaceViewLabel(workspace.key, viewKey)}`,
+          to: buildDeviceWorkspaceTarget(deviceId, location.search, workspace.key, viewKey),
+          disabled:
+            activeWorkspaceKey === workspace.key &&
+            normalizeWorkspaceView(workspace.key, activeWorkspaceView) === viewKey,
+        });
+      });
+    });
+    if (deviceId) {
+      menuItems.push({
+        id: "device-workspace-remote-desktop",
+        label: "Remote Desktop",
+        to: APP_PATHS.deviceRemoteDesktop(deviceId),
+      });
+    }
+    return menuItems;
+  }, [activeWorkspaceKey, activeWorkspaceView, deviceId, location.search]);
+  const deviceBreadcrumbItems = useMemo(() => {
+    const workspaceLabel = getWorkspaceLabel(activeWorkspaceKey);
+    const normalizedView = normalizeWorkspaceView(activeWorkspaceKey, activeWorkspaceView);
+    const viewLabel = getWorkspaceViewLabel(activeWorkspaceKey, normalizedView);
+    const defaultView = WORKSPACE_VIEW_DEFAULTS[activeWorkspaceKey] || normalizedView || "";
+    const workspaceTarget = buildDeviceWorkspaceTarget(
+      deviceId,
+      location.search,
+      activeWorkspaceKey,
+      defaultView
+    );
+    const items = [
+      {
+        id: `device-workspace-${activeWorkspaceKey}`,
+        label: workspaceLabel,
+        to: viewLabel ? workspaceTarget : null,
+        menuItems: deviceWorkspaceMenuItems,
+      },
+    ];
+    if (viewLabel) {
+      items.push({
+        id: `device-workspace-${activeWorkspaceKey}-${normalizedView}`,
+        label: viewLabel,
+        menuItems: deviceWorkspaceMenuItems,
+      });
+    }
+    return items;
+  }, [
+    activeWorkspaceKey,
+    activeWorkspaceView,
+    deviceId,
+    deviceWorkspaceMenuItems,
+    location.search,
+  ]);
 
   useRoutePageChrome({
     title: displayHostname,
     subtitle: pageSubtitle,
     Icon: DeviceSummaryPageIcon,
+    breadcrumbLabel: displayHostname,
+    breadcrumbs: deviceBreadcrumbItems,
     actions: pageHeaderActions,
     navigationSidebar: deviceNavigationSidebar,
   });

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/app/hooks/useRoutePageChrome.js
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/app/hooks/useRoutePageChrome.js
@@ -13,6 +13,11 @@ export function useRoutePageChrome(pageChrome) {
     typeof pageChrome?.breadcrumbLabel === "string" ? pageChrome.breadcrumbLabel : "";
   const actions = Array.isArray(pageChrome?.actions) ? pageChrome.actions : EMPTY_ITEMS;
   const controls = Array.isArray(pageChrome?.controls) ? pageChrome.controls : EMPTY_ITEMS;
+  const breadcrumbs = Array.isArray(pageChrome?.breadcrumbs) ? pageChrome.breadcrumbs : EMPTY_ITEMS;
+  const breadcrumbsReplace = Boolean(pageChrome?.breadcrumbsReplace);
+  const breadcrumbMenuItems = Array.isArray(pageChrome?.breadcrumbMenuItems)
+    ? pageChrome.breadcrumbMenuItems
+    : EMPTY_ITEMS;
   const navigationSidebar = pageChrome?.navigationSidebar || null;
 
   useEffect(() => {
@@ -22,6 +27,9 @@ export function useRoutePageChrome(pageChrome) {
         subtitle,
         Icon,
         breadcrumbLabel,
+        breadcrumbs,
+        breadcrumbsReplace,
+        breadcrumbMenuItems,
         actions,
         controls,
         navigationSidebar,
@@ -33,5 +41,19 @@ export function useRoutePageChrome(pageChrome) {
     return () => {
       resetPageChrome();
     };
-  }, [Icon, actions, breadcrumbLabel, controls, hasPageChrome, navigationSidebar, resetPageChrome, setPageChrome, subtitle, title]);
+  }, [
+    Icon,
+    actions,
+    breadcrumbLabel,
+    breadcrumbMenuItems,
+    breadcrumbs,
+    breadcrumbsReplace,
+    controls,
+    hasPageChrome,
+    navigationSidebar,
+    resetPageChrome,
+    setPageChrome,
+    subtitle,
+    title,
+  ]);
 }

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/app/providers/PageChromeContext.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/app/providers/PageChromeContext.jsx
@@ -1,12 +1,17 @@
 import React, { createContext, useCallback, useContext, useMemo, useState } from "react";
 
+const EMPTY_ITEMS = Object.freeze([]);
+
 export const EMPTY_PAGE_CHROME = {
   title: "",
   subtitle: "",
   Icon: null,
-  actions: [],
-  controls: [],
+  actions: EMPTY_ITEMS,
+  controls: EMPTY_ITEMS,
   breadcrumbLabel: "",
+  breadcrumbs: EMPTY_ITEMS,
+  breadcrumbsReplace: false,
+  breadcrumbMenuItems: EMPTY_ITEMS,
   navigationSidebar: null,
 };
 
@@ -23,6 +28,11 @@ function normalizePageChrome(meta) {
     controls: Array.isArray(meta.controls) ? meta.controls.filter(Boolean) : [],
     breadcrumbLabel:
       typeof meta.breadcrumbLabel === "string" ? meta.breadcrumbLabel : typeof meta.title === "string" ? meta.title : "",
+    breadcrumbs: Array.isArray(meta.breadcrumbs) ? meta.breadcrumbs.filter(Boolean) : [],
+    breadcrumbsReplace: Boolean(meta.breadcrumbsReplace),
+    breadcrumbMenuItems: Array.isArray(meta.breadcrumbMenuItems)
+      ? meta.breadcrumbMenuItems.filter(Boolean)
+      : [],
     navigationSidebar: meta.navigationSidebar || null,
   };
 }

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/app/routes/breadcrumbs.js
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/app/routes/breadcrumbs.js
@@ -4,6 +4,81 @@ function resolveHandleValue(handle, key, match) {
 }
 
 export const APP_DOCUMENT_TITLE = "Borealis";
+const EMPTY_ITEMS = Object.freeze([]);
+
+function normalizeText(value) {
+  return String(value || "").trim();
+}
+
+function buildTargetFromLocation(location = {}) {
+  const pathname = normalizeText(location.pathname);
+  const search = normalizeText(location.search);
+  if (!pathname) {
+    return "";
+  }
+  return `${pathname}${search}`;
+}
+
+export function normalizeBreadcrumbMenuItems(items = []) {
+  if (!Array.isArray(items)) {
+    return [];
+  }
+
+  return items
+    .map((item, index) => {
+      if (!item) {
+        return null;
+      }
+      if (typeof item === "string") {
+        const label = normalizeText(item);
+        return label ? { id: `menu-${index}`, label, to: null, disabled: true } : null;
+      }
+
+      const label = normalizeText(item.label);
+      if (!label) {
+        return null;
+      }
+
+      return {
+        id: normalizeText(item.id) || `menu-${index}`,
+        label,
+        to: item.to || null,
+        onClick: typeof item.onClick === "function" ? item.onClick : null,
+        disabled: Boolean(item.disabled),
+      };
+    })
+    .filter(Boolean);
+}
+
+export function normalizeBreadcrumbItems(items = []) {
+  if (!Array.isArray(items)) {
+    return [];
+  }
+
+  return items
+    .map((item, index) => {
+      if (!item) {
+        return null;
+      }
+      if (typeof item === "string") {
+        const label = normalizeText(item);
+        return label ? { id: `breadcrumb-${index}`, label, to: null, menuItems: EMPTY_ITEMS } : null;
+      }
+
+      const label = normalizeText(item.label);
+      if (!label) {
+        return null;
+      }
+
+      return {
+        id: normalizeText(item.id) || `breadcrumb-${index}`,
+        label,
+        to: item.to || null,
+        menuItems: normalizeBreadcrumbMenuItems(item.menuItems),
+      };
+    })
+    .filter(Boolean);
+}
 
 export function resolveActiveNavKey(matches = []) {
   for (let index = matches.length - 1; index >= 0; index -= 1) {
@@ -38,6 +113,18 @@ export function resolvePageChromeDefaults(matches = []) {
   };
 }
 
+export function resolveRememberedBreadcrumbTargetKey(matches = []) {
+  for (let index = matches.length - 1; index >= 0; index -= 1) {
+    const handle = matches[index]?.handle;
+    const navKey = normalizeText(handle?.navKey);
+    const pageKey = normalizeText(handle?.pageKey || handle?.navKey);
+    if (navKey && pageKey && navKey === pageKey) {
+      return navKey;
+    }
+  }
+  return "";
+}
+
 export function formatDocumentTitle(pageTitle, appTitle = APP_DOCUMENT_TITLE) {
   const normalizedAppTitle =
     typeof appTitle === "string" && appTitle.trim() ? appTitle.trim() : APP_DOCUMENT_TITLE;
@@ -51,23 +138,88 @@ export function formatDocumentTitle(pageTitle, appTitle = APP_DOCUMENT_TITLE) {
   return `${normalizedAppTitle} - ${normalizedPageTitle}`;
 }
 
-export function buildBreadcrumbItems(matches = [], pageChrome = {}) {
+export function buildBreadcrumbItems(matches = [], pageChrome = {}, options = {}) {
   const breadcrumbMatches = matches.filter((match) => Boolean(match?.handle?.breadcrumb));
   if (!breadcrumbMatches.length) {
-    return [];
+    return normalizeBreadcrumbItems(pageChrome?.breadcrumbs);
   }
 
-  return breadcrumbMatches.map((match, index) => {
+  const rememberedTargets =
+    options?.rememberedTargets && typeof options.rememberedTargets === "object"
+      ? options.rememberedTargets
+      : {};
+  const pageBreadcrumbs = normalizeBreadcrumbItems(pageChrome?.breadcrumbs);
+  const replaceRouteTrail = Boolean(pageChrome?.breadcrumbsReplace);
+  const currentMenuItems = normalizeBreadcrumbMenuItems(pageChrome?.breadcrumbMenuItems);
+  const lastRouteMatch = breadcrumbMatches[breadcrumbMatches.length - 1] || null;
+  const routeItems = breadcrumbMatches.map((match, index) => {
     const isLast = index === breadcrumbMatches.length - 1;
     const defaultLabel = resolveHandleValue(match.handle, "breadcrumb", match) || "";
     const label = isLast
       ? pageChrome?.breadcrumbLabel || pageChrome?.title || defaultLabel
       : defaultLabel;
+    const navKey = normalizeText(match.handle?.navKey);
+    const rememberedTarget = !isLast && navKey ? normalizeText(rememberedTargets[navKey]) : "";
 
     return {
       id: match.id || match.pathname || String(index),
       label,
-      to: !isLast ? match.pathname : null,
+      to: !isLast ? rememberedTarget || match.pathname : null,
+      menuItems: EMPTY_ITEMS,
     };
   });
+
+  let items = replaceRouteTrail ? pageBreadcrumbs : [...routeItems, ...pageBreadcrumbs];
+  if (!replaceRouteTrail && pageBreadcrumbs.length && routeItems.length) {
+    items = items.map((item, index) => {
+      if (index !== routeItems.length - 1 || item.to) {
+        return item;
+      }
+      const routeTarget = buildTargetFromLocation(lastRouteMatch);
+      return routeTarget ? { ...item, to: routeTarget } : item;
+    });
+  }
+
+  if (currentMenuItems.length && items.length) {
+    const lastIndex = items.length - 1;
+    items = items.map((item, index) =>
+      index === lastIndex
+        ? { ...item, menuItems: [...(item.menuItems || EMPTY_ITEMS), ...currentMenuItems] }
+        : item
+    );
+  }
+
+  return items;
+}
+
+export function buildBreadcrumbDisplayItems(items = [], { maxItems = 6 } = {}) {
+  const normalizedItems = normalizeBreadcrumbItems(items);
+  const normalizedMaxItems = Math.max(3, Number(maxItems) || 6);
+  if (normalizedItems.length <= normalizedMaxItems) {
+    return normalizedItems;
+  }
+
+  const visibleSlots = normalizedMaxItems - 1;
+  const beforeCount = Math.max(1, Math.ceil((visibleSlots - 1) / 2));
+  const afterCount = Math.max(1, visibleSlots - beforeCount);
+  const beforeItems = normalizedItems.slice(0, beforeCount);
+  const afterItems = normalizedItems.slice(normalizedItems.length - afterCount);
+  const overflowItems = normalizedItems.slice(beforeCount, normalizedItems.length - afterCount);
+
+  return [
+    ...beforeItems,
+    {
+      id: "breadcrumb-overflow",
+      label: "More",
+      to: null,
+      menuItems: overflowItems.map((item) => ({
+        id: item.id,
+        label: item.label,
+        to: item.to,
+        disabled: !item.to && !item.menuItems?.length,
+      })),
+      overflow: true,
+    },
+    ...afterItems,
+  ];
 }

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/app/shell/AppShell.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/app/shell/AppShell.jsx
@@ -2,7 +2,6 @@ import React, { useCallback, useEffect, useMemo, useState, useSyncExternalStore 
 import {
   AppBar,
   Box,
-  Breadcrumbs,
   Button,
   CircularProgress,
   Dialog,
@@ -22,6 +21,7 @@ import {
   KeyboardArrowDown as KeyboardArrowDownIcon,
   LockReset as LockResetIcon,
   Logout as LogoutIcon,
+  MoreHoriz as MoreHorizIcon,
   NavigateNext as NavigateNextIcon,
   VpnKey as VpnKeyIcon,
 } from "@mui/icons-material";
@@ -48,11 +48,13 @@ import { useAuth } from "../providers/AuthContext.jsx";
 import { usePageChrome } from "../providers/PageChromeContext.jsx";
 import {
   APP_DOCUMENT_TITLE,
+  buildBreadcrumbDisplayItems,
   buildBreadcrumbItems,
   formatDocumentTitle,
   resolveActiveNavKey,
   resolveCurrentPageKey,
   resolvePageChromeDefaults,
+  resolveRememberedBreadcrumbTargetKey,
 } from "../routes/breadcrumbs.js";
 import { APP_PATHS } from "../routes/paths.js";
 import {
@@ -108,6 +110,189 @@ function formatPasskeyTransportLabel(transports) {
     .join(", ");
 }
 
+const BREADCRUMB_DESKTOP_MAX_ITEMS = 6;
+const BREADCRUMB_MOBILE_MAX_ITEMS = 3;
+
+const BREADCRUMB_RAIL_SX = {
+  display: "inline-flex",
+  alignItems: "center",
+  minWidth: 0,
+  maxWidth: "100%",
+  px: 1,
+  py: 0.45,
+  borderRadius: 1.25,
+  border: "1px solid rgba(125,211,252,0.20)",
+  background:
+    "linear-gradient(135deg, rgba(8,12,24,0.56), rgba(15,23,42,0.34))",
+  boxShadow: "inset 0 1px 0 rgba(255,255,255,0.04)",
+  backdropFilter: "blur(8px)",
+};
+
+const BREADCRUMB_LINK_SX = {
+  minWidth: 0,
+  px: 0.65,
+  py: 0.15,
+  borderRadius: 1,
+  color: "#bfdbfe",
+  fontSize: "0.78rem",
+  fontWeight: 600,
+  lineHeight: 1.45,
+  textTransform: "none",
+  justifyContent: "flex-start",
+  maxWidth: { xs: 142, sm: 180, lg: 240 },
+  "& .MuiButton-endIcon": { ml: 0.35 },
+  "&:hover": {
+    color: "#f8fbff",
+    backgroundColor: "rgba(125,211,252,0.10)",
+  },
+};
+
+const BREADCRUMB_CURRENT_SX = {
+  px: 0.65,
+  py: 0.15,
+  minWidth: 0,
+  maxWidth: { xs: 150, sm: 220, lg: 300 },
+  color: "#f8fbff",
+  fontSize: "0.78rem",
+  fontWeight: 700,
+  lineHeight: 1.45,
+};
+
+const BREADCRUMB_MENU_PAPER_SX = {
+  mt: 0.8,
+  minWidth: 190,
+  border: "1px solid rgba(125,211,252,0.20)",
+  background:
+    "linear-gradient(165deg, rgba(8,12,24,0.98), rgba(15,23,42,0.96))",
+  color: "#dbeafe",
+  boxShadow: "0 18px 48px rgba(2,8,23,0.46)",
+};
+
+function BreadcrumbLabel({ children, sx }) {
+  return (
+    <Typography component="span" noWrap sx={sx}>
+      {children}
+    </Typography>
+  );
+}
+
+function BreadcrumbTrail({ items, maxItems, navigate, sx }) {
+  const [menuState, setMenuState] = useState({ anchorEl: null, items: [] });
+  const visibleItems = useMemo(
+    () => buildBreadcrumbDisplayItems(items, { maxItems }),
+    [items, maxItems]
+  );
+
+  const closeMenu = useCallback(() => {
+    setMenuState({ anchorEl: null, items: [] });
+  }, []);
+
+  const openMenu = useCallback((event, menuItems) => {
+    setMenuState({ anchorEl: event.currentTarget, items: menuItems || [] });
+  }, []);
+
+  const navigateTo = useCallback(
+    (target) => {
+      if (!target) {
+        return;
+      }
+      navigate(target);
+    },
+    [navigate]
+  );
+
+  const handleMenuItemClick = useCallback(
+    (item) => {
+      closeMenu();
+      if (item?.disabled) {
+        return;
+      }
+      if (typeof item?.onClick === "function") {
+        item.onClick();
+        return;
+      }
+      navigateTo(item?.to);
+    },
+    [closeMenu, navigateTo]
+  );
+
+  if (!visibleItems.length) {
+    return null;
+  }
+
+  return (
+    <Box component="nav" aria-label="Page breadcrumb" sx={{ ...BREADCRUMB_RAIL_SX, ...sx }}>
+      {visibleItems.map((item, index) => {
+        const menuItems = Array.isArray(item.menuItems) ? item.menuItems : [];
+        const hasMenu = menuItems.length > 0;
+        const isLast = index === visibleItems.length - 1;
+        const isCurrent = isLast && !item.to;
+        const buttonSx = isCurrent ? { ...BREADCRUMB_LINK_SX, color: "#f8fbff" } : BREADCRUMB_LINK_SX;
+
+        return (
+          <React.Fragment key={item.id}>
+            {index > 0 ? (
+              <NavigateNextIcon
+                aria-hidden="true"
+                sx={{ mx: 0.15, fontSize: 15, color: "rgba(148,163,184,0.72)", flexShrink: 0 }}
+              />
+            ) : null}
+
+            {item.overflow ? (
+              <Tooltip title="Show Hidden Breadcrumbs">
+                <Button
+                  type="button"
+                  aria-label="Show hidden breadcrumbs"
+                  onClick={(event) => openMenu(event, menuItems)}
+                  sx={{ ...BREADCRUMB_LINK_SX, px: 0.45, minWidth: 28 }}
+                >
+                  <MoreHorizIcon sx={{ fontSize: 18 }} />
+                </Button>
+              </Tooltip>
+            ) : item.to || hasMenu ? (
+              <Button
+                type="button"
+                endIcon={hasMenu ? <KeyboardArrowDownIcon sx={{ fontSize: 16 }} /> : null}
+                onClick={(event) => {
+                  if (hasMenu) {
+                    openMenu(event, menuItems);
+                    return;
+                  }
+                  navigateTo(item.to);
+                }}
+                sx={buttonSx}
+              >
+                <BreadcrumbLabel sx={{ overflow: "hidden", textOverflow: "ellipsis" }}>
+                  {item.label}
+                </BreadcrumbLabel>
+              </Button>
+            ) : (
+              <BreadcrumbLabel sx={BREADCRUMB_CURRENT_SX}>{item.label}</BreadcrumbLabel>
+            )}
+          </React.Fragment>
+        );
+      })}
+      <Menu
+        anchorEl={menuState.anchorEl}
+        open={Boolean(menuState.anchorEl)}
+        onClose={closeMenu}
+        PaperProps={{ sx: BREADCRUMB_MENU_PAPER_SX }}
+      >
+        {menuState.items.map((item) => (
+          <MenuItem
+            key={item.id || item.label}
+            disabled={Boolean(item.disabled)}
+            onClick={() => handleMenuItemClick(item)}
+            sx={{ fontSize: "0.84rem", color: "inherit" }}
+          >
+            {item.label}
+          </MenuItem>
+        ))}
+      </Menu>
+    </Box>
+  );
+}
+
 export default function AppShell() {
   const location = useLocation();
   const navigate = useNavigate();
@@ -158,6 +343,7 @@ export default function AppShell() {
   const [managePasskeyAction, setManagePasskeyAction] = useState({ id: null, type: "" });
   const [newPasskeyLabel, setNewPasskeyLabel] = useState("");
   const [removePasskeyTarget, setRemovePasskeyTarget] = useState(null);
+  const [rememberedBreadcrumbTargets, setRememberedBreadcrumbTargets] = useState({});
 
   const defaultChrome = useMemo(() => resolvePageChromeDefaults(matches), [matches]);
   const activeNavKey = useMemo(() => resolveActiveNavKey(matches), [matches]);
@@ -175,14 +361,20 @@ export default function AppShell() {
       controls: pageChrome.controls?.length ? pageChrome.controls : defaultChrome.controls || [],
       breadcrumbLabel:
         pageChrome.breadcrumbLabel || pageChrome.title || defaultChrome.title || "",
+      breadcrumbs: pageChrome.breadcrumbs || [],
+      breadcrumbsReplace: Boolean(pageChrome.breadcrumbsReplace),
+      breadcrumbMenuItems: pageChrome.breadcrumbMenuItems || [],
       navigationSidebar: pageChrome.navigationSidebar || null,
     }),
     [defaultChrome, pageChrome]
   );
 
   const breadcrumbs = useMemo(
-    () => buildBreadcrumbItems(matches, resolvedChrome),
-    [matches, resolvedChrome]
+    () =>
+      buildBreadcrumbItems(matches, resolvedChrome, {
+        rememberedTargets: rememberedBreadcrumbTargets,
+      }),
+    [matches, rememberedBreadcrumbTargets, resolvedChrome]
   );
 
   const hasPageHeader = Boolean(
@@ -222,6 +414,23 @@ export default function AppShell() {
 
     document.title = formatDocumentTitle(resolvedChrome.title);
   }, [resolvedChrome.title]);
+
+  useEffect(() => {
+    const targetKey = resolveRememberedBreadcrumbTargetKey(matches);
+    if (!targetKey) {
+      return;
+    }
+    const target = `${location.pathname}${location.search || ""}`;
+    setRememberedBreadcrumbTargets((current) => {
+      if (current[targetKey] === target) {
+        return current;
+      }
+      return {
+        ...current,
+        [targetKey]: target,
+      };
+    });
+  }, [location.pathname, location.search, matches]);
 
   useEffect(() => {
     if (isBufferedRoutePending && navigation.location) {
@@ -581,7 +790,7 @@ export default function AppShell() {
             borderBottom: "1px solid rgba(125,183,255,0.20)",
           }}
         >
-          <Toolbar sx={{ minHeight: 40, alignItems: "center", gap: 1 }}>
+          <Toolbar data-testid="app-top-bar" sx={{ minHeight: 40, alignItems: "center", gap: 1 }}>
             <Box
               component="img"
               src="/Borealis_Logo_Full.png"
@@ -598,45 +807,6 @@ export default function AppShell() {
               }}
             >
               <GlobalDeviceSearch onSelectDevice={handleGlobalDeviceSelect} />
-            </Box>
-
-            <Box sx={{ ml: 2, display: "flex", alignItems: "center" }}>
-              <Breadcrumbs
-                separator={<NavigateNextIcon fontSize="inherit" sx={{ color: "#6b6b6b" }} />}
-                aria-label="breadcrumb"
-                sx={{
-                  color: "#9aa0a6",
-                  fontSize: "0.825rem",
-                  "& .MuiBreadcrumbs-separator": { mx: 0.6 },
-                }}
-              >
-                {breadcrumbs.map((item) =>
-                  item.to ? (
-                    <Button
-                      key={item.id}
-                      onClick={() => navigate(item.to)}
-                      size="small"
-                      sx={{
-                        color: "#cde1ff",
-                        textTransform: "none",
-                        minWidth: 0,
-                        p: 0,
-                        fontSize: "0.825rem",
-                      }}
-                    >
-                      {item.label}
-                    </Button>
-                  ) : (
-                    <Typography
-                      key={item.id}
-                      component="span"
-                      sx={{ color: "#f5f5f5", fontSize: "0.825rem" }}
-                    >
-                      {item.label}
-                    </Typography>
-                  )
-                )}
-              </Breadcrumbs>
             </Box>
 
             <Box sx={{ flexGrow: 1 }} />
@@ -736,6 +906,26 @@ export default function AppShell() {
           >
             {hasPageHeader ? (
               <Box sx={{ px: 3, pt: 3, pb: 1.5, flexShrink: 0 }}>
+                {breadcrumbs.length ? (
+                  <Box data-testid="page-header-breadcrumbs" sx={{ mb: 1.1, minWidth: 0 }}>
+                    <BreadcrumbTrail
+                      items={breadcrumbs}
+                      maxItems={BREADCRUMB_DESKTOP_MAX_ITEMS}
+                      navigate={navigate}
+                      sx={{
+                        display: { xs: "none", md: "inline-flex" },
+                      }}
+                    />
+                    <BreadcrumbTrail
+                      items={breadcrumbs}
+                      maxItems={BREADCRUMB_MOBILE_MAX_ITEMS}
+                      navigate={navigate}
+                      sx={{
+                        display: { xs: "inline-flex", md: "none" },
+                      }}
+                    />
+                  </Box>
+                ) : null}
                 <Box
                   sx={{
                     display: "flex",

--- a/Docs/Reference/ui-and-notifications.md
+++ b/Docs/Reference/ui-and-notifications.md
@@ -46,6 +46,7 @@ Treat this document as the single source of truth for Borealis WebUI design rule
 ## Styling and Layout
 - Borealis uses a MagicUI styling language with glass panels, gradients, and Quartz-themed AG Grid tables.
 - The full MagicUI and AG Grid specification is embedded in the Codex Agent section below.
+- Breadcrumbs live in the shared page header above the page title. They should help operators move back through the route hierarchy and, on detail pages, back to the last remembered collection URL when one exists.
 - Workflow Runtime v1 node-shell and port-row styling rules live in [Workflows](../Using%20the%20Platform/Assemblies/workflows.md). Use that document as the source of truth for workflow node title sizing, status badges, named port rows, and Action-vs-data edge behavior.
 - Workflow Runtime v1 naming and edge-label behavior also live there. In particular, use `Device Filter` and `List of Devices` for the targeting nodes, keep workflow data edges dashed Borealis blue, and let target edges auto-label with device counts when available.
 - Workflow node inspection also follows that document: the node sidebar `Debug Info` tab is available in both authoring mode and run-snapshot mode, with authoring previews clearly treated as pre-runtime estimates rather than executed results.
@@ -323,12 +324,25 @@ Treat this document as the single source of truth for Borealis WebUI design rule
 
     #### Page-Level Tabs
     - Header ownership: `Data/Engine/Containers/webui-frontend/data/web-interface/src/app/shell/AppShell.jsx` owns the page title, subtitle, icon, and the page action rail. Routed pages should publish header metadata through `useRoutePageChrome()` or `usePageChrome()`.
+    - Breadcrumb ownership: `AppShell.jsx` also owns the shared breadcrumb rail. Do not render duplicate page-local breadcrumbs in routed pages.
     - Header action contract:
     ```jsx
     useRoutePageChrome({
       title: pageTitle,
       subtitle: pageSubtitle,
       Icon: PageIcon,
+      breadcrumbLabel: pageTitle,
+      breadcrumbs: [
+        { id: "workspace", label: "Backend Tools", to: "/devices/lab-docker-02?tab=remote_ops&view=shell" },
+        {
+          id: "workspace-view",
+          label: "Files",
+          menuItems: [
+            { id: "shell", label: "Shell", to: "/devices/lab-docker-02?tab=remote_ops&view=shell" },
+            { id: "services", label: "Services", to: "/devices/lab-docker-02?tab=remote_ops&view=services" },
+          ],
+        },
+      ],
       controls: [statusSelectControl],
       actions: [
         { id: "refresh", label: "Refresh", icon: <RefreshIcon />, tone: "secondary", onClick: loadData },
@@ -336,6 +350,11 @@ Treat this document as the single source of truth for Borealis WebUI design rule
       ],
     });
     ```
+    - Breadcrumb route source: route `handle.breadcrumb` values define the base trail. `breadcrumbLabel` overrides the current route label; `breadcrumbs` appends contextual depth such as device workspace/view crumbs; `breadcrumbsReplace` may replace the route trail for standalone special surfaces.
+    - Breadcrumb menu source: use `breadcrumbMenuItems` for current-page menu options or per-crumb `menuItems` for contextual sibling navigation. Menu items support `id`, `label`, `to`, `onClick`, and `disabled`.
+    - Remembered collection URLs: `AppShell.jsx` remembers collection routes where `handle.navKey === handle.pageKey`, including query strings. Parent crumbs on nested pages should use that remembered target so `Devices` can return to `/devices?site=<id>` instead of bare `/devices`.
+    - Device Summary breadcrumbs: publish active workspace/view crumbs from existing `tab` and `view` query parameters. Example trail: `Devices / lab-docker-02 / Backend Tools / Files`.
+    - Responsive behavior: desktop shows the full rail until it exceeds the helper limit; narrow widths keep the first crumb, an ellipsis menu, and the current crumb. Breadcrumb text must truncate inside its own control instead of widening the page header.
     - Shared implementation: use `Data/Engine/Containers/webui-frontend/data/web-interface/src/Page_Header_Actions.jsx` for the action-rail renderer and the shared button/control tokens. Standalone pages that render without App should use the same `PageHeaderActionRail` component locally instead of re-creating header buttons.
     - Action rail placement: the rail lives inside the shared header band in normal document flow, aligned to the top-right of the page title block. Do not use `position: "fixed"` for page-level actions.
     - Rail ordering: pages declare actions in their final left-to-right display order. Supporting actions should be listed first and primary actions should be listed last so the main CTA stays on the far right.


### PR DESCRIPTION
## Summary
- Move Engine WebUI breadcrumbs from the top app bar into the shared page header.
- Add normalized page chrome breadcrumb metadata, contextual menus, remembered collection targets, and responsive overflow behavior.
- Add Device Summary workspace/view breadcrumbs using existing `tab` and `view` query state.
- Document the shared breadcrumb contract in the UI reference.

## Validation
- `git diff --check`
- `./Engine_Unit_Tests.sh --domain webui` could not run because the WebUI runtime test cache is missing `Engine/Services/webui-frontend/cache/web-interface/Unit_Tests`. Redeploy/prep the Engine WebUI runtime cache, then rerun the command.

Closes #270