### PR TITLE
issue/ignore-cd-rom-disk-alerts

### DIFF
--- a/Data/Engine/Containers/api-backend/cmd/api-backend/watchdogs_preview.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/watchdogs_preview.go
@@ -616,6 +616,9 @@ func watchdogPreviewEvaluateStorage(rule map[string]any, device map[string]any) 
 	selectedKey := watchdogPreviewStorageDriveKey(selectedDrive)
 	evaluated := []map[string]any{}
 	for _, row := range rows {
+		if watchdogPreviewStorageUsageIgnored(row) {
+			continue
+		}
 		if _, ok := float64Value(row["usage_percent"]); !ok {
 			continue
 		}
@@ -660,6 +663,14 @@ func watchdogPreviewEvaluateStorage(rule map[string]any, device map[string]any) 
 		matchedDriveSamples = append(matchedDriveSamples, map[string]any{"drive": row["drive"], "usage_percent": roundFloat(value, 2)})
 	}
 	return watchdogPreviewRuleResult(rule, len(matchedRows) > 0, false, summary, map[string]any{"drive_scope": "all", "threshold": roundFloat(threshold, 2), "highest_drive": chosen["drive"], "highest_usage_percent": roundFloat(usage, 2), "matched_drives": matchedDriveSamples})
+}
+
+func watchdogPreviewStorageUsageIgnored(row map[string]any) bool {
+	diskType := strings.ToLower(cleanText(firstNonEmpty(row["disk_type"], row["type"])))
+	if diskType == "" {
+		return false
+	}
+	return strings.Contains(diskType, "cd-rom") || strings.Contains(diskType, "cdrom") || strings.Contains(diskType, "cd rom")
 }
 
 func watchdogPreviewEvaluateRoleHealth(rule map[string]any, device map[string]any, now int64, priorResult map[string]any) map[string]any {

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/watchdogs_test.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/watchdogs_test.go
@@ -317,6 +317,58 @@ func TestWatchdogPreviewEvaluatesOfflineRule(t *testing.T) {
 	}
 }
 
+func TestWatchdogPreviewStorageUsageIgnoresCdRomDrives(t *testing.T) {
+	record := map[string]any{
+		"criteria": map[string]any{
+			"match_mode": "all",
+			"rules": []any{
+				map[string]any{"id": "storage", "type": "storage_usage_percent", "threshold": int64(90), "drive_mode": "all"},
+			},
+		},
+		"match_mode":         "all",
+		"boot_grace_seconds": int64(0),
+	}
+	device := map[string]any{
+		"hostname": "LAB-OPERATOR-01",
+		"storage": []any{
+			map[string]any{"drive": "E:", "disk_type": "CD-ROM", "total": float64(100), "used": float64(100)},
+			map[string]any{"drive": "C:", "disk_type": "Fixed Disk", "total": float64(100), "used": float64(50)},
+		},
+	}
+
+	evaluation := evaluateWatchdogPreviewDevice(record, device, nil)
+	if boolDefault(evaluation["matched"], false) || evaluation["state"] != "normal" {
+		t.Fatalf("expected CD-ROM drive to be ignored, got %#v", evaluation)
+	}
+	results := anySlice(evaluation["rule_results"])
+	if len(results) != 1 {
+		t.Fatalf("expected one rule result, got %#v", results)
+	}
+	sample := asStringAnyMap(asStringAnyMap(results[0])["sample"])
+	if sample["highest_drive"] != "C:" || coerceInt64(sample["highest_usage_percent"]) != 50 {
+		t.Fatalf("expected fixed disk to drive storage sample, got %#v", sample)
+	}
+}
+
+func TestWatchdogPreviewSpecificStorageUsageIgnoresCdRomDrive(t *testing.T) {
+	rule := map[string]any{"id": "storage", "type": "storage_usage_percent", "threshold": int64(90), "drive_mode": "specific", "drive": "E:"}
+	device := map[string]any{
+		"hostname": "LAB-OPERATOR-01",
+		"storage": []any{
+			map[string]any{"drive": "E:", "disk_type": "CD-ROM", "total": float64(100), "used": float64(100)},
+		},
+	}
+
+	result := watchdogPreviewEvaluateStorage(rule, device)
+	if boolDefault(result["matched"], false) {
+		t.Fatalf("expected CD-ROM-specific storage rule to stay clear, got %#v", result)
+	}
+	sample := asStringAnyMap(result["sample"])
+	if boolDefault(sample["present"], true) {
+		t.Fatalf("expected CD-ROM target to be treated as absent for usage checks, got %#v", sample)
+	}
+}
+
 func TestNormalizeWatchdogSaveRecordPreservesExistingScopeAndActions(t *testing.T) {
 	existing := map[string]any{
 		"id":       int64(7),

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/Devices/Tabs/storageAlerts.test.js
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/Devices/Tabs/storageAlerts.test.js
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { isCdRomStorageDevice, isStorageUsageAlert } from "@/Devices/Tabs/storageAlerts.js";
+
+describe("storage alert helpers", () => {
+  it("flags fixed disks above the usage threshold", () => {
+    expect(isStorageUsageAlert({ disk_type: "Fixed Disk", usage: 91 })).toBe(true);
+    expect(isStorageUsageAlert({ disk_type: "Fixed Disk", usage: 90 })).toBe(false);
+  });
+
+  it("ignores CD-ROM storage devices for usage alerts", () => {
+    expect(isCdRomStorageDevice({ disk_type: "CD-ROM" })).toBe(true);
+    expect(isStorageUsageAlert({ disk_type: "CD-ROM", usage: 100 })).toBe(false);
+    expect(isStorageUsageAlert({ type: "cdrom", usage: 99 })).toBe(false);
+  });
+});

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Device_Summary.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Device_Summary.jsx
@@ -70,6 +70,12 @@ import AgentBranchChannelDialog, {
   normalizeAgentBranch,
   normalizeAgentReleaseChannel,
 } from "../../AgentBranchChannelDialog.jsx";
+import {
+  STORAGE_USAGE_ALERT_COLOR,
+  STORAGE_USAGE_ALERT_LABEL,
+  STORAGE_USAGE_ALERT_THRESHOLD_PCT,
+  isStorageUsageAlert,
+} from "./storageAlerts.js";
 
 const TUNNEL_STATUS_POLL_INTERVAL_MS = 15000;
 const DEVICE_DETAILS_POLL_INTERVAL_MS = 60000;
@@ -410,9 +416,6 @@ const SUMMARY_GRID_STYLE = {
 const SUMMARY_FIELD_TEXT_COLOR = "#58a6ff"; // matches hostname blue in Device_List.jsx
 const SUMMARY_DEFAULT_TEXT_COLOR = NAV_TAB_COLORS.textActive;
 const UNABLE_TO_RETRIEVE_SN = "<Unable to Retrieve S/N>";
-const STORAGE_USAGE_ALERT_THRESHOLD_PCT = 90;
-const STORAGE_USAGE_ALERT_LABEL = `Usage Exceeding ${STORAGE_USAGE_ALERT_THRESHOLD_PCT}%`;
-const STORAGE_USAGE_ALERT_COLOR = "#facc15";
 
 function statusFromHeartbeat(tsSec, offlineAfter = 300) {
   if (!tsSec) return "Offline";
@@ -797,11 +800,6 @@ export async function loadDeviceSummaryPageData(request, routeDeviceId) {
     progress.finalize();
   }
 }
-
-const isStorageUsageAlert = (usageValue) =>
-  typeof usageValue === "number" &&
-  !Number.isNaN(usageValue) &&
-  usageValue > STORAGE_USAGE_ALERT_THRESHOLD_PCT;
 
 const formatHostnameForDisplay = (value) => {
   const text = typeof value === "string" ? value.trim() : value == null ? "" : String(value).trim();
@@ -3134,7 +3132,7 @@ export default function DeviceSummary() {
       return {
         id: `${d.drive || idx}`,
         driveLabel: String(d.drive || "").replace("\\\\", ""),
-        disk_type: d.disk_type || "Fixed Disk",
+        disk_type: d.disk_type || d.type || "Fixed Disk",
         total,
         used: usedBytes,
         freeBytes,
@@ -3194,7 +3192,7 @@ export default function DeviceSummary() {
         sortable: false,
         filter: false,
         cellRenderer: (params) => {
-          if (!isStorageUsageAlert(params?.data?.usage)) return "";
+          if (!isStorageUsageAlert(params?.data)) return "";
           return (
             <Box
               component="span"
@@ -3245,7 +3243,7 @@ export default function DeviceSummary() {
 
   const hardwareOverview = useMemo(() => {
     const storageCritical = storageRows.filter(
-      (row) => isStorageUsageAlert(row.usage)
+      (row) => isStorageUsageAlert(row)
     ).length;
     const installedMemory = memoryRows.filter((row) => {
       if (typeof row.capacity === "number") return row.capacity > 0;

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/storageAlerts.js
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/storageAlerts.js
@@ -1,0 +1,23 @@
+export const STORAGE_USAGE_ALERT_THRESHOLD_PCT = 90;
+export const STORAGE_USAGE_ALERT_LABEL = `Usage Exceeding ${STORAGE_USAGE_ALERT_THRESHOLD_PCT}%`;
+export const STORAGE_USAGE_ALERT_COLOR = "#facc15";
+
+function normalizeDiskType(value) {
+  return String(value || "").trim().toLowerCase();
+}
+
+export function isCdRomStorageDevice(storageEntry) {
+  const diskType = normalizeDiskType(storageEntry?.disk_type || storageEntry?.type);
+  if (!diskType) return false;
+  return diskType.includes("cd-rom") || diskType.includes("cdrom") || diskType.includes("cd rom");
+}
+
+export function isStorageUsageAlert(storageEntry) {
+  const usageValue = storageEntry?.usage;
+  return (
+    !isCdRomStorageDevice(storageEntry) &&
+    typeof usageValue === "number" &&
+    !Number.isNaN(usageValue) &&
+    usageValue > STORAGE_USAGE_ALERT_THRESHOLD_PCT
+  );
+}

--- a/Docs/Using the Platform/device-auditing.md
+++ b/Docs/Using the Platform/device-auditing.md
@@ -19,6 +19,7 @@ Device Auditing is the normal starting point for understanding a managed endpoin
 Device Summary collects the last-known inventory and action tabs for one endpoint.
 
 - `Device Summary` shows high-level identity, OS, hardware, network, current user, uptime, and description.
+- Storage usage warnings ignore `CD-ROM` drives so optical media does not count as disk pressure.
 - `Installed Software` shows software inventory and software actions.
 - `Services`, `Processes`, `File Management`, `Remote Shell`, and `Remote Desktop` are live operations tabs.
 - `Activity History` shows quick job and automation output tied to the device.

--- a/Docs/Using the Platform/watchdogs.md
+++ b/Docs/Using the Platform/watchdogs.md
@@ -30,7 +30,7 @@ Scope controls which sites the watchdog can apply to. Targets choose devices ins
 
 ## Build Rules
 
-Watchdog rules can evaluate device offline state, storage usage, service state, agent role health, CPU, memory, uptime, reboot/change detection, sessions, processes, software presence/version, and agent version status.
+Watchdog rules can evaluate device offline state, storage usage, service state, agent role health, CPU, memory, uptime, reboot/change detection, sessions, processes, software presence/version, and agent version status. Storage usage checks ignore `CD-ROM` drives so mounted optical media does not create disk space incidents.
 
 Use `all` when every condition must match. Use `any` when one condition should open the incident.
 


### PR DESCRIPTION
Closes #294

ISSUE GOAL:
- Expected behavior: disk space usage alerting ignores CD-ROM drives so optical media does not create alert-list incidents or Device Summary storage warning badges.
- Affected subsystem: Engine watchdog storage evaluation and WebUI Device Summary storage table.
- Relevant docs: `Docs/Using the Platform/alerts.md`, `Docs/Using the Platform/watchdogs.md`, `Docs/Using the Platform/device-auditing.md`, `Docs/Reference/ui-and-notifications.md`, `Docs/Reference/Unit_Testing.md`.
- Validation: targeted Go watchdog tests; WebUI Vitest lane requires runtime cache/Node in this environment.
- Docs/SBOM/debt impact: docs updated for operator behavior; no SBOM or technical-debt issue needed.

VALIDATION:
- PASS: `/opt/Borealis/Dependencies/Go/go1.22.12/bin/go test ./cmd/api-backend -run 'TestWatchdogPreview.*StorageUsage' -count=1` from `Data/Engine/Containers/api-backend`.
- PASS: `/opt/Borealis/Dependencies/Go/go1.22.12/bin/go test ./cmd/api-backend -count=1` from `Data/Engine/Containers/api-backend`.
- BLOCKED: `./Engine_Unit_Tests.sh --domain watchdogs` returned status 2 because no `Data/Engine/Unit_Tests/test_watchdogs_api.py` exists in this checkout.
- BLOCKED: `./Engine_Unit_Tests.sh --domain webui` returned status 2 because `Engine/Services/webui-frontend/cache/web-interface/Unit_Tests` is missing. Redeploy Engine/runtime WebUI cache, then rerun this command.