### PR TITLE
issue/dependabot-alert-3-vite-fs-deny-bypass

### DIFF
--- a/Data/Engine/Containers/webui-frontend/data/web-interface/package.json
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/package.json
@@ -58,9 +58,9 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^16.0.0",
-    "@vitejs/plugin-react": "^4.0.0",
+    "@vitejs/plugin-react": "^4.7.0",
     "jsdom": "^26.0.0",
-    "vite": "^5.0.0",
+    "vite": "^6.4.3",
     "vitest": "^3.0.0"
   },
   "browserslist": {

--- a/Docs/Reference/SBOM.md
+++ b/Docs/Reference/SBOM.md
@@ -150,9 +150,9 @@ Use `shared-engine` for dependencies that support host deployment, build orchest
 | webui-frontend | socket.io-client | [MIT](https://spdx.org/licenses/MIT.html) |
 | webui-frontend | @testing-library/jest-dom | [MIT](https://spdx.org/licenses/MIT.html) |
 | webui-frontend | @testing-library/react | [MIT](https://spdx.org/licenses/MIT.html) |
-| webui-frontend | @vitejs/plugin-react | [MIT](https://spdx.org/licenses/MIT.html) |
+| webui-frontend | @vitejs/plugin-react ^4.7.0 | [MIT](https://spdx.org/licenses/MIT.html) |
 | webui-frontend | jsdom | [MIT](https://github.com/jsdom/jsdom/blob/main/LICENSE.txt) |
-| webui-frontend | vite | [MIT](https://spdx.org/licenses/MIT.html) |
+| webui-frontend | vite ^6.4.3 | [MIT](https://spdx.org/licenses/MIT.html) |
 | webui-frontend | vitest | [MIT](https://github.com/vitest-dev/vitest/blob/main/LICENSE) |
 | wireguard-tunnel | Debian Bookworm base image (`debian:bookworm-slim`) | [Debian Free Software Guidelines / package-specific licenses](https://www.debian.org/legal/licenses/) |
 | wireguard-tunnel | Python (system Python on Linux) | [PSF License](https://docs.python.org/3/license.html) |


### PR DESCRIPTION
## Summary

- Resolves Dependabot alert #3 for Vite by raising the WebUI `vite` dev dependency floor from `^5.0.0` to patched `^6.4.3`.
- Raises `@vitejs/plugin-react` to `^4.7.0`, whose 4.x peer range explicitly supports Vite 6.
- Updates SBOM rows for the changed WebUI Vite toolchain ranges.

## Impact

The advisory covers GHSA-fx2h-pf6j-xcff / CVE-2026-53571, a Vite dev-server `server.fs.deny` bypass on Windows alternate path forms. Borealis production WebUI serves static output without Vite. Borealis dev mode runs Vite inside the Linux `webui-frontend` container, bound on loopback and routed through Traefik only when dev mode is intentionally enabled, so Borealis exposure is narrower than the base advisory.

## Validation

- `jq empty Data/Engine/Containers/webui-frontend/data/web-interface/package.json`
- `git diff --check`
- npm registry metadata check: `vite@6.4.3` supports Node `^18.0.0 || ^20.0.0 || >=22.0.0`; `@vitejs/plugin-react@4.7.0` peers `vite` `^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0`.
- Attempted: `./Engine_Unit_Tests.sh --domain webui`; blocked because runtime WebUI unit tests are missing at `Engine/Services/webui-frontend/cache/web-interface/Unit_Tests`. Script says redeploy Engine so container-owned WebUI source is staged, then rerun.

Closes #306