### PR TITLE
issue/remote-editors-clean-url-state

### DIFF
--- a/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/Devices/Tabs/Device_Summary.workspaceSearch.test.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/Devices/Tabs/Device_Summary.workspaceSearch.test.jsx
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  createDeviceWorkspaceSearch,
+  pruneDeviceWorkspaceContextParams,
+} from "@/Devices/Tabs/deviceWorkspaceUrlState.js";
+
+describe("Device Summary workspace URL state", () => {
+  it("keeps file working directory and removes registry path in file workspace", () => {
+    expect(
+      createDeviceWorkspaceSearch(
+        "?tab=remote_ops&view=registry&registry_path=HKLM%5CSOFTWARE&working_directory=C%3A%5CUsers&debugSummaryGrid=1",
+        "remote_ops",
+        "files"
+      )
+    ).toBe("?tab=remote_ops&view=files&working_directory=C%3A%5CUsers&debugSummaryGrid=1");
+  });
+
+  it("keeps registry path and removes file working directory in registry workspace", () => {
+    expect(
+      createDeviceWorkspaceSearch(
+        "?tab=remote_ops&view=files&working_directory=C%3A%5CUsers&registry_path=HKLM%5CSOFTWARE",
+        "remote_ops",
+        "registry"
+      )
+    ).toBe("?tab=remote_ops&view=registry&registry_path=HKLM%5CSOFTWARE");
+  });
+
+  it("removes editor paths outside file and registry workspaces", () => {
+    expect(
+      createDeviceWorkspaceSearch(
+        "?tab=remote_ops&view=files&working_directory=C%3A%5CUsers&registry_path=HKLM%5CSOFTWARE",
+        "remote_ops",
+        "shell"
+      )
+    ).toBe("?tab=remote_ops&view=shell");
+
+    expect(
+      createDeviceWorkspaceSearch(
+        "?tab=remote_ops&view=registry&working_directory=C%3A%5CUsers&registry_path=HKLM%5CSOFTWARE",
+        "inventory",
+        "software"
+      )
+    ).toBe("?tab=inventory&view=software");
+  });
+
+  it("cleans direct URL params against current workspace context", () => {
+    const fileParams = new URLSearchParams(
+      "tab=remote_ops&view=files&registry_path=HKLM%5CSOFTWARE&working_directory=C%3A%5CUsers"
+    );
+    pruneDeviceWorkspaceContextParams(fileParams, "remote_ops", "files");
+    expect(fileParams.toString()).toBe("tab=remote_ops&view=files&working_directory=C%3A%5CUsers");
+
+    const registryParams = new URLSearchParams(
+      "tab=remote_ops&view=registry&registry_path=HKLM%5CSOFTWARE&working_directory=C%3A%5CUsers"
+    );
+    pruneDeviceWorkspaceContextParams(registryParams, "remote_ops", "registry");
+    expect(registryParams.toString()).toBe("tab=remote_ops&view=registry&registry_path=HKLM%5CSOFTWARE");
+  });
+});

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Device_Summary.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Device_Summary.jsx
@@ -77,6 +77,14 @@ import {
   STORAGE_USAGE_ALERT_THRESHOLD_PCT,
   isStorageUsageAlert,
 } from "./storageAlerts.js";
+import {
+  LEGACY_TAB_TO_WORKSPACE,
+  WORKSPACE_KEYS,
+  createDeviceWorkspaceSearch,
+  normalizeWorkspaceKey,
+  normalizeWorkspaceView,
+  pruneDeviceWorkspaceContextParams,
+} from "./deviceWorkspaceUrlState.js";
 
 const TUNNEL_STATUS_POLL_INTERVAL_MS = 15000;
 const DEVICE_DETAILS_POLL_INTERVAL_MS = 60000;
@@ -286,70 +294,6 @@ const WORKSPACES = [
   { key: "history", label: "History", icon: ListAltRoundedIcon },
   { key: "config", label: "Metadata", icon: LabelRoundedIcon },
 ];
-const WORKSPACE_KEYS = new Set(WORKSPACES.map((workspace) => workspace.key));
-const WORKSPACE_VIEW_DEFAULTS = Object.freeze({
-  remote_ops: "shell",
-  inventory: "summary",
-  config: "metadata",
-});
-const WORKSPACE_VIEW_OPTIONS = Object.freeze({
-  remote_ops: ["shell", "files", "registry", "processes", "services"],
-  inventory: ["summary", "software"],
-  config: ["metadata"],
-});
-const LEGACY_TAB_TO_WORKSPACE = Object.freeze({
-  command: { workspace: "inventory", view: "summary" },
-  device_summary: { workspace: "inventory", view: "summary" },
-  summary: { workspace: "inventory", view: "summary" },
-  file_management: { workspace: "remote_ops", view: "files" },
-  registry: { workspace: "remote_ops", view: "registry" },
-  registry_editor: { workspace: "remote_ops", view: "registry" },
-  installed_software: { workspace: "inventory", view: "software" },
-  software: { workspace: "inventory", view: "software" },
-  metadata_fields: { workspace: "config", view: "metadata" },
-  metadata: { workspace: "config", view: "metadata" },
-  services: { workspace: "remote_ops", view: "services" },
-  process_management: { workspace: "remote_ops", view: "processes" },
-  processes: { workspace: "remote_ops", view: "processes" },
-  watchdogs: { workspace: "protection" },
-  activity_history: { workspace: "history" },
-  activity: { workspace: "history" },
-  remote_shell: { workspace: "remote_ops", view: "shell" },
-  shell: { workspace: "remote_ops", view: "shell" },
-  agent_health: { workspace: "inventory", view: "summary" },
-  health: { workspace: "inventory", view: "summary" },
-});
-
-const normalizeWorkspaceKey = (value, fallback = "inventory") => {
-  const normalized = String(value || "").trim().toLowerCase();
-  if (WORKSPACE_KEYS.has(normalized)) return normalized;
-  const legacyTarget = LEGACY_TAB_TO_WORKSPACE[normalized];
-  if (legacyTarget?.workspace && WORKSPACE_KEYS.has(legacyTarget.workspace)) {
-    return legacyTarget.workspace;
-  }
-  return fallback;
-};
-
-const normalizeWorkspaceView = (workspaceKey, value) => {
-  const allowedViews = WORKSPACE_VIEW_OPTIONS[workspaceKey] || [];
-  const fallback = WORKSPACE_VIEW_DEFAULTS[workspaceKey] || "";
-  const normalized = String(value || "").trim().toLowerCase();
-  if (allowedViews.includes(normalized)) return normalized;
-  return fallback;
-};
-
-const createDeviceWorkspaceSearch = (currentSearch, workspaceKey, viewKey = "") => {
-  const params = new URLSearchParams(currentSearch || "");
-  const normalizedWorkspace = normalizeWorkspaceKey(workspaceKey);
-  const normalizedView = normalizeWorkspaceView(normalizedWorkspace, viewKey);
-  params.set("tab", normalizedWorkspace);
-  if (normalizedView) {
-    params.set("view", normalizedView);
-  } else {
-    params.delete("view");
-  }
-  return params.toString() ? `?${params.toString()}` : "";
-};
 
 const resolveDeviceId = (device) =>
   device?.agent_guid ||
@@ -1472,12 +1416,14 @@ export default function DeviceSummary() {
   );
   useEffect(() => {
     const params = new URLSearchParams(location.search);
+    const originalSearch = params.toString();
     const legacyTab = String(params.get("tab") || "").trim().toLowerCase();
     if (!deviceId) {
       return;
     }
     if (legacyTab === "remote_desktop" || legacyTab === "vnc") {
       params.delete("tab");
+      pruneDeviceWorkspaceContextParams(params, "", "");
       navigate(
         {
           pathname: APP_PATHS.deviceRemoteDesktop(deviceId),
@@ -1488,16 +1434,39 @@ export default function DeviceSummary() {
       return;
     }
     if (!legacyTab || WORKSPACE_KEYS.has(legacyTab)) {
+      const workspace = normalizeWorkspaceKey(legacyTab, "inventory");
+      const view = normalizeWorkspaceView(workspace, String(params.get("view") || "").trim().toLowerCase());
+      pruneDeviceWorkspaceContextParams(params, workspace, view);
+      if (params.toString() !== originalSearch) {
+        navigate(
+          {
+            pathname: location.pathname,
+            search: params.toString() ? `?${params.toString()}` : "",
+          },
+          { replace: true, state: location.state }
+        );
+      }
       return;
     }
     const target = LEGACY_TAB_TO_WORKSPACE[legacyTab];
     if (!target?.workspace) {
+      pruneDeviceWorkspaceContextParams(params, "", "");
+      if (params.toString() !== originalSearch) {
+        navigate(
+          {
+            pathname: location.pathname,
+            search: params.toString() ? `?${params.toString()}` : "",
+          },
+          { replace: true, state: location.state }
+        );
+      }
       return;
     }
     params.set("tab", target.workspace);
     if (target.view && !String(params.get("view") || "").trim()) {
       params.set("view", target.view);
     }
+    pruneDeviceWorkspaceContextParams(params, target.workspace, params.get("view"));
     navigate(
       {
         pathname: location.pathname,

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Remote_File_Management.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Remote_File_Management.jsx
@@ -1678,6 +1678,7 @@ export default function RemoteFileManagement({ device }) {
       return;
     }
     const nextParams = new URLSearchParams(searchParams);
+    nextParams.delete("registry_path");
     if (shouldClear) {
       nextParams.delete("working_directory");
     } else {

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Remote_Registry_Editor.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Remote_Registry_Editor.jsx
@@ -702,6 +702,7 @@ export default function RemoteRegistryEditor({ device }) {
       return;
     }
     const nextParams = new URLSearchParams(searchParams);
+    nextParams.delete("working_directory");
     if (serializedPath) {
       nextParams.set("registry_path", serializedPath);
     } else {

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/deviceWorkspaceUrlState.js
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/deviceWorkspaceUrlState.js
@@ -1,0 +1,92 @@
+const WORKSPACE_KEY_VALUES = Object.freeze(["inventory", "remote_ops", "protection", "history", "config"]);
+
+export const WORKSPACE_KEYS = new Set(WORKSPACE_KEY_VALUES);
+
+export const WORKSPACE_VIEW_DEFAULTS = Object.freeze({
+  remote_ops: "shell",
+  inventory: "summary",
+  config: "metadata",
+});
+
+export const WORKSPACE_VIEW_OPTIONS = Object.freeze({
+  remote_ops: ["shell", "files", "registry", "processes", "services"],
+  inventory: ["summary", "software"],
+  config: ["metadata"],
+});
+
+export const LEGACY_TAB_TO_WORKSPACE = Object.freeze({
+  command: { workspace: "inventory", view: "summary" },
+  device_summary: { workspace: "inventory", view: "summary" },
+  summary: { workspace: "inventory", view: "summary" },
+  file_management: { workspace: "remote_ops", view: "files" },
+  registry: { workspace: "remote_ops", view: "registry" },
+  registry_editor: { workspace: "remote_ops", view: "registry" },
+  installed_software: { workspace: "inventory", view: "software" },
+  software: { workspace: "inventory", view: "software" },
+  metadata_fields: { workspace: "config", view: "metadata" },
+  metadata: { workspace: "config", view: "metadata" },
+  services: { workspace: "remote_ops", view: "services" },
+  process_management: { workspace: "remote_ops", view: "processes" },
+  processes: { workspace: "remote_ops", view: "processes" },
+  watchdogs: { workspace: "protection" },
+  activity_history: { workspace: "history" },
+  activity: { workspace: "history" },
+  remote_shell: { workspace: "remote_ops", view: "shell" },
+  shell: { workspace: "remote_ops", view: "shell" },
+  agent_health: { workspace: "inventory", view: "summary" },
+  health: { workspace: "inventory", view: "summary" },
+});
+
+const REMOTE_OPS_CONTEXT_PARAMS = Object.freeze(["working_directory", "registry_path"]);
+const EMPTY_CONTEXT_PARAMS = new Set();
+const REMOTE_OPS_CONTEXT_PARAMS_BY_VIEW = Object.freeze({
+  files: new Set(["working_directory"]),
+  registry: new Set(["registry_path"]),
+});
+
+export const normalizeWorkspaceKey = (value, fallback = "inventory") => {
+  const normalized = String(value || "").trim().toLowerCase();
+  if (WORKSPACE_KEYS.has(normalized)) return normalized;
+  const legacyTarget = LEGACY_TAB_TO_WORKSPACE[normalized];
+  if (legacyTarget?.workspace && WORKSPACE_KEYS.has(legacyTarget.workspace)) {
+    return legacyTarget.workspace;
+  }
+  return fallback;
+};
+
+export const normalizeWorkspaceView = (workspaceKey, value) => {
+  const allowedViews = WORKSPACE_VIEW_OPTIONS[workspaceKey] || [];
+  const fallback = WORKSPACE_VIEW_DEFAULTS[workspaceKey] || "";
+  const normalized = String(value || "").trim().toLowerCase();
+  if (allowedViews.includes(normalized)) return normalized;
+  return fallback;
+};
+
+export const pruneDeviceWorkspaceContextParams = (params, workspaceKey, viewKey = "") => {
+  const normalizedWorkspace = normalizeWorkspaceKey(workspaceKey);
+  const normalizedView = normalizeWorkspaceView(normalizedWorkspace, viewKey);
+  const retainedParams =
+    normalizedWorkspace === "remote_ops"
+      ? REMOTE_OPS_CONTEXT_PARAMS_BY_VIEW[normalizedView] || EMPTY_CONTEXT_PARAMS
+      : EMPTY_CONTEXT_PARAMS;
+  REMOTE_OPS_CONTEXT_PARAMS.forEach((paramKey) => {
+    if (!retainedParams.has(paramKey)) {
+      params.delete(paramKey);
+    }
+  });
+  return params;
+};
+
+export const createDeviceWorkspaceSearch = (currentSearch, workspaceKey, viewKey = "") => {
+  const params = new URLSearchParams(currentSearch || "");
+  const normalizedWorkspace = normalizeWorkspaceKey(workspaceKey);
+  const normalizedView = normalizeWorkspaceView(normalizedWorkspace, viewKey);
+  params.set("tab", normalizedWorkspace);
+  if (normalizedView) {
+    params.set("view", normalizedView);
+  } else {
+    params.delete("view");
+  }
+  pruneDeviceWorkspaceContextParams(params, normalizedWorkspace, normalizedView);
+  return params.toString() ? `?${params.toString()}` : "";
+};

--- a/Docs/Reference/ui-and-notifications.md
+++ b/Docs/Reference/ui-and-notifications.md
@@ -85,6 +85,7 @@ Treat this document as the single source of truth for Borealis WebUI design rule
   - lightweight inline text editing should open in a large glass dialog that mirrors the StdOut / StdErr viewer shell: path subtitle on the left, `Save` and `Close` actions on the top-right, and a monospace syntax-highlighted editor surface sized for quick inline edits rather than full IDE workflows
   - duplicate upload conflicts should use an explorer-style `Replace or Skip Files` decision dialog rather than a generic confirmation modal
 - Registry browser surfaces should follow the same dense backend-tool shape as File Management: URL-sync the current registry path with `registry_path`, keep hive navigation explicit, and require typed path confirmation before key deletion.
+- Workspace-specific path query keys are scoped to the active browser. Leaving File Management clears `working_directory`, leaving Registry clears `registry_path`, and switching to any other Device Summary area clears both path keys.
 - Real-time refresh uses `watchdog_incidents_changed` and `device_watchdogs_changed` on the shared `window.BorealisSocket`.
 
 ??? example "Detailed Codex Breakdown"


### PR DESCRIPTION
## Summary

- Scoped Device Summary remote editor URL params so `working_directory` only persists in File Management and `registry_path` only persists in Registry.
- Added parent route cleanup for direct URLs, workspace switches, legacy tab redirects, and non-editor Device Summary areas.
- Added mirrored child-editor cleanup to prevent stale file/registry params from being reintroduced during editor URL sync.
- Documented URL path param scoping in the WebUI guidance.

## Validation

- `git diff --check` passed.
- `git diff --cached --check` passed.
- `./Engine_Unit_Tests.sh --domain webui` attempted, but blocked because runtime WebUI unit test cache is missing at `Engine/Services/webui-frontend/cache/web-interface/Unit_Tests`. Script says redeploy Engine so container-owned WebUI source is staged, then rerun.

Closes #298