### PR TITLE
issue/dependabot-x-crypto-dos

### DIFF
--- a/Data/Engine/Containers/api-backend/build-api-backend.sh
+++ b/Data/Engine/Containers/api-backend/build-api-backend.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd -- "${script_dir}/../../../.." && pwd)"
 minimum_go_major=1
-minimum_go_minor=22
-go_version="${BOREALIS_GO_VERSION:-1.22.12}"
+minimum_go_minor=23
+go_version="${BOREALIS_GO_VERSION:-1.23.12}"
 go_install_root="${BOREALIS_GO_INSTALL_ROOT:-${repo_root}/Dependencies/Go/go${go_version}}"
 version_value="${BOREALIS_API_BACKEND_VERSION:-$(git -C "${repo_root}" rev-parse HEAD 2>/dev/null || echo dev)}"
 output_root="${BOREALIS_GO_API_BACKEND_OUTPUT_ROOT:-${script_dir}/dist}"

--- a/Data/Engine/Containers/api-backend/go.mod
+++ b/Data/Engine/Containers/api-backend/go.mod
@@ -1,6 +1,6 @@
 module borealis/api-backend
 
-go 1.22
+go 1.23.0
 
 require (
 	github.com/go-webauthn/webauthn v0.10.2
@@ -9,7 +9,7 @@ require (
 
 require (
 	github.com/go-ldap/ldap/v3 v3.4.8
-	golang.org/x/crypto v0.33.0
+	golang.org/x/crypto v0.35.0
 )
 
 require (

--- a/Data/Engine/Containers/api-backend/go.sum
+++ b/Data/Engine/Containers/api-backend/go.sum
@@ -61,8 +61,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
 golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
 golang.org/x/crypto v0.21.0/go.mod h1:0BP7YvVV9gBbVKyeTG0Gyn+gZm94bibOW5BjDEYAOMs=
-golang.org/x/crypto v0.33.0 h1:IOBPskki6Lysi0lo9qQvbxiQ+FvsCC/YWOecCHAixus=
-golang.org/x/crypto v0.33.0/go.mod h1:bVdXmD7IV/4GdElGPozy6U7lWdRXA4qyRVGJV57uQ5M=
+golang.org/x/crypto v0.35.0 h1:b15kiHdrGCHrP6LvwaQ3c03kgNhhiMgvlhxHQhmg2Xs=
+golang.org/x/crypto v0.35.0/go.mod h1:dy7dXNW32cAb/6/PRuTNsix8T+vJAqvuIy5Bli/x0YQ=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/Docs/Reference/SBOM.md
+++ b/Docs/Reference/SBOM.md
@@ -43,7 +43,7 @@ Use `shared-engine` for dependencies that support host deployment, build orchest
 | api-backend | tzdata | [Public Domain](https://data.iana.org/time-zones/tzdb/LICENSE) |
 | api-backend | Go standard library/runtime (compiled into the Go `api-backend` gateway) | [BSD-3-Clause](https://go.dev/LICENSE) |
 | api-backend | github.com/lib/pq v1.10.9 (Go PostgreSQL driver) | [MIT](https://github.com/lib/pq/blob/master/LICENSE.md) |
-| api-backend | golang.org/x/crypto v0.33.0 (Go scrypt KDF support) | [BSD-3-Clause](https://cs.opensource.google/go/x/crypto/+/master:LICENSE) |
+| api-backend | golang.org/x/crypto v0.35.0 (Go scrypt KDF, Curve25519 tunnel helper, and SSH private-key parsing support) | [BSD-3-Clause](https://cs.opensource.google/go/x/crypto/+/master:LICENSE) |
 | api-backend | github.com/go-ldap/ldap/v3 v3.4.8 (Go LDAP/LDAPS directory-provider support) | [MIT](https://github.com/go-ldap/ldap/blob/master/LICENSE) |
 | api-backend | github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 (Go LDAP NTLM support dependency) | [MIT](https://github.com/Azure/go-ntlmssp/blob/master/LICENSE) |
 | api-backend | github.com/go-asn1-ber/asn1-ber v1.5.5 (Go LDAP ASN.1 BER codec dependency) | [MIT](https://github.com/go-asn1-ber/asn1-ber/blob/master/LICENSE) |
@@ -163,7 +163,7 @@ Use `shared-engine` for dependencies that support host deployment, build orchest
 | shared-engine | Docker Buildx plugin / BuildKit (optional local Engine image build cache acceleration) | [Apache-2.0](https://github.com/docker/buildx/blob/master/LICENSE) |
 | shared-engine | Tecnativa Docker Socket Proxy container image (`ghcr.io/tecnativa/docker-socket-proxy:v0.4.2`) | [Apache-2.0](https://github.com/Tecnativa/docker-socket-proxy/blob/master/LICENSE.txt) |
 | shared-engine | Python (system Python on Linux, used by `Engine.sh` deployment helpers) | [PSF License](https://docs.python.org/3/license.html) |
-| shared-engine | Go toolchain (native Linux `api-backend` build helper installs official Go into `Dependencies/Go` when missing) | [BSD-3-Clause](https://go.dev/LICENSE) |
+| shared-engine | Go toolchain 1.23.12 (native Linux `api-backend` build helper installs official Go into `Dependencies/Go` when missing) | [BSD-3-Clause](https://go.dev/LICENSE) |
 
 ## Maintenance Notes
 

--- a/Docs/Reference/Unit_Testing.md
+++ b/Docs/Reference/Unit_Testing.md
@@ -101,6 +101,7 @@ BOREALIS_AGENT_UNIT_TEST_DOMAIN=go-agent ./Data/Agent/Unit_Tests/Agent_Unit_Test
 ## Expected Setup
 - Run scripts from repo root.
 - Engine tests prefer `Engine/bin/python` when available because Engine venv includes pytest.
+- Engine Go backend tests/builds use Go 1.23+; `Data/Engine/Containers/api-backend/build-api-backend.sh` installs a native Go toolchain under `Dependencies/Go` on Linux when missing.
 - Agent tests use Go 1.22+; `Data/Agent/build-agent.sh` installs a native Go toolchain under `Dependencies/Go` on Linux when missing.
 - WebUI tests require a prepared runtime cache at `Engine/Services/webui-frontend/cache/web-interface` with `node_modules` and `Unit_Tests`. Container deploys also seed editable dev/HMR source under `Engine/Services/webui-frontend/data/web-interface/`, but that source folder is not the test dependency cache.
 - Do not run npm or Vite from `Data/Engine/Containers/webui-frontend/data/web-interface`; use a prepared runtime cache, the dev/HMR runtime source, or defer UI runtime validation to the operator redeploying the WebUI container.

--- a/Docs/Reference/security-whitepaper.md
+++ b/Docs/Reference/security-whitepaper.md
@@ -381,7 +381,7 @@ Scripts and assemblies are signed before delivery. Agents treat payloads as untr
 
     ### Validation
 
-    - Engine focused Go tests: `cd Data/Engine/Containers/api-backend && /opt/Borealis/Dependencies/Go/go1.22.12/bin/go test ./cmd/api-backend`.
+    - Engine focused Go tests: `cd Data/Engine/Containers/api-backend && /opt/Borealis/Dependencies/Go/go1.23.12/bin/go test ./cmd/api-backend`.
     - Agent focused Go tests: `cd Data/Agent && /opt/Borealis/Dependencies/Go/go1.22.12/bin/go test ./internal/roles/wireguard_tunnel`.
     - Control socket tests: `/opt/Borealis/.cache/codex-engine-tests/bin/python3 -m pytest Data/Engine/Unit_Tests/test_wireguard_control_server.py`.
     - Engine remote-access domain wrapper: `BOREALIS_ENGINE_TEST_PYTHON=/opt/Borealis/.cache/codex-engine-tests/bin/python3 ./Engine_Unit_Tests.sh --domain remote-access`.


### PR DESCRIPTION
## Summary

- Updates Engine `golang.org/x/crypto` from `v0.33.0` to patched `v0.35.0` for Dependabot alert 6 / CVE-2025-22869.
- Raises the Engine Go backend module/build helper floor to Go 1.23 because patched `x/crypto` requires Go 1.23+.
- Updates SBOM and validation docs for the patched dependency and Engine toolchain path.

Closes #309.

## Validation

- `bash Data/Engine/Containers/api-backend/build-api-backend.sh`
- `cd Data/Engine/Containers/api-backend && /opt/Borealis/Dependencies/Go/go1.23.12/bin/go test ./cmd/api-backend`
- `cd Data/Engine/Containers/api-backend && /opt/Borealis/Dependencies/Go/go1.23.12/bin/go test ./...`
- `git diff --check`

## Risk

- Runtime deploy not run; operators need Engine redeploy after merge for patched binary to reach service.
- Immediate Borealis exposure appears limited because current code does not run a Go SSH/SFTP server, but module is direct runtime dependency.