### PR TITLE
issue/fix-site-worker-task-ui-bug

### DIFF
--- a/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/Sites/Site_List.taskCountdown.test.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/Sites/Site_List.taskCountdown.test.jsx
@@ -51,4 +51,44 @@ describe("site assigned task countdown", () => {
     expect(groups[0].removal_remaining_seconds).toBeNull();
     expect(groups[0].counts.running).toBe(1);
   });
+
+  it("suppresses premature terminal rows for active one-device runs", () => {
+    const payload = {
+      active_work: [
+        {
+          id: "scheduled-run:1440",
+          kind: "scheduled_run",
+          site_id: 7,
+          job_id: 144,
+          run_id: 1440,
+          status: "running",
+          started_at: 1000,
+          updated_at: 1010,
+          target_count: 1,
+        },
+      ],
+      recent_work: [
+        {
+          id: 501,
+          kind: "scheduled_run",
+          site_id: 7,
+          job_id: 144,
+          run_id: 1440,
+          target_id: 3001,
+          status: "succeeded",
+          started_at: 1000,
+          finished_at: 1012,
+          target_count: 1,
+        },
+      ],
+    };
+
+    const groups = buildTaskGroupsByWorker(payload, 1015).get("site:7");
+    expect(groups).toHaveLength(1);
+    expect(groups[0].has_active_work).toBe(true);
+    expect(groups[0].expires_at).toBeNull();
+    expect(groups[0].counts.running).toBe(1);
+    expect(groups[0].counts.success).toBe(0);
+    expect(groups[0].counts.total_tasks).toBe(1);
+  });
 });

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Sites/Site_List.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Sites/Site_List.jsx
@@ -530,11 +530,93 @@ function workIdentity(work) {
   ].join(":");
 }
 
-function jobIdForWork(work) {
+function positiveWorkNumber(...values) {
+  for (const value of values) {
+    const parsed = Number(value || 0);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  return 0;
+}
+
+function workRunId(work) {
   const taskLink = work?.task_link || {};
-  const value = work?.job_id || taskLink?.job_id || "";
-  const numberValue = Number(value || 0);
-  return Number.isFinite(numberValue) && numberValue > 0 ? numberValue : null;
+  return positiveWorkNumber(work?.run_id, taskLink?.run_id);
+}
+
+function workJobId(work) {
+  const taskLink = work?.task_link || {};
+  return positiveWorkNumber(work?.job_id, taskLink?.job_id);
+}
+
+function workTargetCount(work) {
+  return positiveWorkNumber(work?.target_count, work?.task_link?.target_count);
+}
+
+function workTargetId(work) {
+  return positiveWorkNumber(work?.target_id, work?.task_link?.target_id);
+}
+
+function workDisplayIdentity(work, activeSingletonRunIds) {
+  const runId = workRunId(work);
+  if (runId > 0) {
+    if (activeSingletonRunIds?.has(runId)) return `run:${runId}:single-target`;
+    const targetId = workTargetId(work);
+    if (targetId > 0) return `run:${runId}:target:${targetId}`;
+    if (workTargetCount(work) <= 1) return `run:${runId}:single-target`;
+    return `run:${runId}:all-targets`;
+  }
+
+  const jobId = workJobId(work);
+  if (jobId > 0) {
+    const targetId = workTargetId(work);
+    if (targetId > 0) return `job:${jobId}:target:${targetId}`;
+    if (workTargetCount(work) <= 1) return `job:${jobId}:single-target`;
+    return `job:${jobId}:all-targets`;
+  }
+
+  return workIdentity(work);
+}
+
+function shouldReplaceDisplayedWork(existing, next) {
+  const existingBucket = workStatusBucket(existing?.status);
+  const nextBucket = workStatusBucket(next?.status);
+  const existingActive = !isTerminalTaskBucket(existingBucket);
+  const nextActive = !isTerminalTaskBucket(nextBucket);
+  if (existingActive !== nextActive) return nextActive;
+  const rankDelta = statusRank(next?.status) - statusRank(existing?.status);
+  if (rankDelta !== 0) return rankDelta < 0;
+  return taskActivitySeconds(next) >= taskActivitySeconds(existing);
+}
+
+function visibleWorkerTaskRecords(activeWork, recentWork) {
+  const activeSingletonRunIds = new Set();
+  activeWork.forEach((work) => {
+    const runId = workRunId(work);
+    if (runId <= 0 || isTerminalTaskBucket(workStatusBucket(work?.status))) return;
+    const targetCount = workTargetCount(work);
+    if (workTargetId(work) <= 0 && targetCount > 0 && targetCount <= 1) {
+      activeSingletonRunIds.add(runId);
+    }
+  });
+
+  const seen = new Set();
+  const byDisplayIdentity = new Map();
+  [...activeWork, ...recentWork].forEach((work) => {
+    const identity = workIdentity(work);
+    if (seen.has(identity)) return;
+    seen.add(identity);
+    const displayIdentity = workDisplayIdentity(work, activeSingletonRunIds);
+    const existing = byDisplayIdentity.get(displayIdentity);
+    if (!existing || shouldReplaceDisplayedWork(existing, work)) {
+      byDisplayIdentity.set(displayIdentity, work);
+    }
+  });
+  return Array.from(byDisplayIdentity.values());
+}
+
+function jobIdForWork(work) {
+  const numberValue = workJobId(work);
+  return numberValue > 0 ? numberValue : null;
 }
 
 function jobPathForWork(work, jobId) {
@@ -560,13 +642,9 @@ function taskCountdownSecondsLabel(seconds) {
 
 export function buildTaskGroupsByWorker(payload, nowSeconds = Math.floor(Date.now() / 1000)) {
   const byWorker = new Map();
-  const seen = new Set();
   const activeWork = Array.isArray(payload?.active_work) ? payload.active_work : [];
   const recentWork = Array.isArray(payload?.recent_work) ? payload.recent_work : [];
-  [...activeWork, ...recentWork].forEach((work) => {
-    const identity = workIdentity(work);
-    if (seen.has(identity)) return;
-    seen.add(identity);
+  visibleWorkerTaskRecords(activeWork, recentWork).forEach((work) => {
     const keys = new Set(
       [work?.worker_guid, work?.lease_owner, work?.container_name]
         .map((value) => String(value || "").trim())


### PR DESCRIPTION
ISSUE GOAL:
- Expected behavior: Sites page shows one active single-device site-worker task as running only, not running plus premature success for same device.
- Affected subsystem: Engine WebUI Sites task visualization and site-worker task state projection.
- Relevant docs: Docs/Reference/ui-and-notifications.md, Docs/Reference/Unit_Testing.md.
- Validation: inspect Site_List task aggregation; focused WebUI regression added; ./Engine_Unit_Tests.sh --domain webui attempted but blocked by missing runtime cache.
- Docs/SBOM/debt impact: no SBOM change; no operator docs needed for bugfix.

## Summary
- Collapse duplicate active/recent task observations before Sites assigned-task bucket counts.
- Prefer non-terminal running/pending state over terminal success/failed/skipped rows when both describe the same one-device scheduled run.
- Keep target-specific rows distinct when identity is available, preserving multi-target visibility.
- Add regression coverage for issue #279 payload shape.

## Validation
- git diff --check
- ./Engine_Unit_Tests.sh --domain webui (blocked: Engine WebUI runtime unit tests missing at /opt/Borealis/Engine/Services/webui-frontend/cache/web-interface/Unit_Tests; redeploy Engine to stage runtime cache, then rerun)

Refs #279