### PR TITLE
issue/dependabot-alert-5-golang-jwt-header-parsing

### DIFF
--- a/Data/Engine/Containers/api-backend/go.mod
+++ b/Data/Engine/Containers/api-backend/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/fxamacker/cbor/v2 v2.6.0 // indirect
 	github.com/go-asn1-ber/asn1-ber v1.5.5 // indirect
 	github.com/go-webauthn/x v0.1.9 // indirect
-	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
+	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
 	github.com/google/go-tpm v0.9.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect

--- a/Data/Engine/Containers/api-backend/go.sum
+++ b/Data/Engine/Containers/api-backend/go.sum
@@ -15,8 +15,8 @@ github.com/go-webauthn/webauthn v0.10.2 h1:OG7B+DyuTytrEPFmTX503K77fqs3HDK/0Iv+z
 github.com/go-webauthn/webauthn v0.10.2/go.mod h1:Gd1IDsGAybuvK1NkwUTLbGmeksxuRJjVN2PE/xsPxHs=
 github.com/go-webauthn/x v0.1.9 h1:v1oeLmoaa+gPOaZqUdDentu6Rl7HkSSsmOT6gxEQHhE=
 github.com/go-webauthn/x v0.1.9/go.mod h1:pJNMlIMP1SU7cN8HNlKJpLEnFHCygLCvaLZ8a1xeoQA=
-github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
-github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
+github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
+github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/go-tpm v0.9.0 h1:sQF6YqWMi+SCXpsmS3fd21oPy/vSddwZry4JnmltHVk=
 github.com/google/go-tpm v0.9.0/go.mod h1:FkNVkc6C+IsvDI9Jw1OveJmxGZUUaKxtrpOS47QWKfU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/Docs/Reference/SBOM.md
+++ b/Docs/Reference/SBOM.md
@@ -50,7 +50,7 @@ Use `shared-engine` for dependencies that support host deployment, build orchest
 | api-backend | github.com/go-webauthn/webauthn v0.10.2 (Go WebAuthn passkey ceremonies) | [BSD-3-Clause](https://github.com/go-webauthn/webauthn/blob/master/LICENSE) |
 | api-backend | github.com/fxamacker/cbor/v2 v2.6.0 (Go WebAuthn CBOR codec dependency) | [MIT](https://github.com/fxamacker/cbor/blob/master/LICENSE) |
 | api-backend | github.com/go-webauthn/x v0.1.9 (Go WebAuthn support dependency) | [BSD-3-Clause](https://github.com/go-webauthn/x/blob/master/LICENSE) |
-| api-backend | github.com/golang-jwt/jwt/v5 v5.2.1 (Go WebAuthn transitive JWT support dependency) | [MIT](https://github.com/golang-jwt/jwt/blob/main/LICENSE) |
+| api-backend | github.com/golang-jwt/jwt/v5 v5.2.2 (Go WebAuthn transitive JWT support dependency) | [MIT](https://github.com/golang-jwt/jwt/blob/main/LICENSE) |
 | api-backend | github.com/google/go-tpm v0.9.0 (Go WebAuthn TPM attestation support dependency) | [Apache-2.0](https://github.com/google/go-tpm/blob/main/LICENSE) |
 | api-backend | github.com/google/uuid v1.6.0 (Go WebAuthn UUID support dependency) | [BSD-3-Clause](https://github.com/google/uuid/blob/master/LICENSE) |
 | api-backend | github.com/mitchellh/mapstructure v1.5.0 (Go WebAuthn config decode dependency) | [MIT](https://github.com/mitchellh/mapstructure/blob/main/LICENSE) |


### PR DESCRIPTION
## Summary

- Resolves Dependabot alert #5 for `github.com/golang-jwt/jwt/v5` by moving Engine `api-backend` from `v5.2.1` to patched `v5.2.2`.
- Updates Go checksums and SBOM inventory to match resolved dependency graph.

## Impact

The alert covers GHSA-mh63-6h87-95cp / CVE-2025-30204, where JWT header parsing can allocate excessive memory from attacker-controlled token text. Borealis pulls this package through Go WebAuthn passkey ceremony support, not as a direct app dependency. Risk is availability-focused, with no confidentiality or integrity impact called out by the advisory.

## Validation

- `cd Data/Engine/Containers/api-backend && /opt/Borealis/Dependencies/Go/go1.22.12/bin/go test ./...`
- `git diff --check`
- `cd Data/Engine/Containers/api-backend && /opt/Borealis/Dependencies/Go/go1.22.12/bin/go list -m all | rg '^(github.com/go-webauthn/webauthn|github.com/golang-jwt/jwt/v5|borealis/api-backend)'`

Closes #304