### PR TITLE
issue/optimize-webui-frontend-build

### DIFF
--- a/Data/Engine/Containers/webui-frontend/Dockerfile
+++ b/Data/Engine/Containers/webui-frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-bookworm-slim AS base
+FROM node:22-alpine AS deps
 
 ENV NODE_ENV=development
 
@@ -7,20 +7,45 @@ WORKDIR /opt/Borealis/Data/Engine/web-interface
 COPY data/web-interface/package.json /opt/Borealis/Data/Engine/web-interface/package.json
 RUN npm install --include=dev --no-fund --audit=false
 
+FROM deps AS source
+
 COPY data/web-interface /opt/Borealis/Data/Engine/web-interface
+
+FROM source AS dev
+
 COPY entrypoint.sh /usr/local/bin/borealis-webui-frontend
 COPY healthcheck.js /usr/local/bin/borealis-webui-healthcheck
+COPY static-server.js /usr/local/bin/borealis-webui-static-server.js
 
-RUN chmod +x /usr/local/bin/borealis-webui-frontend /usr/local/bin/borealis-webui-healthcheck
+RUN chmod +x \
+    /usr/local/bin/borealis-webui-frontend \
+    /usr/local/bin/borealis-webui-healthcheck \
+    /usr/local/bin/borealis-webui-static-server.js
 
 EXPOSE 8000
 
-FROM base AS dev
-
 ENTRYPOINT ["/usr/local/bin/borealis-webui-frontend"]
 
-FROM base AS prod
+FROM source AS build
 
 RUN NODE_ENV=production npm run build
+
+FROM node:22-alpine AS prod
+
+ENV NODE_ENV=production
+
+WORKDIR /opt/Borealis/Data/Engine/web-interface
+
+COPY --from=build /opt/Borealis/Data/Engine/web-interface/build /opt/Borealis/Data/Engine/web-interface/build
+COPY entrypoint.sh /usr/local/bin/borealis-webui-frontend
+COPY healthcheck.js /usr/local/bin/borealis-webui-healthcheck
+COPY static-server.js /usr/local/bin/borealis-webui-static-server.js
+
+RUN chmod +x \
+    /usr/local/bin/borealis-webui-frontend \
+    /usr/local/bin/borealis-webui-healthcheck \
+    /usr/local/bin/borealis-webui-static-server.js
+
+EXPOSE 8000
 
 ENTRYPOINT ["/usr/local/bin/borealis-webui-frontend"]

--- a/Data/Engine/Containers/webui-frontend/entrypoint.sh
+++ b/Data/Engine/Containers/webui-frontend/entrypoint.sh
@@ -1,7 +1,5 @@
-#!/usr/bin/env bash
-set -o errexit
-set -o nounset
-set -o pipefail
+#!/bin/sh
+set -eu
 
 cd /opt/Borealis/Data/Engine/web-interface
 
@@ -11,11 +9,11 @@ case "${mode}" in
   dev|developer)
     export NODE_ENV=development
     export BOREALIS_DEV_UI_PROXY_ENABLED=1
-    exec npm run dev -- --host 127.0.0.1 --port "${port}" --strictPort --open false
+    exec npm run dev -- --host 127.0.0.1 --port "${port}" --strictPort --no-open
     ;;
   prod|production|"")
     export NODE_ENV=production
-    exec npm exec -- vite preview --host 127.0.0.1 --port "${port}" --strictPort
+    exec node /usr/local/bin/borealis-webui-static-server.js
     ;;
   *)
     echo "Unsupported BOREALIS_WEBUI_MODE '${mode}'. Use prod or dev." >&2

--- a/Data/Engine/Containers/webui-frontend/static-server.js
+++ b/Data/Engine/Containers/webui-frontend/static-server.js
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const http = require("http");
+const path = require("path");
+const { pipeline } = require("stream");
+
+const host = "127.0.0.1";
+const port = Number.parseInt(process.env.BOREALIS_WEBUI_UPSTREAM_PORT || "8000", 10);
+const root = path.resolve(
+  process.env.BOREALIS_WEBUI_STATIC_ROOT || "/opt/Borealis/Data/Engine/web-interface/build",
+);
+const indexPath = path.join(root, "index.html");
+
+const mimeTypes = new Map([
+  [".css", "text/css; charset=utf-8"],
+  [".gif", "image/gif"],
+  [".html", "text/html; charset=utf-8"],
+  [".ico", "image/x-icon"],
+  [".js", "text/javascript; charset=utf-8"],
+  [".json", "application/json; charset=utf-8"],
+  [".map", "application/json; charset=utf-8"],
+  [".png", "image/png"],
+  [".svg", "image/svg+xml"],
+  [".txt", "text/plain; charset=utf-8"],
+  [".wasm", "application/wasm"],
+  [".woff", "font/woff"],
+  [".woff2", "font/woff2"],
+]);
+
+function sendText(response, statusCode, body) {
+  response.writeHead(statusCode, {
+    "content-length": Buffer.byteLength(body),
+    "content-type": "text/plain; charset=utf-8",
+  });
+  response.end(body);
+}
+
+function resolveRequestPath(pathname) {
+  let decodedPath = "/";
+  try {
+    decodedPath = decodeURIComponent(pathname || "/");
+  } catch {
+    return null;
+  }
+  if (decodedPath.includes("\0")) {
+    return null;
+  }
+
+  const normalizedPath = path.posix.normalize(decodedPath);
+  const relativePath = normalizedPath.replace(/^\/+/, "");
+  const resolvedPath = path.resolve(root, relativePath);
+  if (resolvedPath !== root && !resolvedPath.startsWith(`${root}${path.sep}`)) {
+    return null;
+  }
+  return resolvedPath;
+}
+
+function sendFile(request, response, filePath, cacheable) {
+  const contentType = mimeTypes.get(path.extname(filePath).toLowerCase()) || "application/octet-stream";
+  const headers = {
+    "cache-control": cacheable ? "public, max-age=31536000, immutable" : "no-cache",
+    "content-type": contentType,
+  };
+
+  fs.stat(filePath, (statError, stats) => {
+    if (statError || !stats.isFile()) {
+      sendText(response, 404, "Not Found\n");
+      return;
+    }
+
+    response.writeHead(200, {
+      ...headers,
+      "content-length": stats.size,
+    });
+    if (request.method === "HEAD") {
+      response.end();
+      return;
+    }
+
+    pipeline(fs.createReadStream(filePath), response, (streamError) => {
+      if (streamError && !response.headersSent) {
+        sendText(response, 500, "Internal Server Error\n");
+      }
+    });
+  });
+}
+
+function handleRequest(request, response) {
+  if (!["GET", "HEAD"].includes(request.method || "")) {
+    response.writeHead(405, { allow: "GET, HEAD" });
+    response.end();
+    return;
+  }
+
+  let requestUrl;
+  try {
+    requestUrl = new URL(request.url || "/", `http://${request.headers.host || host}`);
+  } catch {
+    sendText(response, 400, "Bad Request\n");
+    return;
+  }
+  const requestedPath = resolveRequestPath(requestUrl.pathname);
+  if (!requestedPath) {
+    sendText(response, 400, "Bad Request\n");
+    return;
+  }
+
+  fs.stat(requestedPath, (statError, stats) => {
+    if (!statError && stats.isDirectory()) {
+      sendFile(request, response, path.join(requestedPath, "index.html"), false);
+      return;
+    }
+    if (!statError && stats.isFile()) {
+      sendFile(request, response, requestedPath, requestUrl.pathname.startsWith("/assets/"));
+      return;
+    }
+
+    if (path.extname(requestUrl.pathname)) {
+      sendText(response, 404, "Not Found\n");
+      return;
+    }
+    sendFile(request, response, indexPath, false);
+  });
+}
+
+const server = http.createServer(handleRequest);
+server.listen(port, host, () => {
+  console.log(`Borealis WebUI static server listening on http://${host}:${port}`);
+});

--- a/Docs/Engine/deploying-the-engine.md
+++ b/Docs/Engine/deploying-the-engine.md
@@ -84,7 +84,7 @@ During deployment, Borealis will install missing dependencies, prepare runtime c
     ```
 
 ### Docker Storage Cleanup
-Every Engine deploy cleans Docker storage after the stack has reconciled successfully. Borealis prunes inactive Docker images and clears Docker builder cache while keeping one current per-service Buildx cache export under `Engine/Deploy/cache/buildkit/<service>/current` so source-only rebuilds can reuse dependency layers.
+Every Engine deploy cleans Docker storage after the stack has reconciled successfully. Borealis prunes inactive Docker images and clears Docker builder cache while keeping timestamped per-service Buildx cache exports for 7 days under `Engine/Deploy/cache/buildkit/<service>/`. Each retained export is a complete Buildx cache snapshot from that service build, so source-only rebuilds can reuse dependency layers without letting cache directories grow forever.
 
 `site-worker` images are handled carefully because the scheduler may need the current image even when no site-worker container is running. Borealis keeps the current site-worker image available and removes stale site-worker tags separately.
 

--- a/Docs/Engine/deploying-the-engine.md
+++ b/Docs/Engine/deploying-the-engine.md
@@ -84,7 +84,7 @@ During deployment, Borealis will install missing dependencies, prepare runtime c
     ```
 
 ### Docker Storage Cleanup
-Every Engine deploy cleans Docker storage after the stack has reconciled successfully. Borealis prunes inactive Docker images, clears Docker builder cache, and removes Engine Buildx cache exports so old image tags and build snapshots do not fill root storage over time.
+Every Engine deploy cleans Docker storage after the stack has reconciled successfully. Borealis prunes inactive Docker images and clears Docker builder cache while keeping one current per-service Buildx cache export under `Engine/Deploy/cache/buildkit/<service>/current` so source-only rebuilds can reuse dependency layers.
 
 `site-worker` images are handled carefully because the scheduler may need the current image even when no site-worker container is running. Borealis keeps the current site-worker image available and removes stale site-worker tags separately.
 

--- a/Docs/Reference/Core Runtimes/Stack_Breakdown.md
+++ b/Docs/Reference/Core Runtimes/Stack_Breakdown.md
@@ -175,9 +175,9 @@ borealis-engine/<service>:sha-<inputhash12>
 ```
 
 Build cache:
-- Docker Buildx uses `Engine/Deploy/cache/buildkit/<service>/` when available.
+- Docker Buildx uses `Engine/Deploy/cache/buildkit/<service>/current` when available.
 - Hosts without usable Buildx fall back to `DOCKER_BUILDKIT=1 docker build`.
-- Successful deploys prune inactive Docker images with `docker image prune -a`, clear Docker builder cache with `docker builder prune --all`, and clear Engine Buildx cache exports under `Engine/Deploy/cache/buildkit/`. Set `BOREALIS_SKIP_DOCKER_PRUNE=1` to skip this cleanup on a shared Docker host.
+- Successful deploys prune inactive Docker images with `docker image prune -a`, clear Docker builder cache with `docker builder prune --all`, and trim Engine Buildx cache exports so only each known service's `current` cache remains under `Engine/Deploy/cache/buildkit/`. Set `BOREALIS_SKIP_DOCKER_PRUNE=1` to skip this cleanup on a shared Docker host.
 - `api-backend` keeps repo-root build context because it packages `Data/Agent` and `Agent.exe`.
 - `api-backend` uses an Alpine runtime image with the Go API binary plus `ca-certificates`, `git`, and `tzdata`. WireGuard command execution belongs to `wireguard-tunnel` through its control socket.
 - `job-scheduler` uses an Alpine runtime image with the Go scheduler mode, Bash/Python for detached `Engine.sh` service-action helpers, Docker CLI, Docker Compose plugin, `ca-certificates`, and `tzdata`.
@@ -190,7 +190,7 @@ Build cache:
 - `compose.env` carries image tags, stable env-file paths, deployment profile metadata, DB pool values, PostgreSQL startup settings, and profile-managed site-worker scheduled work-item slots.
 - `runtime.env` is shared by API, PostgreSQL, guacd, and WireGuard. It intentionally excludes image tag variables and keeps stable production WebUI defaults so one image or mode change does not mutate every container's environment.
 - `webui-frontend.env` overrides shared runtime settings with the requested `BOREALIS_WEBUI_MODE`. Switching `prod`/`dev` should recreate only `webui-frontend` when all containers are already running.
-- Traefik always routes the WebUI service to `127.0.0.1:8000`; production preview and Vite HMR both bind that same loopback port.
+- Traefik always routes the WebUI service to `127.0.0.1:8000`; the production static server and Vite HMR both bind that same loopback port.
 
 Deploy output:
 - Terminal output uses compact service status lines such as `<timestamp> <service>: [Already Up-to-Date]` or `<timestamp> <service>: [(Re)Building]`.
@@ -200,8 +200,8 @@ Deploy output:
 - Full Docker build detail remains in `Engine/Deploy/build.log`.
 
 WebUI targets:
-- Production builds Docker target `prod`, which runs `npm run build`.
-- Dev builds Docker target `dev`, which keeps Vite HMR available and skips production static build work.
+- Production builds Docker target `prod`, which runs `npm run build` in a build stage, copies only the static `build/` output into the runtime stage, and serves it without `node_modules` or Vite preview.
+- Dev builds Docker target `dev`, which keeps Vite HMR available with the full Node dependency tree and skips production static build work.
 - Dev HMR source edits should happen under `Engine/Services/webui-frontend/data/web-interface/`; Compose bind-mounts that runtime copy into the WebUI container.
 
 ## Runtime Start Order
@@ -605,7 +605,7 @@ If remote shell, Ansible, or tunnel-backed operations fail:
 
     Build cache, when Docker Buildx is available, lives under:
     ```text
-    Engine/Deploy/cache/buildkit/<service>/
+    Engine/Deploy/cache/buildkit/<service>/current
     ```
 
     Operators should treat `Engine/` as generated runtime state. Edit committed source under `Data/Engine/Containers/`, then redeploy through `Engine.sh`. For live WebUI dev/HMR work, edit the seeded runtime WebUI source under `Engine/Services/webui-frontend/data/web-interface/`.

--- a/Docs/Reference/Core Runtimes/Stack_Breakdown.md
+++ b/Docs/Reference/Core Runtimes/Stack_Breakdown.md
@@ -150,7 +150,7 @@ Engine/Services/webui-frontend/data/web-interface/vite.config.mts -> /opt/Boreal
 16. Run scoped Compose `up -d --no-deps --no-build <service...>` when only service images changed or when switching prod/dev WebUI mode.
 17. Run full Compose `up -d --no-build` when compose config, shared runtime env, or container state requires it.
 18. Write `Engine/Deploy/deploy-manifest.json`.
-19. Prune inactive Docker images, Docker builder cache, and Engine Buildx cache exports after successful reconciliation.
+19. Prune inactive Docker images, Docker builder cache, and Engine Buildx cache exports older than 7 days after successful reconciliation.
 
 Build order follows `Engine.sh` local build roles. `docker-proxy` is an external image and is not locally built.
 ```text
@@ -175,9 +175,9 @@ borealis-engine/<service>:sha-<inputhash12>
 ```
 
 Build cache:
-- Docker Buildx uses `Engine/Deploy/cache/buildkit/<service>/current` when available.
+- Docker Buildx uses retained `Engine/Deploy/cache/buildkit/<service>/<YYYYMMDDTHHMMSSZ>-<inputhash12>` exports when available.
 - Hosts without usable Buildx fall back to `DOCKER_BUILDKIT=1 docker build`.
-- Successful deploys prune inactive Docker images with `docker image prune -a`, clear Docker builder cache with `docker builder prune --all`, and trim Engine Buildx cache exports so only each known service's `current` cache remains under `Engine/Deploy/cache/buildkit/`. Set `BOREALIS_SKIP_DOCKER_PRUNE=1` to skip this cleanup on a shared Docker host.
+- Successful Buildx builds write a full `mode=max` cache export for the service, and successful deploys prune inactive Docker images with `docker image prune -a`, clear Docker builder cache with `docker builder prune --all`, and delete whole Engine Buildx cache export directories older than 7 days. Set `BOREALIS_SKIP_DOCKER_PRUNE=1` to skip this cleanup on a shared Docker host.
 - `api-backend` keeps repo-root build context because it packages `Data/Agent` and `Agent.exe`.
 - `api-backend` uses an Alpine runtime image with the Go API binary plus `ca-certificates`, `git`, and `tzdata`. WireGuard command execution belongs to `wireguard-tunnel` through its control socket.
 - `job-scheduler` uses an Alpine runtime image with the Go scheduler mode, Bash/Python for detached `Engine.sh` service-action helpers, Docker CLI, Docker Compose plugin, `ca-certificates`, and `tzdata`.
@@ -605,7 +605,7 @@ If remote shell, Ansible, or tunnel-backed operations fail:
 
     Build cache, when Docker Buildx is available, lives under:
     ```text
-    Engine/Deploy/cache/buildkit/<service>/current
+    Engine/Deploy/cache/buildkit/<service>/<YYYYMMDDTHHMMSSZ>-<inputhash12>
     ```
 
     Operators should treat `Engine/` as generated runtime state. Edit committed source under `Data/Engine/Containers/`, then redeploy through `Engine.sh`. For live WebUI dev/HMR work, edit the seeded runtime WebUI source under `Engine/Services/webui-frontend/data/web-interface/`.

--- a/Docs/Reference/Core Runtimes/engine-runtime.md
+++ b/Docs/Reference/Core Runtimes/engine-runtime.md
@@ -52,8 +52,8 @@ Describe the Borealis Engine runtime, its services, configuration, and operation
     - `job-scheduler` uses `alpine:3.24` with Bash, Python 3, Docker CLI, Docker Compose plugin, `ca-certificates`, and `tzdata`; Docker Buildx is not installed in this container.
     - Go backup/restore routes live in `Data/Engine/Containers/api-backend/cmd/api-backend/server_backup.go` and snapshot allow-listed PostgreSQL tables plus allow-listed Engine secret/config files.
     - Mode inputs affect image hashes only for services with mode-specific build targets. Today that means `webui-frontend`; DB, guacd, WireGuard, Traefik, and API images do not rebuild merely because the operator switches `prod`/`dev`.
-    - Docker Buildx cache is stored under `Engine/Deploy/cache/buildkit/<service>/` when usable; plain Docker build remains the fallback.
-    - After successful deploy or service rebuild reconciliation, `Engine.sh` prunes inactive Docker images, Docker builder cache, and Engine Buildx cache exports. Set `BOREALIS_SKIP_DOCKER_PRUNE=1` to skip cleanup.
+    - Docker Buildx cache is stored under `Engine/Deploy/cache/buildkit/<service>/current` when usable; plain Docker build remains the fallback.
+    - After successful deploy or service rebuild reconciliation, `Engine.sh` prunes inactive Docker images, clears Docker builder cache, and trims Engine Buildx cache exports so each known service keeps only its current cache. Set `BOREALIS_SKIP_DOCKER_PRUNE=1` to skip cleanup.
     - The current `site-worker` image is preserved even when no site-worker container is running. Stale site-worker tags are removed separately so scheduler-launched workers can still start after cleanup.
     - Deploy output uses compact colored service status lines in interactive terminals; set `NO_COLOR=1` to force plain text.
     - No-op redeploys reuse existing image tags and skip Compose when deploy manifest, runtime env, image hashes, and container state already match.
@@ -113,6 +113,7 @@ Describe the Borealis Engine runtime, its services, configuration, and operation
     ### WebUI hosting and dev mode
     - Production UI is served by the `webui-frontend` container from its built static output.
     - Dev UI runs Vite HMR behind `traefik-edge`.
+    - The WebUI image uses Node Alpine stages. The production target copies only built static output plus the dependency-free static server into the final image, while the development target keeps Vite and `node_modules` for HMR.
     - The API backend sets `BOREALIS_WEBUI_EXTERNAL=1` in container mode so `Data.Engine.bootstrapper` skips Engine-side WebUI staging/build.
     - The SPA fallback in `Data/Engine/Containers/api-backend/data/services/WebUI/__init__.py` remains for tests and non-container execution.
 

--- a/Docs/Reference/Core Runtimes/engine-runtime.md
+++ b/Docs/Reference/Core Runtimes/engine-runtime.md
@@ -52,8 +52,8 @@ Describe the Borealis Engine runtime, its services, configuration, and operation
     - `job-scheduler` uses `alpine:3.24` with Bash, Python 3, Docker CLI, Docker Compose plugin, `ca-certificates`, and `tzdata`; Docker Buildx is not installed in this container.
     - Go backup/restore routes live in `Data/Engine/Containers/api-backend/cmd/api-backend/server_backup.go` and snapshot allow-listed PostgreSQL tables plus allow-listed Engine secret/config files.
     - Mode inputs affect image hashes only for services with mode-specific build targets. Today that means `webui-frontend`; DB, guacd, WireGuard, Traefik, and API images do not rebuild merely because the operator switches `prod`/`dev`.
-    - Docker Buildx cache is stored under `Engine/Deploy/cache/buildkit/<service>/current` when usable; plain Docker build remains the fallback.
-    - After successful deploy or service rebuild reconciliation, `Engine.sh` prunes inactive Docker images, clears Docker builder cache, and trims Engine Buildx cache exports so each known service keeps only its current cache. Set `BOREALIS_SKIP_DOCKER_PRUNE=1` to skip cleanup.
+    - Docker Buildx cache is stored as timestamped full `mode=max` exports under `Engine/Deploy/cache/buildkit/<service>/<YYYYMMDDTHHMMSSZ>-<inputhash12>` when usable; plain Docker build remains the fallback.
+    - After successful deploy or service rebuild reconciliation, `Engine.sh` prunes inactive Docker images, clears Docker builder cache, and deletes whole Engine Buildx cache export directories older than 7 days. Set `BOREALIS_SKIP_DOCKER_PRUNE=1` to skip cleanup.
     - The current `site-worker` image is preserved even when no site-worker container is running. Stale site-worker tags are removed separately so scheduler-launched workers can still start after cleanup.
     - Deploy output uses compact colored service status lines in interactive terminals; set `NO_COLOR=1` to force plain text.
     - No-op redeploys reuse existing image tags and skip Compose when deploy manifest, runtime env, image hashes, and container state already match.

--- a/Docs/Reference/SBOM.md
+++ b/Docs/Reference/SBOM.md
@@ -102,7 +102,7 @@ Use `shared-engine` for dependencies that support host deployment, build orchest
 | site-worker | WireGuard tools | [GPL-2.0-only](https://spdx.org/licenses/GPL-2.0-only.html) |
 | traefik-edge | Traefik container image (`traefik:v3.3`) | [MIT](https://github.com/traefik/traefik/blob/master/LICENSE.md) |
 | traefik-edge | Traefik (Borealis-managed local HTTPS edge and ACME client) | [MIT](https://github.com/traefik/traefik/blob/master/LICENSE.md) |
-| webui-frontend | Node.js container base image (`node:22-bookworm-slim`) | [MIT plus Debian package licenses](https://github.com/nodejs/node/blob/main/LICENSE) |
+| webui-frontend | Node.js container base image (`node:22-alpine`) | [MIT plus Alpine package licenses](https://github.com/nodejs/node/blob/main/LICENSE) |
 | webui-frontend | @emotion/react | [MIT](https://spdx.org/licenses/MIT.html) |
 | webui-frontend | @emotion/styled | [MIT](https://spdx.org/licenses/MIT.html) |
 | webui-frontend | @fortawesome/fontawesome-free | [CC-BY-4.0 AND OFL-1.1 AND MIT](https://github.com/FortAwesome/Font-Awesome/blob/7.x/LICENSE.txt) |

--- a/Engine.sh
+++ b/Engine.sh
@@ -1577,11 +1577,7 @@ prune_expired_engine_build_cache_exports() {
     printf '[%s] Failed to prune one or more Engine Buildx cache exports under %s\n' "$(date +%FT%T)" "${cache_root}" >> "${BUILD_LOG}"
     return 1
   fi
-  if ((removed > 0)); then
-    log_status "Docker cleanup" "Pruned ${removed} Engine build cache export(s)" "${C_GREEN}"
-  else
-    log_status "Docker cleanup" "Retained ${retained} Engine build cache export(s)" "${C_DIM}"
-  fi
+  log_status "Docker cleanup" "Engine build cache removed=${removed} retained=${retained}" "${C_GREEN}"
   printf '[%s] Engine Buildx cache retention complete: removed=%d retained=%d\n' "$(date +%FT%T)" "${removed}" "${retained}" >> "${BUILD_LOG}"
   return 0
 }

--- a/Engine.sh
+++ b/Engine.sh
@@ -1456,13 +1456,37 @@ restore_required_engine_images() {
   done
 }
 
-prune_engine_build_cache_exports() {
+trim_engine_build_cache_exports() {
   local cache_root="${DEPLOY_DIR}/cache/buildkit"
   [[ -d "${cache_root}" ]] || return 0
-  log_status "Docker cleanup" "Clearing Engine build cache" "${C_YELLOW}"
-  if ! find "${cache_root}" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} + >> "${BUILD_LOG}" 2>&1; then
-    log_status "Docker cleanup" "Engine build cache cleanup failed" "${C_RED}"
-    printf '[%s] Failed to clear Engine Buildx cache export directory %s\n' "$(date +%FT%T)" "${cache_root}" >> "${BUILD_LOG}"
+  log_status "Docker cleanup" "Trimming Engine build cache" "${C_YELLOW}"
+  local cleanup_failed=0
+  local cache_dir=""
+  for cache_dir in "${cache_root}"/*; do
+    [[ -d "${cache_dir}" ]] || continue
+    local cache_name
+    cache_name="$(basename "${cache_dir}")"
+    local known_service=0
+    local service=""
+    for service in "${BUILD_ROLES[@]}"; do
+      if [[ "${cache_name}" == "${service}" ]]; then
+        known_service=1
+        break
+      fi
+    done
+    if [[ "${known_service}" -ne 1 ]]; then
+      if ! rm -rf "${cache_dir}" >> "${BUILD_LOG}" 2>&1; then
+        cleanup_failed=1
+      fi
+      continue
+    fi
+    if ! find "${cache_dir}" -mindepth 1 -maxdepth 1 ! -name current -exec rm -rf -- {} + >> "${BUILD_LOG}" 2>&1; then
+      cleanup_failed=1
+    fi
+  done
+  if [[ "${cleanup_failed}" -ne 0 ]]; then
+    log_status "Docker cleanup" "Engine build cache trim failed" "${C_RED}"
+    printf '[%s] Failed to trim Engine Buildx cache export directory %s\n' "$(date +%FT%T)" "${cache_root}" >> "${BUILD_LOG}"
   fi
 }
 
@@ -1490,7 +1514,7 @@ prune_engine_docker_storage() {
     log_status "Docker cleanup" "Builder prune failed" "${C_RED}"
   fi
 
-  prune_engine_build_cache_exports
+  trim_engine_build_cache_exports
 
   if [[ "${cleanup_failed}" -eq 0 ]]; then
     log_status "Docker cleanup" "Complete" "${C_GREEN}"

--- a/Engine.sh
+++ b/Engine.sh
@@ -27,6 +27,7 @@ WEBUI_ENV="${DEPLOY_DIR}/webui-frontend.env"
 IMAGE_MANIFEST="${DEPLOY_DIR}/image-manifest.json"
 DEPLOY_MANIFEST="${DEPLOY_DIR}/deploy-manifest.json"
 BUILD_LOG="${DEPLOY_DIR}/build.log"
+BUILD_CACHE_RETENTION_DAYS=7
 DEFAULT_INSTALL_DIR="/opt/Borealis"
 DEFAULT_REPO_URL="https://github.com/bunny-lab-io/Borealis.git"
 DEFAULT_REPO_REF="main"
@@ -1281,6 +1282,34 @@ except Exception:
 PY
 }
 
+is_build_role() {
+  local candidate="$1"
+  local service=""
+  for service in "${BUILD_ROLES[@]}"; do
+    if [[ "${candidate}" == "${service}" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+build_cache_export_epoch() {
+  local export_name="$1"
+  local stamp="${export_name%%-*}"
+  [[ "${stamp}" =~ ^[0-9]{8}T[0-9]{6}Z$ ]] || return 1
+  date -u -d "${stamp:0:4}-${stamp:4:2}-${stamp:6:2} ${stamp:9:2}:${stamp:11:2}:${stamp:13:2} UTC" +%s 2>/dev/null
+}
+
+collect_build_cache_exports() {
+  local service="$1"
+  local cache_root="${DEPLOY_DIR}/cache/buildkit/${service}"
+  [[ -d "${cache_root}" ]] || return 0
+  find "${cache_root}" -mindepth 1 -maxdepth 1 -type d -name '????????T??????Z-*' -print | sort
+  if [[ -d "${cache_root}/current" ]]; then
+    printf '%s\n' "${cache_root}/current"
+  fi
+}
+
 prepare_service_build_artifacts() {
   local service="$1"
   case "${service}" in
@@ -1364,19 +1393,35 @@ build_service_image() {
     fi
     if docker buildx version >/dev/null 2>&1; then
       local cache_root="${DEPLOY_DIR}/cache/buildkit/${service}"
-      local cache_current="${cache_root}/current"
-      local cache_next="${cache_root}/next"
       mkdir -p "${cache_root}"
+      local cache_stamp
+      cache_stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+      local cache_export_name="${cache_stamp}-${image_hash:0:12}"
+      local cache_next="${cache_root}/next-${cache_export_name}-$$"
+      local cache_final="${cache_root}/${cache_export_name}"
+      if [[ -e "${cache_final}" ]]; then
+        cache_final="${cache_root}/${cache_export_name}-$$"
+      fi
       rm -rf "${cache_next}"
       local buildx_args=(buildx build --load --progress=plain)
-      if [[ -d "${cache_current}" ]]; then
-        buildx_args+=(--cache-from "type=local,src=${cache_current}")
+      local cache_sources=()
+      mapfile -t cache_sources < <(collect_build_cache_exports "${service}")
+      if ((${#cache_sources[@]} > 0)); then
+        printf '[%s] %s using %d retained Buildx cache export(s)\n' "$(date +%FT%T)" "${service}" "${#cache_sources[@]}"
+        local cache_source=""
+        for cache_source in "${cache_sources[@]}"; do
+          printf '[%s] %s cache-from %s\n' "$(date +%FT%T)" "${service}" "${cache_source}"
+          buildx_args+=(--cache-from "type=local,src=${cache_source}")
+        done
+      else
+        printf '[%s] %s has no retained Buildx cache exports\n' "$(date +%FT%T)" "${service}"
       fi
       buildx_args+=(--cache-to "type=local,dest=${cache_next},mode=max")
       if DOCKER_BUILDKIT=1 docker "${buildx_args[@]}" "${build_args[@]}" "${SCRIPT_DIR}/${context}"; then
         if [[ -d "${cache_next}" ]]; then
-          rm -rf "${cache_current}"
-          mv "${cache_next}" "${cache_current}"
+          rm -rf "${cache_final}"
+          mv "${cache_next}" "${cache_final}"
+          printf '[%s] %s stored full Buildx cache export %s\n' "$(date +%FT%T)" "${service}" "${cache_final}"
         fi
       else
         rm -rf "${cache_next}"
@@ -1456,38 +1501,89 @@ restore_required_engine_images() {
   done
 }
 
-trim_engine_build_cache_exports() {
+prune_expired_engine_build_cache_exports() {
   local cache_root="${DEPLOY_DIR}/cache/buildkit"
   [[ -d "${cache_root}" ]] || return 0
-  log_status "Docker cleanup" "Trimming Engine build cache" "${C_YELLOW}"
+  log_status "Docker cleanup" "Pruning Engine build cache >${BUILD_CACHE_RETENTION_DAYS}d" "${C_YELLOW}"
+  printf '[%s] Pruning Engine Buildx cache exports older than %d days from %s\n' "$(date +%FT%T)" "${BUILD_CACHE_RETENTION_DAYS}" "${cache_root}" >> "${BUILD_LOG}"
+  local cutoff_epoch
+  if ! cutoff_epoch="$(date -u -d "${BUILD_CACHE_RETENTION_DAYS} days ago" +%s 2>/dev/null)"; then
+    log_status "Docker cleanup" "Engine build cache retention failed" "${C_RED}"
+    printf '[%s] Failed to compute Engine Buildx cache retention cutoff\n' "$(date +%FT%T)" >> "${BUILD_LOG}"
+    return 1
+  fi
   local cleanup_failed=0
-  local cache_dir=""
-  for cache_dir in "${cache_root}"/*; do
-    [[ -d "${cache_dir}" ]] || continue
-    local cache_name
-    cache_name="$(basename "${cache_dir}")"
-    local known_service=0
-    local service=""
-    for service in "${BUILD_ROLES[@]}"; do
-      if [[ "${cache_name}" == "${service}" ]]; then
-        known_service=1
-        break
-      fi
-    done
-    if [[ "${known_service}" -ne 1 ]]; then
-      if ! rm -rf "${cache_dir}" >> "${BUILD_LOG}" 2>&1; then
+  local removed=0
+  local retained=0
+  local service_dir=""
+  for service_dir in "${cache_root}"/*; do
+    [[ -d "${service_dir}" ]] || continue
+    local service_name
+    service_name="$(basename "${service_dir}")"
+    if ! is_build_role "${service_name}"; then
+      printf '[%s] Removing unknown Engine Buildx cache service directory %s\n' "$(date +%FT%T)" "${service_dir}" >> "${BUILD_LOG}"
+      if rm -rf "${service_dir}" >> "${BUILD_LOG}" 2>&1; then
+        ((removed += 1))
+      else
         cleanup_failed=1
       fi
       continue
     fi
-    if ! find "${cache_dir}" -mindepth 1 -maxdepth 1 ! -name current -exec rm -rf -- {} + >> "${BUILD_LOG}" 2>&1; then
-      cleanup_failed=1
-    fi
+
+    local cache_dir=""
+    for cache_dir in "${service_dir}"/*; do
+      [[ -d "${cache_dir}" ]] || continue
+      local export_name
+      export_name="$(basename "${cache_dir}")"
+      local should_remove=0
+      local reason=""
+      if [[ "${export_name}" == next-* ]]; then
+        should_remove=1
+        reason="incomplete temporary export"
+      elif [[ "${export_name}" == "current" ]]; then
+        local legacy_epoch
+        legacy_epoch="$(stat -c %Y "${cache_dir}" 2>/dev/null || printf '0')"
+        if ((legacy_epoch < cutoff_epoch)); then
+          should_remove=1
+          reason="legacy current export older than ${BUILD_CACHE_RETENTION_DAYS} days"
+        fi
+      else
+        local export_epoch=""
+        if export_epoch="$(build_cache_export_epoch "${export_name}")"; then
+          if ((export_epoch < cutoff_epoch)); then
+            should_remove=1
+            reason="timestamp older than ${BUILD_CACHE_RETENTION_DAYS} days"
+          fi
+        else
+          should_remove=1
+          reason="unrecognized export name"
+        fi
+      fi
+
+      if [[ "${should_remove}" -eq 1 ]]; then
+        printf '[%s] Removing Engine Buildx cache export %s (%s)\n' "$(date +%FT%T)" "${cache_dir}" "${reason}" >> "${BUILD_LOG}"
+        if rm -rf "${cache_dir}" >> "${BUILD_LOG}" 2>&1; then
+          ((removed += 1))
+        else
+          cleanup_failed=1
+        fi
+      else
+        ((retained += 1))
+      fi
+    done
   done
   if [[ "${cleanup_failed}" -ne 0 ]]; then
-    log_status "Docker cleanup" "Engine build cache trim failed" "${C_RED}"
-    printf '[%s] Failed to trim Engine Buildx cache export directory %s\n' "$(date +%FT%T)" "${cache_root}" >> "${BUILD_LOG}"
+    log_status "Docker cleanup" "Engine build cache prune failed" "${C_RED}"
+    printf '[%s] Failed to prune one or more Engine Buildx cache exports under %s\n' "$(date +%FT%T)" "${cache_root}" >> "${BUILD_LOG}"
+    return 1
   fi
+  if ((removed > 0)); then
+    log_status "Docker cleanup" "Pruned ${removed} Engine build cache export(s)" "${C_GREEN}"
+  else
+    log_status "Docker cleanup" "Retained ${retained} Engine build cache export(s)" "${C_DIM}"
+  fi
+  printf '[%s] Engine Buildx cache retention complete: removed=%d retained=%d\n' "$(date +%FT%T)" "${removed}" "${retained}" >> "${BUILD_LOG}"
+  return 0
 }
 
 prune_engine_docker_storage() {
@@ -1514,7 +1610,9 @@ prune_engine_docker_storage() {
     log_status "Docker cleanup" "Builder prune failed" "${C_RED}"
   fi
 
-  trim_engine_build_cache_exports
+  if ! prune_expired_engine_build_cache_exports; then
+    cleanup_failed=1
+  fi
 
   if [[ "${cleanup_failed}" -eq 0 ]]; then
     log_status "Docker cleanup" "Complete" "${C_GREEN}"


### PR DESCRIPTION
## Goal

Resolve #284 by reducing `webui-frontend` container build time while preserving production static hosting and development Vite HMR behavior, without reintroducing unbounded Buildx cache growth on Engine hosts.

## Changes

- Switched WebUI container stages to `node:22-alpine`.
- Split prod/dev targets so production runs `npm run build` in a build stage, then ships only built static output plus a small dependency-free Node static server.
- Kept the dev target on the full Node dependency tree for Vite HMR.
- Changed dev entrypoint from `--open false` to `--no-open` so Vite does not try to launch `xdg-open` inside the container.
- Changed Engine Buildx cache handling to write timestamped full `mode=max` cache exports per successful service build under `Engine/Deploy/cache/buildkit/<service>/<YYYYMMDDTHHMMSSZ>-<inputhash12>`.
- Engine cleanup now uses all retained exports as cache sources and automatically deletes whole export directories older than 7 days, plus incomplete `next-*` exports and unknown service cache directories.
- Cache retention is visible in CLI output as `removed=<count> retained=<count>` and detailed in `Engine/Deploy/build.log` with exact removed paths and retained counts.
- Updated Engine runtime docs and SBOM for the WebUI Alpine base image and cache behavior.

## Validation

- `bash -n Engine.sh`
- `sh -n Data/Engine/Containers/webui-frontend/entrypoint.sh`
- `docker compose -f Data/Engine/Containers/compose.yaml config`
- `git diff --check`
- `find Data/Engine/Containers/webui-frontend -name '*.py' -o -name '*.pyc' -o -name '__pycache__' -print` returned no files.
- `sudo docker build --target prod ...` passed; cold final prod build measured `1:57` after removing production `node_modules` from final image.
- `sudo docker build --target dev ...` passed; dev target keeps Vite/HMR dependencies.
- Helper-only prod rebuild measured `0:03.97`, confirming script/server edits do not rerun npm install or Vite build.
- Prod smoke: `curl http://127.0.0.1:18080/` returned 200; SPA fallback path returned 200; `borealis-webui-healthcheck` passed.
- Dev smoke: Vite served `http://127.0.0.1:18081/` with 200; `borealis-webui-healthcheck` passed; logs showed no `xdg-open` error.
- WebUI image no-Python checks: no `python`/`python3` binary in prod or dev images; no `.py`, `.pyc`, or `__pycache__` in prod WebUI runtime tree.
- Retention smoke: sourced `Engine.sh` without `main` in a subshell and ran `prune_expired_engine_build_cache_exports` against a disposable temp cache tree. CLI reported `Engine build cache removed=1 retained=1`; build log recorded removal of the 8-day-old export while retaining the current timestamped export.

## Notes

- `./Engine_Unit_Tests.sh --domain webui` was not run because this checkout does not have the documented runtime WebUI test cache at `Engine/Services/webui-frontend/cache/web-interface/node_modules`.