### PR TITLE
issue/clickable-site-connectivity-drilldown

### DIFF
--- a/Data/Engine/Containers/api-backend/cmd/api-backend/devices.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/devices.go
@@ -22,6 +22,12 @@ type deviceListStore interface {
 	listDevices(ctx context.Context, profile operatorProfile, filter deviceListFilter) ([]map[string]any, error)
 }
 
+type agentSocketSnapshot struct {
+	Hostnames map[string]struct{}
+	AgentIDs  map[string]struct{}
+	GUIDs     map[string]struct{}
+}
+
 type deviceDetailStore interface {
 	getDeviceByGUID(ctx context.Context, profile operatorProfile, guid string) (map[string]any, int, error)
 	getDeviceDetails(ctx context.Context, profile operatorProfile, hostname string) (map[string]any, int, error)
@@ -175,8 +181,139 @@ func deviceListHandler(auth *authService) http.HandlerFunc {
 			writeJSON(w, http.StatusInternalServerError, map[string]any{"error": err.Error()})
 			return
 		}
+		enrichDeviceAgentSocketState(ctx, auth, devices)
 		writeJSON(w, http.StatusOK, map[string]any{"devices": devices})
 	}
+}
+
+func enrichDeviceAgentSocketState(ctx context.Context, auth *authService, devices []map[string]any) {
+	if auth == nil || len(devices) == 0 {
+		return
+	}
+	store, ok := auth.store.(*postgresOperatorStore)
+	if !ok || store == nil || store.db == nil {
+		return
+	}
+	siteIDs := make(map[int64]struct{})
+	for _, device := range devices {
+		siteID := coerceInt64(device["site_id"])
+		if siteID > 0 {
+			siteIDs[siteID] = struct{}{}
+		}
+	}
+	if len(siteIDs) == 0 {
+		return
+	}
+	conn, err := store.db.Conn(ctx)
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+
+	snapshots := make(map[int64]agentSocketSnapshot, len(siteIDs))
+	for siteID := range siteIDs {
+		route, err := fetchAgentWorkerRoute(ctx, conn, siteID)
+		if err != nil || route == nil {
+			continue
+		}
+		snapshots[siteID] = fetchWorkerAgentSocketSnapshot(ctx, auth, route)
+	}
+
+	for _, device := range devices {
+		siteID := coerceInt64(device["site_id"])
+		snapshot, ok := snapshots[siteID]
+		registered := ok && snapshot.deviceRegistered(device)
+		device["agent_socket"] = registered
+		if summary, ok := device["summary"].(map[string]any); ok {
+			summary["agent_socket"] = registered
+		}
+		if details, ok := device["details"].(map[string]any); ok {
+			if detailSummary, ok := details["summary"].(map[string]any); ok {
+				detailSummary["agent_socket"] = registered
+			}
+		}
+	}
+}
+
+func fetchWorkerAgentSocketSnapshot(ctx context.Context, auth *authService, route *agentWorkerRoute) agentSocketSnapshot {
+	snapshot := agentSocketSnapshot{
+		Hostnames: map[string]struct{}{},
+		AgentIDs:  map[string]struct{}{},
+		GUIDs:     map[string]struct{}{},
+	}
+	if auth == nil || route == nil {
+		return snapshot
+	}
+	target := workerInternalURL(route, "/agents")
+	if target == "" {
+		return snapshot
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return snapshot
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set(internalTokenHeader, goInternalToken(auth.verifier.secret))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return snapshot
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return snapshot
+	}
+	var payload map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return snapshot
+	}
+	agents, _ := payload["agents"].(map[string]any)
+	for _, raw := range agents {
+		agent, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if mode := strings.ToLower(cleanText(agent["service_mode"])); mode != "" && mode != "system" {
+			continue
+		}
+		if hostname := strings.ToLower(cleanText(agent["hostname"])); hostname != "" {
+			snapshot.Hostnames[hostname] = struct{}{}
+		}
+		if agentID := strings.ToLower(cleanText(agent["agent_id"])); agentID != "" {
+			snapshot.AgentIDs[agentID] = struct{}{}
+		}
+		if guid := normalizeGUID(cleanText(agent["guid"])); guid != "" {
+			snapshot.GUIDs[guid] = struct{}{}
+		}
+	}
+	return snapshot
+}
+
+func (s agentSocketSnapshot) deviceRegistered(device map[string]any) bool {
+	if len(s.Hostnames) == 0 && len(s.AgentIDs) == 0 && len(s.GUIDs) == 0 {
+		return false
+	}
+	if hostname := strings.ToLower(cleanText(device["hostname"])); hostname != "" {
+		if _, ok := s.Hostnames[hostname]; ok {
+			return true
+		}
+	}
+	if agentID := strings.ToLower(cleanText(device["agent_id"])); agentID != "" {
+		if _, ok := s.AgentIDs[agentID]; ok {
+			return true
+		}
+	}
+	guidCandidates := []any{device["agent_guid"], device["guid"]}
+	if summary, ok := device["summary"].(map[string]any); ok {
+		guidCandidates = append(guidCandidates, summary["agent_guid"], summary["guid"])
+	}
+	for _, candidate := range guidCandidates {
+		if guid := normalizeGUID(cleanText(candidate)); guid != "" {
+			if _, ok := s.GUIDs[guid]; ok {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func deviceByGUIDHandler(auth *authService) http.HandlerFunc {

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/Devices/Device_List.connectivityStatus.test.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/Devices/Device_List.connectivityStatus.test.jsx
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDeviceConnectivityStatusFilter,
+  deviceConnectivityStatusFromState,
+  normalizeDeviceConnectivityStatus,
+} from "@/Devices/Device_List.jsx";
+
+describe("device list connectivity status", () => {
+  it("normalizes route status tokens to Device List labels", () => {
+    expect(normalizeDeviceConnectivityStatus("connected")).toBe("Connected");
+    expect(normalizeDeviceConnectivityStatus("DISCONNECTED")).toBe("Disconnected");
+    expect(normalizeDeviceConnectivityStatus("offline")).toBe("Offline");
+  });
+
+  it("maps online heartbeat plus socket state to site list status labels", () => {
+    expect(deviceConnectivityStatusFromState({ status: "Online", agentSocket: true })).toBe("Connected");
+    expect(deviceConnectivityStatusFromState({ status: "Online", agentSocket: false })).toBe("Disconnected");
+    expect(deviceConnectivityStatusFromState({ status: "Offline", agentSocket: true })).toBe("Offline");
+    expect(deviceConnectivityStatusFromState({ status: "Disconnected", agentSocket: true })).toBe("Connected");
+  });
+
+  it("builds exact AG Grid filter for status drilldowns", () => {
+    expect(buildDeviceConnectivityStatusFilter("disconnected")).toEqual({
+      filterType: "text",
+      type: "equals",
+      filter: "Disconnected",
+    });
+  });
+});

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/Sites/Site_List.connectionStability.test.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/Sites/Site_List.connectionStability.test.jsx
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   applySiteConnectionStability,
+  buildDeviceListSiteStatusPath,
   recordSiteConnectionSnapshots,
   shouldShowConnectedDevicesPlaceholder,
   siteListRowHeightForData,
@@ -97,5 +98,15 @@ describe("site running task row heights", () => {
     const after = siteListRowHeightSignature([{ id: 7, assigned_task_groups: [] }]);
 
     expect(before).not.toBe(after);
+  });
+});
+
+describe("site connectivity drilldown paths", () => {
+  it("builds device list path with site and status query filters", () => {
+    expect(buildDeviceListSiteStatusPath({ id: 7 }, "disconnected")).toBe("/devices?site=7&status=disconnected");
+  });
+
+  it("omits unknown status filters", () => {
+    expect(buildDeviceListSiteStatusPath({ site_id: 9 }, "unknown")).toBe("/devices?site=9");
   });
 });

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Device_List.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Device_List.jsx
@@ -334,6 +334,47 @@ function statusFromHeartbeat(tsSec, offlineAfter = 300) {
   return now - tsSec <= offlineAfter ? "Online" : "Offline";
 }
 
+export function normalizeDeviceConnectivityStatus(value) {
+  const normalized = String(value || "").trim().toLowerCase();
+  if (normalized === "connected" || normalized === "online") return "Connected";
+  if (normalized === "disconnected" || normalized === "degraded") return "Disconnected";
+  if (normalized === "offline" || normalized === "down" || normalized === "unavailable") return "Offline";
+  return "";
+}
+
+function heartbeatOnlineFromStatus(status, lastSeen, offlineAfter = 300) {
+  const normalizedStatus = String(status || "").trim().toLowerCase();
+  if (["connected", "disconnected", "degraded", "online"].includes(normalizedStatus)) return true;
+  if (["offline", "down", "unavailable"].includes(normalizedStatus)) return false;
+  return statusFromHeartbeat(lastSeen, offlineAfter) === "Online";
+}
+
+export function deviceConnectivityStatusFromState({ status, lastSeen, agentSocket } = {}) {
+  const rawStatus = String(status || "").trim().toLowerCase();
+  if (!heartbeatOnlineFromStatus(status, lastSeen)) return "Offline";
+  if (agentSocket === true) return "Connected";
+  if (agentSocket === false) return "Disconnected";
+  if (rawStatus === "connected") return "Connected";
+  return "Disconnected";
+}
+
+export function buildDeviceConnectivityStatusFilter(status) {
+  const normalized = normalizeDeviceConnectivityStatus(status);
+  if (!normalized) return null;
+  return { filterType: "text", type: "equals", filter: normalized };
+}
+
+function statusFilterMatches(statusFilter, status) {
+  const expected = normalizeDeviceConnectivityStatus(status);
+  return Boolean(
+    expected &&
+      statusFilter &&
+      statusFilter.filterType === "text" &&
+      statusFilter.type === "equals" &&
+      normalizeDeviceConnectivityStatus(statusFilter.filter) === expected
+  );
+}
+
 function extractGuidFromAgentId(value) {
   const text = typeof value === "string" ? value.trim() : value == null ? "" : String(value).trim();
   if (!text) return "";
@@ -392,7 +433,6 @@ function normalizeDeviceCollection(
     const guidRaw = (device.agent_guid || summary.agent_guid || "").trim();
     const rowKey = guidRaw || agentId || hostname || `device-${index + 1}`;
     const lastSeen = Number(device.last_seen || summary.last_seen || 0) || 0;
-    const status = device.status || statusFromHeartbeat(lastSeen);
 
     if (guidRaw && !summary.agent_guid) {
       summary.agent_guid = guidRaw;
@@ -427,6 +467,15 @@ function normalizeDeviceCollection(
     const wireguardVpnStatus = agentLookupKey
       ? tunnelStatusLookup.get(agentLookupKey) || "Offline"
       : "Offline";
+    const agentSocket =
+      device.agent_socket === true ||
+      summary.agent_socket === true ||
+      (agentLookupKey && tunnelStatusLookup.get(`${agentLookupKey}:agent_socket`) === "Connected");
+    const status = deviceConnectivityStatusFromState({
+      status: device.status || summary.status || statusFromHeartbeat(lastSeen),
+      lastSeen,
+      agentSocket,
+    });
     const wireguardPeerIp = (
       device.wireguard_peer_ip ||
       device.peer_ip ||
@@ -495,6 +544,7 @@ function normalizeDeviceCollection(
       internalIp,
       externalIp,
       wireguardVpnStatus,
+      agentSocket,
       wireguardPeerIp,
       lastReboot,
       uptime: uptimeSeconds,
@@ -587,6 +637,10 @@ export default function DeviceList({
   );
   const selectedSiteId = useMemo(
     () => String(searchParams.get("site") || "").trim(),
+    [searchParams]
+  );
+  const selectedConnectivityStatus = useMemo(
+    () => normalizeDeviceConnectivityStatus(searchParams.get("status") || searchParams.get("connectivity")),
     [searchParams]
   );
   const initialError = String(loaderData?.initialError || "");
@@ -721,6 +775,7 @@ export default function DeviceList({
   const initialSortAppliedRef = useRef(false);
   const tunnelPeerCacheRef = useRef(new Map());
   const tunnelStatusCacheRef = useRef(new Map());
+  const routeStatusFilterRef = useRef("");
 
   // Per-column filters
   const [filtersState, setFiltersState] = useState({});
@@ -835,7 +890,8 @@ export default function DeviceList({
   const heroStats = useMemo(() => {
     const now = Date.now() / 1000;
     const siteSet = new Set();
-    let online = 0;
+    let connected = 0;
+    let disconnected = 0;
     let offline = 0;
     let stale = 0;
     rows.forEach((row) => {
@@ -851,16 +907,15 @@ export default function DeviceList({
       if (siteName && siteName.toLowerCase() !== "not configured") {
         siteSet.add(siteName);
       }
-      const statusRaw =
-        row.status ||
-        row.summary?.status ||
-        statusFromHeartbeat(lastSeen);
-      if ((statusRaw || "").toLowerCase() === "online") online += 1;
+      const statusRaw = normalizeDeviceConnectivityStatus(row.status);
+      if (statusRaw === "Connected") connected += 1;
+      else if (statusRaw === "Disconnected") disconnected += 1;
       else offline += 1;
     });
     return {
       total: rows.length,
-      online,
+      connected,
+      disconnected,
       offline,
       sites: siteSet.size,
       stale,
@@ -902,9 +957,13 @@ export default function DeviceList({
           if (ip) peerByAgent.set(agentKey, ip);
           const vpnStatus = wireguardStatusFromTunnel(tunnel);
           statusByAgent.set(agentKey, vpnStatus);
+          statusByAgent.set(`${agentKey}:agent_socket`, tunnel.agent_socket === true ? "Connected" : "Disconnected");
           if (guidKey) {
             if (ip && !peerByAgent.has(guidKey)) peerByAgent.set(guidKey, ip);
             if (!statusByAgent.has(guidKey)) statusByAgent.set(guidKey, vpnStatus);
+            if (!statusByAgent.has(`${guidKey}:agent_socket`)) {
+              statusByAgent.set(`${guidKey}:agent_socket`, tunnel.agent_socket === true ? "Connected" : "Disconnected");
+            }
           }
         });
         tunnelPeerCacheRef.current = peerByAgent;
@@ -929,14 +988,25 @@ export default function DeviceList({
         if (!agentKey) return row;
         const peerIp = peerByAgent.get(agentKey) || "";
         const vpnStatus = statusByAgent.get(agentKey) || "Offline";
+        const socketStatus = statusByAgent.get(`${agentKey}:agent_socket`) || "";
+        const agentSocket = socketStatus ? socketStatus === "Connected" : row.agentSocket === true;
+        const nextStatus = deviceConnectivityStatusFromState({
+          status: row.status,
+          lastSeen: row.lastSeen,
+          agentSocket,
+        });
         const shouldUpdatePeerIp = Boolean(peerIp) && peerIp !== row.wireguardPeerIp;
         const shouldUpdateStatus = vpnStatus !== row.wireguardVpnStatus;
-        if (!shouldUpdatePeerIp && !shouldUpdateStatus) return row;
+        const shouldUpdateSocket = agentSocket !== row.agentSocket;
+        const shouldUpdateConnectivityStatus = nextStatus !== row.status;
+        if (!shouldUpdatePeerIp && !shouldUpdateStatus && !shouldUpdateSocket && !shouldUpdateConnectivityStatus) return row;
         changed = true;
         return {
           ...row,
           wireguardPeerIp: shouldUpdatePeerIp ? peerIp : row.wireguardPeerIp,
           wireguardVpnStatus: vpnStatus,
+          agentSocket,
+          status: nextStatus,
         };
       });
       return changed ? next : prev;
@@ -1113,6 +1183,27 @@ export default function DeviceList({
   }, [COL_LABELS.site, mergeFilters, selectedSiteId]);
 
   useEffect(() => {
+    setFiltersState((prev) => {
+      const base = prev || {};
+      const previousRouteStatus = routeStatusFilterRef.current;
+      if (selectedConnectivityStatus) {
+        const statusFilter = buildDeviceConnectivityStatusFilter(selectedConnectivityStatus);
+        routeStatusFilterRef.current = selectedConnectivityStatus;
+        if (!statusFilter || statusFilterMatches(base.status, selectedConnectivityStatus)) return base;
+        return { ...base, status: statusFilter };
+      }
+      if (previousRouteStatus && statusFilterMatches(base.status, previousRouteStatus)) {
+        const next = { ...base };
+        delete next.status;
+        routeStatusFilterRef.current = "";
+        return next;
+      }
+      routeStatusFilterRef.current = "";
+      return base;
+    });
+  }, [selectedConnectivityStatus]);
+
+  useEffect(() => {
     let active = true;
     const loadSavedFilterPreview = async () => {
       try {
@@ -1167,8 +1258,11 @@ export default function DeviceList({
     const siteScopedRows = selectedSiteId
       ? filteredRows.filter((row) => String(row?.siteId ?? "") === selectedSiteId)
       : filteredRows;
-    return [...siteScopedRows].sort(compareDeviceRowsBySiteThenHostname);
-  }, [rows, savedFilterHostnames, selectedSiteId]);
+    const statusScopedRows = selectedConnectivityStatus
+      ? siteScopedRows.filter((row) => normalizeDeviceConnectivityStatus(row?.status) === selectedConnectivityStatus)
+      : siteScopedRows;
+    return [...statusScopedRows].sort(compareDeviceRowsBySiteThenHostname);
+  }, [rows, savedFilterHostnames, selectedConnectivityStatus, selectedSiteId]);
 
   const applyView = useCallback((view) => {
     if (!view || view.id === "default") {
@@ -1200,6 +1294,18 @@ export default function DeviceList({
         background: "rgba(0, 209, 140, 0.16)",
         border: "1px solid rgba(0, 209, 140, 0.45)",
         dot: "#00d18c",
+      },
+      Connected: {
+        text: "#00d18c",
+        background: "rgba(0, 209, 140, 0.16)",
+        border: "1px solid rgba(0, 209, 140, 0.45)",
+        dot: "#00d18c",
+      },
+      Disconnected: {
+        text: "#ff8a8a",
+        background: "rgba(255, 79, 79, 0.15)",
+        border: "1px solid rgba(255, 79, 79, 0.42)",
+        dot: "#ff4f4f",
       },
       Recovering: {
         text: "#ffb347",

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Device_List.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Device_List.jsx
@@ -1817,8 +1817,8 @@ export default function DeviceList({
             headerName: col.label,
             cellRenderer: statusCellRenderer,
             cellClass: "status-pill-cell",
-            width: 112,
-            minWidth: 112,
+            width: 140,
+            minWidth: 140,
             flex: 0,
           };
         case "site":

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Sites/Site_List.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Sites/Site_List.jsx
@@ -412,6 +412,18 @@ function siteIdForRow(row) {
   return Number.isFinite(siteId) && siteId > 0 ? siteId : 0;
 }
 
+export function buildDeviceListSiteStatusPath(site, statusKey = "") {
+  const siteId = siteIdForRow(site);
+  if (!siteId) return "";
+  const params = new URLSearchParams();
+  params.set("site", String(siteId));
+  const normalizedStatus = String(statusKey || "").trim().toLowerCase();
+  if (CONNECTION_SECTIONS.some((section) => section.key === normalizedStatus)) {
+    params.set("status", normalizedStatus);
+  }
+  return `${APP_PATHS.devices}?${params.toString()}`;
+}
+
 function normalizedConnectionCounts(row) {
   const connected = Math.max(0, Number(row?.connected_devices || 0));
   const disconnected = Math.max(0, Number(row?.disconnected_devices || 0));
@@ -1496,6 +1508,12 @@ function ConnectedDevicesCell(params) {
   const offline = Number(params?.data?.offline_devices || 0);
   const total = Math.max(0, Number(params?.data?.site_device_count || 0), connected + disconnected + offline);
   const counts = { connected, disconnected, offline };
+  const openDevicesForSiteStatus = params?.context?.openDevicesForSiteStatus;
+  const handleOpenStatus = (event, section) => {
+    event?.preventDefault?.();
+    event?.stopPropagation?.();
+    openDevicesForSiteStatus?.(params?.data, section.key);
+  };
   return (
     <Box
       sx={{
@@ -1508,6 +1526,10 @@ function ConnectedDevicesCell(params) {
         height: "100%",
         minWidth: 0,
         lineHeight: 1.25,
+        "@keyframes siteConnectivityPulse": {
+          "0%": { transform: "scaleY(1)" },
+          "100%": { transform: "scaleY(1.55)" },
+        },
       }}
     >
       <Box
@@ -1527,12 +1549,30 @@ function ConnectedDevicesCell(params) {
           return (
             <Box
               key={section.key}
-              component="span"
+              component="button"
+              type="button"
+              aria-label={`Show ${section.label} devices for this site`}
+              onMouseDown={stopGridRowSelectionEvent}
+              onClick={(event) => handleOpenStatus(event, section)}
               sx={{
                 display: "block",
                 height: "100%",
                 width: `${Math.max(4, Math.round((value / total) * 100))}%`,
                 backgroundColor: section.color,
+                border: 0,
+                p: 0,
+                m: 0,
+                minWidth: 4,
+                cursor: "pointer",
+                transformOrigin: "center",
+                transition: "filter 160ms ease, transform 160ms ease, box-shadow 160ms ease",
+                "&:hover, &:focus-visible": {
+                  animation: "siteConnectivityPulse 720ms ease-in-out infinite alternate",
+                  filter: "brightness(1.18)",
+                  outline: "none",
+                  boxShadow: "0 0 10px rgba(125,211,252,0.45)",
+                  zIndex: 1,
+                },
               }}
             />
           );
@@ -1551,7 +1591,33 @@ function ConnectedDevicesCell(params) {
         }}
       >
         {CONNECTION_SECTIONS.map((section) => (
-          <Box key={section.key} component="span" sx={{ display: "inline-flex", alignItems: "center", gap: 0.35 }}>
+          <Box
+            key={section.key}
+            component="button"
+            type="button"
+            aria-label={`Show ${section.label} devices for this site`}
+            onMouseDown={stopGridRowSelectionEvent}
+            onClick={(event) => handleOpenStatus(event, section)}
+            sx={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 0.35,
+              border: 0,
+              p: 0,
+              m: 0,
+              color: "inherit",
+              background: "transparent",
+              font: "inherit",
+              cursor: "pointer",
+              borderRadius: 0.75,
+              transition: "color 160ms ease, transform 160ms ease",
+              "&:hover, &:focus-visible": {
+                color: MAGIC_UI.textBright,
+                outline: "none",
+                transform: "translateY(-0.5px)",
+              },
+            }}
+          >
             <Box component="span" sx={{ width: 5, height: 5, borderRadius: 1, backgroundColor: section.color }} />
             {counts[section.key]} {section.label}
           </Box>
@@ -2072,9 +2138,18 @@ export default function SiteList() {
 
   const handleOpenDevicesForSite = useCallback(
     (site) => {
-      const siteId = site?.id;
-      if (siteId == null || siteId === "") return;
-      navigate(`${APP_PATHS.devices}?site=${encodeURIComponent(String(siteId))}`);
+      const path = buildDeviceListSiteStatusPath(site);
+      if (!path) return;
+      navigate(path);
+    },
+    [navigate]
+  );
+
+  const handleOpenDevicesForSiteStatus = useCallback(
+    (site, statusKey) => {
+      const path = buildDeviceListSiteStatusPath(site, statusKey);
+      if (!path) return;
+      navigate(path);
     },
     [navigate]
   );
@@ -2851,8 +2926,9 @@ export default function SiteList() {
   const gridContext = useMemo(
     () => ({
       navigate,
+      openDevicesForSiteStatus: handleOpenDevicesForSiteStatus,
     }),
-    [navigate]
+    [handleOpenDevicesForSiteStatus, navigate]
   );
 
   return (

--- a/Docs/Using the Platform/device-auditing.md
+++ b/Docs/Using the Platform/device-auditing.md
@@ -10,7 +10,7 @@ Device Auditing is the normal starting point for understanding a managed endpoin
 ## Open Device Inventory
 
 1. Open `Inventory > Devices`.
-2. Search or filter by hostname, site, status, user, type, or operating system.
+2. Search or filter by hostname, site, connection status, user, type, or operating system.
 3. Select a device hostname to open Device Summary.
 4. Use saved table views when you need repeatable columns and filters for routine audits.
 
@@ -28,9 +28,10 @@ Device Summary collects the last-known inventory and action tabs for one endpoin
 
 ## Understand Status
 
-- `Online` means the Engine saw a recent heartbeat.
+- `Connected` means the Engine saw a recent heartbeat and the site worker reports the Agent management socket is connected.
+- `Disconnected` means the Engine saw a recent heartbeat, but the site-worker management connection is not healthy.
 - `Offline` means heartbeat age exceeded the online window.
-- Agent Health explains startup and role state; it does not replace online/offline status.
+- Agent Health explains startup and role state; it does not replace connection status.
 - Stale inventory means the device may be online but a specific role has not published fresh data yet.
 
 !!! tip
@@ -72,7 +73,8 @@ Device Summary collects the last-known inventory and action tabs for one endpoin
 
     ### Source map
 
-    - Device APIs: `Data/Engine/Containers/api-backend/data/services/API/devices/`
+    - Device APIs: `Data/Engine/Containers/api-backend/cmd/api-backend/devices.go` and related `device_*` Go files.
+    - Device List UI: `Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Device_List.jsx`
     - Device Summary UI: `Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Device_Summary.jsx`
     - Registry Editor UI: `Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Remote_Registry_Editor.jsx`
     - Agent Health UI: `Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Agent_Health.jsx`
@@ -80,7 +82,10 @@ Device Summary collects the last-known inventory and action tabs for one endpoin
 
     ### Runtime behavior
 
-    - Online/offline status is derived from `devices.last_seen`.
+    - Device List status is derived from `devices.last_seen` plus the site-worker Agent socket registry exposed through `/api/devices` as `agent_socket`.
+    - `GET /api/devices` enriches device rows by fetching each visible site worker's `/agents` snapshot once, then matching system sockets by hostname, Agent ID, or GUID.
+    - Site List drilldowns use `/devices?site=<site_id>&status=<connected|disconnected|offline>`; Device List normalizes those status tokens to `Connected`, `Disconnected`, or `Offline`.
+    - Heartbeat-only online state without a confirmed Agent socket renders as `Disconnected`, not `Connected`.
     - Heavy inventory lands through `/api/agent/details`; heartbeat carries lightweight metrics and metadata deltas.
     - Session inventory includes helper readiness fields so current-user execution can distinguish a logged-in user from a helper-ready session.
     - Software data is stored both in `devices.software` for UI detail and `device_software_inventory` for reliable filter matching.

--- a/Docs/Using the Platform/sites.md
+++ b/Docs/Using the Platform/sites.md
@@ -35,6 +35,8 @@ Resource mini-trends refresh with the site-worker payload every 5 seconds and ke
 
 The Connected Devices bar uses the last known connected breakdown for a short grace window before showing an all-disconnected state. This prevents one missed site-worker heartbeat or zero-connected poll from briefly turning healthy sites red.
 
+Select any colored section of the Connected Devices bar, or its `Connected`, `Disconnected`, or `Offline` label, to open Device Inventory filtered to that site and connection status. Use this drilldown when the bar shows disconnected or offline devices and you need the exact endpoints to inspect.
+
 !!! tip
 
     Keep one site per customer, lab, or security boundary. Filters and scheduled jobs become easier to reason about when site scope matches real ownership.
@@ -63,6 +65,7 @@ The Connected Devices bar uses the last known connected breakdown for a short gr
 
     - Site API: `Data/Engine/Containers/api-backend/data/services/API/sites/management.py`
     - Sites UI: `Data/Engine/Containers/webui-frontend/data/web-interface/src/Sites/Site_List.jsx`
+    - Device List UI: `Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Device_List.jsx`
     - Site assignment UI: `Data/Engine/Containers/webui-frontend/data/web-interface/src/Sites/Site_Assignment.jsx`
 
     ### Runtime behavior
@@ -74,3 +77,4 @@ The Connected Devices bar uses the last known connected breakdown for a short gr
     - Site-worker resource usage comes from the Docker stats payload and Docker inspect size metadata attached to each worker row by the Engine API. Sites does not fetch worker metrics from the route loader; browser polling starts immediately after the page renders and continues every 5 seconds.
     - CPU uses Docker CPU percent, RAM uses memory usage bytes, NET is browser-calculated throughput from cumulative Docker network counters, and DISK uses Docker `SizeRootFs`.
     - The Connected Devices bar caches the last non-zero connected breakdown in browser state and reuses it for brief zero-connected worker polls. Sustained zero-connected payloads still render as disconnected after the grace window.
+    - Connected Devices bar segments and labels deep-link to `/devices?site=<site_id>&status=<connected|disconnected|offline>`.


### PR DESCRIPTION
Resolves #302.

## What changed
- Made Site List Connected Devices bar segments and matching labels clickable.
- Added `/devices?site=<site_id>&status=<connected|disconnected|offline>` drilldown URLs.
- Changed Device List status labels to `Connected`, `Disconnected`, and `Offline` from heartbeat plus site-worker Agent socket state.
- Enriched `GET /api/devices` with `agent_socket` by fetching each visible site worker's `/agents` snapshot once and matching system sockets by hostname, Agent ID, or GUID.
- Added focused WebUI helper tests and updated Sites / Device Auditing docs.

## Validation
- Passed: `/opt/Borealis/Dependencies/Go/go1.22.12/bin/go test ./cmd/api-backend`
- Passed: `git diff --check`
- Blocked: `./Engine_Unit_Tests.sh --domain webui` because runtime WebUI test cache is missing at `Engine/Services/webui-frontend/cache/web-interface/Unit_Tests`; script says redeploy Engine to stage cache, then rerun.
- Blocked/expected environment gap: `./Engine_Unit_Tests.sh --domain devices` exits 2 because this checkout has no Python device-domain tests under `Data/Engine/Unit_Tests`.

## Risk
- WebUI helper tests were added but could not run in this workspace until runtime cache is staged.