### PR TITLE
issue/create-text-files-file-management

### DIFF
--- a/Data/Engine/Containers/api-backend/cmd/api-backend/remote_files.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/remote_files.go
@@ -276,16 +276,17 @@ func remoteFileUploadHandler(auth *authService) func(http.ResponseWriter, *http.
 			return
 		}
 		files := remoteFileUploadFiles(r)
-		if len(files) == 0 {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "upload_files_required"})
-			return
-		}
 		manifestItems := uploadManifestFromMultipartForm(r.FormValue("manifest"), files)
 		if len(manifestItems) == 0 {
 			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "upload_files_required"})
 			return
 		}
-		if len(manifestItems) != len(files) {
+		manifestOnlyEmptyUpload := remoteFileManifestOnlyEmptyUpload(files, manifestItems)
+		if len(files) == 0 && !manifestOnlyEmptyUpload {
+			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "upload_files_required"})
+			return
+		}
+		if len(files) > 0 && len(manifestItems) != len(files) {
 			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "upload_manifest_mismatch"})
 			return
 		}
@@ -337,9 +338,16 @@ func remoteFileUploadHandler(auth *authService) func(http.ResponseWriter, *http.
 		manifestToUpload := make([]map[string]any, 0, len(manifestItems))
 		overwriteKeys := []string{}
 		skippedCount := 0
-		for index, file := range files {
-			manifestRow := manifestItems[index]
-			filename := sanitizeUploadName(firstText(cleanText(manifestRow["name"]), file.Filename))
+		for index, manifestRow := range manifestItems {
+			var file *multipart.FileHeader
+			if index < len(files) {
+				file = files[index]
+			}
+			fileNameFallback := ""
+			if file != nil {
+				fileNameFallback = file.Filename
+			}
+			filename := sanitizeUploadName(firstText(cleanText(manifestRow["name"]), fileNameFallback))
 			clientKey := firstText(cleanText(manifestRow["client_key"]), filename)
 			if filename == "" || clientKey == "" {
 				continue
@@ -351,10 +359,12 @@ func remoteFileUploadHandler(auth *authService) func(http.ResponseWriter, *http.
 			case "replace":
 				overwriteKeys = append(overwriteKeys, clientKey)
 			}
-			filesToUpload = append(filesToUpload, file)
+			if file != nil {
+				filesToUpload = append(filesToUpload, file)
+			}
 			manifestToUpload = append(manifestToUpload, manifestRow)
 		}
-		if len(filesToUpload) == 0 {
+		if len(manifestToUpload) == 0 {
 			writeJSON(w, http.StatusOK, map[string]any{
 				"ok":            true,
 				"status":        "skipped",
@@ -1080,6 +1090,21 @@ func uploadManifestFromMultipartForm(value string, files []*multipart.FileHeader
 		})
 	}
 	return normalizeUploadManifestItems(fallbackRows)
+}
+
+func remoteFileManifestOnlyEmptyUpload(files []*multipart.FileHeader, manifestItems []map[string]any) bool {
+	if len(files) != 0 || len(manifestItems) == 0 {
+		return false
+	}
+	for _, row := range manifestItems {
+		if sanitizeUploadName(cleanText(row["name"])) == "" || cleanText(row["relative_path"]) == "" {
+			return false
+		}
+		if coerceInt64(row["size_bytes"]) != 0 {
+			return false
+		}
+	}
+	return true
 }
 
 func normalizeConflictResolutionMap(value string) map[string]string {

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/remote_files_test.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/remote_files_test.go
@@ -249,6 +249,107 @@ func TestRemoteFileUploadStartsWorkerTransfer(t *testing.T) {
 	}
 }
 
+func TestRemoteFileUploadAllowsManifestOnlyEmptyFile(t *testing.T) {
+	var sawUpload bool
+	worker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get(internalTokenHeader); got != goInternalToken([]byte("test-secret")) {
+			t.Fatalf("unexpected internal token %q", got)
+		}
+		switch r.URL.Path {
+		case "/remote-ops/host-service/status":
+			_ = json.NewEncoder(w).Encode(map[string]any{"registered": true})
+		case "/remote-ops/host-service/call":
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("worker request body decode failed: %v", err)
+			}
+			payload, _ := body["payload"].(map[string]any)
+			if payload["action"] != "upload_conflicts" || payload["target_path"] != "C:\\Temp" {
+				t.Fatalf("unexpected conflict payload %#v", payload)
+			}
+			items, _ := payload["items"].([]any)
+			if len(items) != 1 {
+				t.Fatalf("expected one conflict item, got %#v", payload["items"])
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"called": true,
+				"response": map[string]any{
+					"ok":          true,
+					"target_path": "C:\\Temp",
+					"conflicts":   []any{},
+				},
+			})
+		case "/remote-files/transfers/upload":
+			sawUpload = true
+			if err := r.ParseMultipartForm(1 << 20); err != nil {
+				t.Fatalf("multipart parse failed: %v", err)
+			}
+			if r.FormValue("hostname") != "LAB-OPERATOR-01" || r.FormValue("device_guid") == "" || r.FormValue("target_path") != "C:\\Temp" {
+				t.Fatalf("unexpected upload form host=%q guid=%q target=%q", r.FormValue("hostname"), r.FormValue("device_guid"), r.FormValue("target_path"))
+			}
+			if files := r.MultipartForm.File["files"]; len(files) != 0 {
+				t.Fatalf("expected manifest-only upload to omit file parts, got %#v", files)
+			}
+			var manifest []map[string]any
+			if err := json.Unmarshal([]byte(r.FormValue("manifest")), &manifest); err != nil {
+				t.Fatalf("manifest decode failed: %v", err)
+			}
+			if len(manifest) != 1 || manifest[0]["name"] != "Test.ini" || manifest[0]["size_bytes"].(float64) != 0 {
+				t.Fatalf("unexpected manifest %#v", manifest)
+			}
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"transfer_id":    "transfer-empty",
+				"direction":      "upload",
+				"status":         "pending",
+				"hostname":       "LAB-OPERATOR-01",
+				"bytes_complete": 0,
+				"bytes_total":    0,
+				"item_count":     1,
+			})
+		default:
+			t.Fatalf("unexpected worker path %s", r.URL.Path)
+		}
+	}))
+	defer worker.Close()
+
+	store := &fakeProcessStore{
+		profile: operatorProfile{Username: "operator", Role: "Admin"},
+		snapshot: deviceProcessContext{
+			GUID:     "00000000-0000-4000-8000-000000000123",
+			Hostname: "LAB-OPERATOR-01",
+			AgentID:  "LAB-OPERATOR-01_SYSTEM",
+			Route:    routeForTestWorker(t, worker.URL),
+		},
+	}
+	mux := http.NewServeMux()
+	registerRemoteFileRoutes(mux, processTestAuth(store), http.NotFoundHandler())
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	if err := writer.WriteField("target_path", "C:\\Temp"); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.WriteField("manifest", `[{"client_key":"Test.ini","name":"Test.ini","relative_path":"Test.ini","size_bytes":0,"modified_at":0}]`); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/api/device/files/LAB-OPERATOR-01/upload", &body)
+	request.Header.Set("Authorization", "Bearer "+testAuthToken)
+	request.Header.Set("Content-Type", writer.FormDataContentType())
+	mux.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if !sawUpload {
+		t.Fatalf("expected manifest-only upload request")
+	}
+}
+
 func TestRemoteFileTransferContentProxiesWorkerStream(t *testing.T) {
 	worker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get(internalTokenHeader); got != goInternalToken([]byte("test-secret")) {

--- a/Data/Engine/Containers/api-backend/data/services/job_scheduler/worker_socket.py
+++ b/Data/Engine/Containers/api-backend/data/services/job_scheduler/worker_socket.py
@@ -26,6 +26,7 @@ from Data.Engine.db import dbapi as sqlite3
 from Data.Engine.services.remote_files.transfers import (
     FILE_TRANSFER_SESSION_TTL_SECONDS,
     FileTransferStore,
+    _manifest_has_only_empty_files,
     _normalize_text as _normalize_file_text,
     _normalize_transfer_entries,
     _sanitize_upload_name,
@@ -555,8 +556,20 @@ class SiteWorkerSocketRuntime:
                 overwrite_keys = json.loads(_normalize_file_text(request.form.get("overwrite_keys")) or "[]")
             except Exception:
                 overwrite_keys = []
-            if not hostname or not device_guid or not target_path or not files or not manifest_items:
-                return jsonify({"error": "invalid_request"}), 400
+            manifest_only_empty_upload = _manifest_has_only_empty_files(manifest_items)
+            missing_fields = []
+            if not hostname:
+                missing_fields.append("hostname")
+            if not device_guid:
+                missing_fields.append("device_guid")
+            if not target_path:
+                missing_fields.append("target_path")
+            if not manifest_items:
+                missing_fields.append("manifest")
+            if not files and not manifest_only_empty_upload:
+                missing_fields.append("files")
+            if missing_fields:
+                return jsonify({"error": "invalid_request", "missing": missing_fields}), 400
             try:
                 snapshot = self._file_transfer_store.create_upload_session(
                     hostname=hostname,

--- a/Data/Engine/Containers/api-backend/data/services/remote_files/transfers.py
+++ b/Data/Engine/Containers/api-backend/data/services/remote_files/transfers.py
@@ -136,6 +136,23 @@ def _upload_manifest_from_form(form_value: Any, files: Iterable[Any]) -> list[Di
     return _normalize_upload_manifest_items(fallback_rows)
 
 
+def _manifest_has_only_empty_files(manifest_items: Iterable[Dict[str, Any]]) -> bool:
+    rows = list(manifest_items or [])
+    if not rows:
+        return False
+    for row in rows:
+        if not _sanitize_upload_name((row or {}).get("name")):
+            return False
+        if not _sanitize_relative_upload_path((row or {}).get("relative_path"), fallback_name=(row or {}).get("name")):
+            return False
+        try:
+            if int((row or {}).get("size_bytes") or 0) != 0:
+                return False
+        except Exception:
+            return False
+    return True
+
+
 def _transfer_status_snapshot(session: Dict[str, Any]) -> Dict[str, Any]:
     return {
         "transfer_id": session.get("transfer_id") or "",
@@ -233,16 +250,21 @@ class FileTransferStore:
         bytes_total = 0
         manifest_list = list(manifest_items or [])
         upload_list = list(files or [])
-        if manifest_list and len(manifest_list) != len(upload_list):
+        manifest_only_empty_upload = not upload_list and _manifest_has_only_empty_files(manifest_list)
+        if manifest_list and len(manifest_list) != len(upload_list) and not manifest_only_empty_upload:
             shutil.rmtree(session_dir, ignore_errors=True)
             raise ValueError("upload_manifest_mismatch")
         overwrite_source = list(overwrite_keys or []) or list(overwrite_names or [])
         overwrite_lookup = {_normalize_text(key): True for key in overwrite_source if _normalize_text(key)}
-        paired_rows = (
-            zip(upload_list, manifest_list)
-            if manifest_list
-            else ((storage, {"name": getattr(storage, "filename", ""), "relative_path": getattr(storage, "filename", "")}) for storage in upload_list)
-        )
+        if manifest_only_empty_upload:
+            paired_rows = ((None, manifest_row) for manifest_row in manifest_list)
+        elif manifest_list:
+            paired_rows = zip(upload_list, manifest_list)
+        else:
+            paired_rows = (
+                (storage, {"name": getattr(storage, "filename", ""), "relative_path": getattr(storage, "filename", "")})
+                for storage in upload_list
+            )
         for storage, manifest_row in paired_rows:
             filename = _sanitize_upload_name((manifest_row or {}).get("name") or getattr(storage, "filename", ""))
             relative_path = _sanitize_relative_upload_path((manifest_row or {}).get("relative_path"), fallback_name=filename)
@@ -251,7 +273,10 @@ class FileTransferStore:
                 continue
             item_id = uuid.uuid4().hex
             stored_path = uploads_dir / f"{item_id}.bin"
-            storage.save(stored_path)
+            if storage is None:
+                stored_path.write_bytes(b"")
+            else:
+                storage.save(stored_path)
             try:
                 size_bytes = int(stored_path.stat().st_size)
             except Exception:

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/Devices/Tabs/Remote_File_Management.editorLanguage.test.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/Devices/Tabs/Remote_File_Management.editorLanguage.test.jsx
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { detectEditorLanguage } from "@/Devices/Tabs/Remote_File_Management.jsx";
+
+describe("Remote File Management editor language detection", () => {
+  it("recognizes INI and service-style configuration files", () => {
+    expect(detectEditorLanguage("C:\\ProgramData\\Borealis\\agent.ini")).toBe("ini");
+    expect(detectEditorLanguage("/etc/systemd/system/borealis.service")).toBe("ini");
+    expect(detectEditorLanguage("/opt/app/.env.production")).toBe("ini");
+  });
+
+  it("keeps logs and basic text-like files editable as plaintext", () => {
+    expect(detectEditorLanguage("/var/log/borealis/engine.log")).toBe("plaintext");
+    expect(detectEditorLanguage("/tmp/script.out")).toBe("plaintext");
+    expect(detectEditorLanguage("/tmp/table.tsv")).toBe("plaintext");
+    expect(detectEditorLanguage("/opt/app/README")).toBe("plaintext");
+  });
+});

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/Devices/Tabs/Remote_File_Management.test.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/Devices/Tabs/Remote_File_Management.test.jsx
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildRemoteChildPath,
+  validateNewTextFileName,
+} from "@/Devices/Tabs/Remote_File_Management.jsx";
+
+describe("Remote File Management helpers", () => {
+  it("validates new text file names for target platform", () => {
+    expect(validateNewTextFileName("script.ps1", "windows")).toBe("");
+    expect(validateNewTextFileName("notes.log", "linux")).toBe("");
+    expect(validateNewTextFileName("../script.ps1", "linux")).toContain("path separators");
+    expect(validateNewTextFileName("CON", "windows")).toContain("reserved");
+    expect(validateNewTextFileName("script.ps1.", "windows")).toContain("space or period");
+  });
+
+  it("builds child file paths using remote platform separators", () => {
+    expect(buildRemoteChildPath("C:\\Temp\\", "script.ps1", "windows")).toBe("C:\\Temp\\script.ps1");
+    expect(buildRemoteChildPath("/opt/Borealis/", "script.sh", "linux")).toBe("/opt/Borealis/script.sh");
+    expect(buildRemoteChildPath("/", "agent.log", "linux")).toBe("/agent.log");
+  });
+});

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Remote_File_Management.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Remote_File_Management.jsx
@@ -713,6 +713,25 @@ const CODEMIRROR_LANGUAGE_FACTORIES = {
   xml: () => [xmlLanguage()],
   yaml: () => [yamlLanguage()],
 };
+const BASIC_TEXT_EXTENSIONS = new Set([
+  ".csv",
+  ".err",
+  ".log",
+  ".lst",
+  ".list",
+  ".out",
+  ".text",
+  ".trace",
+  ".tsv",
+  ".txt",
+]);
+const BASIC_TEXT_FILE_NAMES = new Set([
+  "authors",
+  "changelog",
+  "license",
+  "notice",
+  "readme",
+]);
 
 function normalizeText(value) {
   if (value == null) return "";
@@ -1043,9 +1062,10 @@ function getEditorFileName(pathValue) {
   return normalizeText(pathValue).toLowerCase().split(/[\\/]/).filter(Boolean).pop() || "";
 }
 
-function detectEditorLanguage(pathValue) {
+export function detectEditorLanguage(pathValue) {
   const normalizedPath = normalizeText(pathValue).toLowerCase();
   const fileName = getEditorFileName(pathValue);
+  const extension = getFileExtension(pathValue);
   if (!normalizedPath) return "plaintext";
   if (fileName === "dockerfile" || fileName === "containerfile" || fileName.endsWith(".dockerfile")) {
     return "dockerfile";
@@ -1175,7 +1195,7 @@ function detectEditorLanguage(pathValue) {
   if (normalizedPath.endsWith(".java")) {
     return "java";
   }
-  if (normalizedPath.endsWith(".log") || normalizedPath.endsWith(".txt")) {
+  if (BASIC_TEXT_EXTENSIONS.has(extension) || BASIC_TEXT_FILE_NAMES.has(fileName)) {
     return "plaintext";
   }
   return "plaintext";
@@ -2387,7 +2407,8 @@ export default function RemoteFileManagement({ device }) {
         icon: "success",
         variant: "success",
       });
-      await refreshBaseView();
+      handleCloseEditor();
+      void refreshBaseView();
     } catch (saveError) {
       const message = String(saveError?.message || saveError);
       setEditorError(message);
@@ -2408,6 +2429,7 @@ export default function RemoteFileManagement({ device }) {
     editorPath,
     editorSaving,
     hostname,
+    handleCloseEditor,
     notifyOperator,
     refreshBaseView,
   ]);

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Remote_File_Management.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Remote_File_Management.jsx
@@ -803,14 +803,18 @@ export function buildRemoteChildPath(parentPath, childName, platform = "") {
   return `${parent.replace(/\/+$/, "")}/${name}`;
 }
 
-function createEmptyTextUploadFile(fileName) {
-  if (typeof File === "function") {
-    return new File([""], fileName, { type: "text/plain", lastModified: Date.now() });
-  }
-  const blob = new Blob([""], { type: "text/plain" });
-  blob.name = fileName;
-  blob.lastModified = Date.now();
-  return blob;
+function buildEmptyTextFileManifest(fileName) {
+  const normalizedName = normalizeText(fileName);
+  if (!normalizedName) return [];
+  return [
+    {
+      client_key: normalizedName,
+      name: normalizedName,
+      relative_path: normalizedName,
+      size_bytes: 0,
+      modified_at: Math.floor(Date.now() / 1000),
+    },
+  ];
 }
 
 function buildUploadManifest(files = [], { preserveRelativePath = false } = {}) {
@@ -2653,7 +2657,19 @@ export default function RemoteFileManagement({ device }) {
       const uploadFiles = Array.isArray(files) ? files : [];
       const uploadManifest = Array.isArray(manifest) ? manifest : [];
       const normalizedTarget = normalizeText(targetPath);
-      if (!uploadFiles.length || !hostname || !normalizedTarget || uploadManifest.length !== uploadFiles.length) return false;
+      const manifestOnlyEmptyUpload =
+        Boolean(options?.allowEmptyManifest) &&
+        !uploadFiles.length &&
+        uploadManifest.length > 0 &&
+        uploadManifest.every((row) => Number(row?.size_bytes || 0) === 0 && normalizeText(row?.name) && normalizeText(row?.relative_path));
+      if (
+        !hostname ||
+        !normalizedTarget ||
+        (!uploadFiles.length && !manifestOnlyEmptyUpload) ||
+        (uploadFiles.length > 0 && uploadManifest.length !== uploadFiles.length)
+      ) {
+        return false;
+      }
       setActionBusy("upload");
       try {
         const formData = new FormData();
@@ -2698,9 +2714,10 @@ export default function RemoteFileManagement({ device }) {
           pendingCreatedFilesRef.current[transferId] = createdFile;
         }
         setActiveTransfers((previous) => ({ ...previous, [data.transfer_id]: data }));
+        const itemCount = Number(data?.item_count || uploadFiles.length || uploadManifest.length);
         await notifyOperator({
-          title: "Upload Started",
-          message: `Uploading ${Number(data?.item_count || uploadFiles.length)} item${Number(data?.item_count || uploadFiles.length) === 1 ? "" : "s"} to ${normalizedTarget}.`,
+          title: normalizeText(options?.startedTitle) || "Upload Started",
+          message: normalizeText(options?.startedMessage) || `Uploading ${itemCount} item${itemCount === 1 ? "" : "s"} to ${normalizedTarget}.`,
           icon: "upload",
           variant: "info",
         });
@@ -2708,7 +2725,7 @@ export default function RemoteFileManagement({ device }) {
         return true;
       } catch (uploadError) {
         await notifyOperator({
-          title: "Upload Failed",
+          title: normalizeText(options?.errorTitle) || "Upload Failed",
           message: String(uploadError?.message || uploadError),
           icon: "error",
           variant: "error",
@@ -3147,8 +3164,7 @@ export default function RemoteFileManagement({ device }) {
       }
       return;
     }
-    const uploadFile = createEmptyTextUploadFile(fileName);
-    const manifest = buildUploadManifest([uploadFile]);
+    const manifest = buildEmptyTextFileManifest(fileName);
     if (manifest.length !== 1) {
       await notifyOperator({
         title: "Create File Failed",
@@ -3178,12 +3194,16 @@ export default function RemoteFileManagement({ device }) {
         throw new Error(`${fileName} already exists in ${destination}.`);
       }
       const createdPath = buildRemoteChildPath(destination, fileName, platform);
-      const accepted = await startUploadRequest([uploadFile], manifest, destination, {}, {
+      const accepted = await startUploadRequest([], manifest, destination, {}, {
+        allowEmptyManifest: true,
         createdFile: {
           path: createdPath,
           parentPath: destination,
           name: fileName,
         },
+        startedTitle: "Creating File",
+        startedMessage: `Creating ${createdPath}.`,
+        errorTitle: "Create File Failed",
       });
       if (accepted) {
         setNewFileOpen(false);

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Remote_File_Management.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Remote_File_Management.jsx
@@ -117,6 +117,30 @@ const IMAGE_PREVIEW_MIME_TYPES = {
   ".webp": "image/webp",
 };
 const IMAGE_PREVIEW_EXTENSIONS = new Set(Object.keys(IMAGE_PREVIEW_MIME_TYPES));
+const WINDOWS_RESERVED_FILE_NAMES = new Set([
+  "con",
+  "prn",
+  "aux",
+  "nul",
+  "com1",
+  "com2",
+  "com3",
+  "com4",
+  "com5",
+  "com6",
+  "com7",
+  "com8",
+  "com9",
+  "lpt1",
+  "lpt2",
+  "lpt3",
+  "lpt4",
+  "lpt5",
+  "lpt6",
+  "lpt7",
+  "lpt8",
+  "lpt9",
+]);
 
 const REFRESH_ICON_BUTTON_SX = {
   width: 42,
@@ -731,6 +755,43 @@ function normalizeUploadRelativePath(value, fallbackName = "") {
     .map((segment) => normalizeText(segment))
     .filter(Boolean)
     .join("/");
+}
+
+export function validateNewTextFileName(value, platform = "") {
+  const name = normalizeText(value);
+  if (!name) return "File name required.";
+  if (name === "." || name === "..") return "Use a file name instead of a directory shortcut.";
+  if (/[\\/]/.test(name)) return "File name cannot include path separators.";
+  if (/[\x00-\x1f]/.test(name)) return "File name cannot include control characters.";
+  if (normalizeText(platform).toLowerCase() === "windows") {
+    if (/[<>:"|?*]/.test(name)) return "File name contains characters Windows does not allow.";
+    if (/[. ]$/.test(name)) return "Windows file names cannot end with a space or period.";
+    if (WINDOWS_RESERVED_FILE_NAMES.has(name.split(".")[0].toLowerCase())) {
+      return "File name uses a reserved Windows device name.";
+    }
+  }
+  return "";
+}
+
+export function buildRemoteChildPath(parentPath, childName, platform = "") {
+  const parent = normalizeText(parentPath);
+  const name = normalizeText(childName);
+  if (!parent || !name) return name;
+  if (normalizeText(platform).toLowerCase() === "windows") {
+    return `${parent.replace(/[\\/]+$/, "")}\\${name}`;
+  }
+  if (parent === "/") return `/${name}`;
+  return `${parent.replace(/\/+$/, "")}/${name}`;
+}
+
+function createEmptyTextUploadFile(fileName) {
+  if (typeof File === "function") {
+    return new File([""], fileName, { type: "text/plain", lastModified: Date.now() });
+  }
+  const blob = new Blob([""], { type: "text/plain" });
+  blob.name = fileName;
+  blob.lastModified = Date.now();
+  return blob;
 }
 
 function buildUploadManifest(files = [], { preserveRelativePath = false } = {}) {
@@ -1474,6 +1535,7 @@ export default function RemoteFileManagement({ device }) {
   const editorViewRef = useRef(null);
   const editorSearchInputRef = useRef(null);
   const handleSaveEditorRef = useRef(null);
+  const pendingCreatedFilesRef = useRef({});
   const imagePreviewTransfersRef = useRef({});
   const imagePreviewUrlRef = useRef("");
 
@@ -1491,6 +1553,8 @@ export default function RemoteFileManagement({ device }) {
   const [initializing, setInitializing] = useState(true);
   const [error, setError] = useState("");
   const [contextMenuState, setContextMenuState] = useState(null);
+  const [newFileOpen, setNewFileOpen] = useState(false);
+  const [newFileName, setNewFileName] = useState("");
   const [newFolderOpen, setNewFolderOpen] = useState(false);
   const [renameOpen, setRenameOpen] = useState(false);
   const [moveOpen, setMoveOpen] = useState(false);
@@ -1533,6 +1597,7 @@ export default function RemoteFileManagement({ device }) {
   const [rowLoadStateByPath, setRowLoadStateByPath] = useState({});
   const [showHiddenItems, setShowHiddenItems] = useState(false);
   const [clipboardState, setClipboardState] = useState(null);
+  const [createdFileToOpen, setCreatedFileToOpen] = useState(null);
   const [imagePreview, setImagePreview] = useState({
     open: false,
     status: "idle",
@@ -1623,6 +1688,10 @@ export default function RemoteFileManagement({ device }) {
   const resolvedClipboardTarget = useMemo(
     () => normalizeText(resolvedUploadTarget || currentPath || (platform === "windows" ? "" : "/")),
     [currentPath, platform, resolvedUploadTarget]
+  );
+  const newFileValidation = useMemo(
+    () => validateNewTextFileName(newFileName, platform),
+    [newFileName, platform]
   );
 
   useEffect(() => {
@@ -2166,13 +2235,26 @@ export default function RemoteFileManagement({ device }) {
                 });
               }
             } else {
-              void notifyOperator({
-                title: "Upload Complete",
-                message: `Uploaded ${Number(transferData?.item_count || 0)} item${Number(transferData?.item_count || 0) === 1 ? "" : "s"} to ${normalizeText(transferData?.target_path) || "the selected directory"}.`,
-                icon: "upload",
-                variant: "success",
-              });
-              void refreshBaseView();
+              const createdFile = pendingCreatedFilesRef.current[transferId];
+              if (createdFile) {
+                delete pendingCreatedFilesRef.current[transferId];
+                setCreatedFileToOpen(createdFile);
+                void notifyOperator({
+                  title: "File Created",
+                  message: `Created ${createdFile.path}.`,
+                  icon: "success",
+                  variant: "success",
+                });
+                void refreshBaseView();
+              } else {
+                void notifyOperator({
+                  title: "Upload Complete",
+                  message: `Uploaded ${Number(transferData?.item_count || 0)} item${Number(transferData?.item_count || 0) === 1 ? "" : "s"} to ${normalizeText(transferData?.target_path) || "the selected directory"}.`,
+                  icon: "upload",
+                  variant: "success",
+                });
+                void refreshBaseView();
+              }
             }
             setActiveTransfers((previous) => {
               const next = { ...previous };
@@ -2183,6 +2265,7 @@ export default function RemoteFileManagement({ device }) {
           if (normalizeText(data?.status).toLowerCase() === "failed" && !handledTransfersRef.current[handledKey]) {
             handledTransfersRef.current[handledKey] = true;
             const previewRequest = imagePreviewTransfersRef.current[transferId];
+            const createdFile = pendingCreatedFilesRef.current[transferId];
             if (previewRequest) {
               delete imagePreviewTransfersRef.current[transferId];
               setImagePreview((previous) =>
@@ -2195,8 +2278,11 @@ export default function RemoteFileManagement({ device }) {
                   : previous
               );
             }
+            if (createdFile) {
+              delete pendingCreatedFilesRef.current[transferId];
+            }
             void notifyOperator({
-              title: "Transfer Failed",
+              title: createdFile ? "File Create Failed" : "Transfer Failed",
               message: normalizeText(transferData?.error) || "The file transfer failed.",
               icon: "error",
               variant: "error",
@@ -2210,6 +2296,7 @@ export default function RemoteFileManagement({ device }) {
           if (normalizeText(data?.status).toLowerCase() === "canceled" && !handledTransfersRef.current[handledKey]) {
             handledTransfersRef.current[handledKey] = true;
             const previewRequest = imagePreviewTransfersRef.current[transferId];
+            const createdFile = pendingCreatedFilesRef.current[transferId];
             if (previewRequest) {
               delete imagePreviewTransfersRef.current[transferId];
               setImagePreview((previous) =>
@@ -2222,8 +2309,11 @@ export default function RemoteFileManagement({ device }) {
                   : previous
               );
             }
+            if (createdFile) {
+              delete pendingCreatedFilesRef.current[transferId];
+            }
             void notifyOperator({
-              title: "Transfer Canceled",
+              title: createdFile ? "File Create Canceled" : "Transfer Canceled",
               message: normalizeText(transferData?.error) || "The file transfer was canceled.",
               icon: "notification",
               variant: "info",
@@ -2346,6 +2436,21 @@ export default function RemoteFileManagement({ device }) {
     },
     [hostname, notifyOperator, selectedEntry]
   );
+
+  useEffect(() => {
+    if (!createdFileToOpen) return;
+    setCreatedFileToOpen(null);
+    void handleOpenEditor(
+      normalizeEntry({
+        path: createdFileToOpen.path,
+        parent_path: createdFileToOpen.parentPath,
+        name: createdFileToOpen.name,
+        kind: "file",
+        size_bytes: 0,
+        modified_at: Math.floor(Date.now() / 1000),
+      })
+    );
+  }, [createdFileToOpen, handleOpenEditor]);
 
   const handleSaveEditor = useCallback(async () => {
     const targetPath = normalizeText(editorPath);
@@ -2522,11 +2627,11 @@ export default function RemoteFileManagement({ device }) {
   }, []);
 
   const startUploadRequest = useCallback(
-    async (files, manifest, targetPath, conflictSelections = {}) => {
+    async (files, manifest, targetPath, conflictSelections = {}, options = {}) => {
       const uploadFiles = Array.isArray(files) ? files : [];
       const uploadManifest = Array.isArray(manifest) ? manifest : [];
       const normalizedTarget = normalizeText(targetPath);
-      if (!uploadFiles.length || !hostname || !normalizedTarget || uploadManifest.length !== uploadFiles.length) return;
+      if (!uploadFiles.length || !hostname || !normalizedTarget || uploadManifest.length !== uploadFiles.length) return false;
       setActionBusy("upload");
       try {
         const formData = new FormData();
@@ -2546,7 +2651,7 @@ export default function RemoteFileManagement({ device }) {
         const data = await response.json().catch(() => ({}));
         if (response.status === 409 && normalizeText(data?.error).toLowerCase() === "upload_conflicts") {
           openUploadConflictDialog(uploadFiles, uploadManifest, normalizedTarget, data?.conflicts || [], conflictSelections);
-          return;
+          return false;
         }
         if (response.status === 409 && normalizeText(data?.error).toLowerCase() === "agent_update_required") {
           throw new Error("This device agent needs to be updated before duplicate upload resolution is available.");
@@ -2563,7 +2668,12 @@ export default function RemoteFileManagement({ device }) {
           });
           await refreshBaseView();
           clearUploadConflictState();
-          return;
+          return true;
+        }
+        const transferId = normalizeText(data?.transfer_id);
+        const createdFile = options?.createdFile || null;
+        if (transferId && createdFile?.path) {
+          pendingCreatedFilesRef.current[transferId] = createdFile;
         }
         setActiveTransfers((previous) => ({ ...previous, [data.transfer_id]: data }));
         await notifyOperator({
@@ -2573,6 +2683,7 @@ export default function RemoteFileManagement({ device }) {
           variant: "info",
         });
         clearUploadConflictState();
+        return true;
       } catch (uploadError) {
         await notifyOperator({
           title: "Upload Failed",
@@ -2580,6 +2691,7 @@ export default function RemoteFileManagement({ device }) {
           icon: "error",
           variant: "error",
         });
+        return false;
       } finally {
         setActionBusy("");
       }
@@ -2998,6 +3110,76 @@ export default function RemoteFileManagement({ device }) {
     }
   }, [currentPath, executeJsonAction, newFolderName, platform, resolvedUploadTarget]);
 
+  const handleCreateFile = useCallback(async () => {
+    const fileName = normalizeText(newFileName);
+    const validationMessage = validateNewTextFileName(fileName, platform);
+    const destination = normalizeText(resolvedUploadTarget || currentPath || (platform === "windows" ? "" : "/"));
+    if (!destination || validationMessage) {
+      if (validationMessage) {
+        await notifyOperator({
+          title: "Create File Failed",
+          message: validationMessage,
+          icon: "error",
+          variant: "error",
+        });
+      }
+      return;
+    }
+    const uploadFile = createEmptyTextUploadFile(fileName);
+    const manifest = buildUploadManifest([uploadFile]);
+    if (manifest.length !== 1) {
+      await notifyOperator({
+        title: "Create File Failed",
+        message: "The file name could not be staged for upload.",
+        icon: "error",
+        variant: "error",
+      });
+      return;
+    }
+    setActionBusy("new-file");
+    try {
+      const response = await fetch(`/api/device/files/${encodeURIComponent(hostname)}/upload/conflicts`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          target_path: destination,
+          items: manifest,
+        }),
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(normalizeText(data?.message) || normalizeText(data?.error) || `HTTP ${response.status}`);
+      }
+      const conflicts = Array.isArray(data?.conflicts) ? data.conflicts : [];
+      if (conflicts.length) {
+        throw new Error(`${fileName} already exists in ${destination}.`);
+      }
+      const createdPath = buildRemoteChildPath(destination, fileName, platform);
+      const accepted = await startUploadRequest([uploadFile], manifest, destination, {}, {
+        createdFile: {
+          path: createdPath,
+          parentPath: destination,
+          name: fileName,
+        },
+      });
+      if (accepted) {
+        setNewFileOpen(false);
+        setNewFileName("");
+        setContextMenuState(null);
+      }
+    } catch (createError) {
+      await notifyOperator({
+        title: "Create File Failed",
+        message: String(createError?.message || createError),
+        icon: "error",
+        variant: "error",
+      });
+    } finally {
+      setActionBusy("");
+    }
+  }, [currentPath, hostname, newFileName, notifyOperator, platform, resolvedUploadTarget, startUploadRequest]);
+
   const handleRename = useCallback(async () => {
     if (!selectedEntry || !renameValue.trim()) return;
     const didRename = await executeJsonAction(
@@ -3263,6 +3445,18 @@ export default function RemoteFileManagement({ device }) {
             : "",
         onClick: () => {
           void handleOpenEditor();
+        },
+      },
+      {
+        id: "new-file",
+        group: "organize",
+        label: "New File",
+        icon: InsertDriveFileRoundedIcon,
+        disabled: !resolvedUploadTarget || !!actionBusy,
+        disabledReason: !resolvedUploadTarget ? "Select a folder or drive first." : "",
+        onClick: () => {
+          setNewFileName("");
+          setNewFileOpen(true);
         },
       },
       {
@@ -4625,6 +4819,41 @@ export default function RemoteFileManagement({ device }) {
           </Button>
           <Button onClick={handleCloseEditor} sx={DIALOG_DANGER_BUTTON_SX}>
             Discard Changes
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={newFileOpen} onClose={() => setNewFileOpen(false)} fullWidth maxWidth="xs" PaperProps={{ sx: DIALOG_PAPER_SX }}>
+        <DialogTitle sx={DIALOG_TITLE_SX}>
+          <DialogHeaderBlock
+            title="New File"
+            subtitle={resolvedUploadTarget ? `Create a new file in ${resolvedUploadTarget}` : "Select a destination folder first."}
+          />
+        </DialogTitle>
+        <DialogContent sx={DIALOG_CONTENT_SX}>
+          <TextField
+            autoFocus
+            fullWidth
+            label="File Name"
+            value={newFileName}
+            onChange={(event) => setNewFileName(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" && !newFileValidation && resolvedUploadTarget && !actionBusy) {
+                event.preventDefault();
+                void handleCreateFile();
+              }
+            }}
+            error={Boolean(newFileName && newFileValidation)}
+            helperText={newFileName && newFileValidation ? newFileValidation : " "}
+            sx={{ ...DIALOG_INPUT_SX, mt: 1.2 }}
+          />
+        </DialogContent>
+        <DialogActions sx={DIALOG_ACTIONS_SX}>
+          <Button onClick={() => setNewFileOpen(false)} sx={DIALOG_BUTTON_SX}>
+            Cancel
+          </Button>
+          <Button onClick={() => void handleCreateFile()} disabled={!newFileName.trim() || Boolean(newFileValidation) || !resolvedUploadTarget || !!actionBusy} sx={DIALOG_PRIMARY_BUTTON_SX}>
+            Create & Edit
           </Button>
         </DialogActions>
       </Dialog>

--- a/Data/Engine/Unit_Tests/test_file_management_api.py
+++ b/Data/Engine/Unit_Tests/test_file_management_api.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from Data.Engine.services.remote_files.transfers import FileTransferStore
+
+
+def test_upload_session_accepts_manifest_only_empty_file(tmp_path: Path) -> None:
+    store = FileTransferStore(tmp_path / "transfers", ttl_seconds=300, logger=logging.getLogger("test"))
+
+    snapshot = store.create_upload_session(
+        hostname="LAB-ONE",
+        device_guid="11111111-2222-3333-4444-555555555555",
+        agent_id="LAB-ONE_SYSTEM",
+        operator_id="operator",
+        target_path="C:\\Temp",
+        files=[],
+        manifest_items=[
+            {
+                "client_key": "Test.ini",
+                "name": "Test.ini",
+                "relative_path": "Test.ini",
+                "size_bytes": 0,
+                "modified_at": 0,
+            }
+        ],
+    )
+
+    session = store.get_session(snapshot["transfer_id"])
+    assert session is not None
+    assert session["item_count"] == 1
+    assert session["bytes_total"] == 0
+    item = session["upload_items"][0]
+    assert item["name"] == "Test.ini"
+    assert item["size_bytes"] == 0
+    assert Path(item["stored_path"]).read_bytes() == b""
+
+
+def test_upload_session_rejects_manifest_only_non_empty_file(tmp_path: Path) -> None:
+    store = FileTransferStore(tmp_path / "transfers", ttl_seconds=300, logger=logging.getLogger("test"))
+
+    with pytest.raises(ValueError, match="upload_manifest_mismatch"):
+        store.create_upload_session(
+            hostname="LAB-ONE",
+            device_guid="11111111-2222-3333-4444-555555555555",
+            agent_id="LAB-ONE_SYSTEM",
+            operator_id="operator",
+            target_path="C:\\Temp",
+            files=[],
+            manifest_items=[
+                {
+                    "client_key": "payload.txt",
+                    "name": "payload.txt",
+                    "relative_path": "payload.txt",
+                    "size_bytes": 12,
+                    "modified_at": 0,
+                }
+            ],
+        )

--- a/Docs/Using the Platform/file-management.md
+++ b/Docs/Using the Platform/file-management.md
@@ -1,6 +1,6 @@
 # File Management
 
-File Management lets operators browse and change a device filesystem without opening a shell. Use it for remote upload, download, folder transfer, rename, move, delete, copy, paste, folder creation, and lightweight text edits.
+File Management lets operators browse and change a device filesystem without opening a shell. Use it for remote upload, download, folder transfer, rename, move, delete, copy, paste, folder and text-file creation, and lightweight text edits.
 
 <figure class="bo-screenshot">
   <img src="../Reference/images/repo_screenshots/Agent_File_Management.png" alt="Borealis Agent File Management" loading="lazy">
@@ -29,6 +29,7 @@ Duplicate uploads show a replace-or-skip decision before transfer begins.
 ## Edit And Organize
 
 - Right-click files or folders for contextual actions.
+- `New File` creates an empty text file in the current destination and opens it in the lightweight editor.
 - Text editing opens one remote file at a time and saves back in place.
 - Copy and cut stay operator-local until paste asks the remote agent to perform the filesystem operation.
 

--- a/Docs/Using the Platform/file-management.md
+++ b/Docs/Using the Platform/file-management.md
@@ -29,7 +29,7 @@ Duplicate uploads show a replace-or-skip decision before transfer begins.
 ## Edit And Organize
 
 - Right-click files or folders for contextual actions.
-- Text editing opens one remote file at a time and saves back in place.
+- Text editing opens one remote INI, log, script, config, or other basic text file at a time. Successful saves close the editor and refresh the current file view.
 - Copy and cut stay operator-local until paste asks the remote agent to perform the filesystem operation.
 
 !!! warning

--- a/Docs/index.md
+++ b/Docs/index.md
@@ -24,7 +24,7 @@ Status means productized support in current Borealis codebase and docs, not long
     | WireGuard Tunnel | Maintain outbound WireGuard transport for remote operations and Engine-side automation reachability. | Full | Full | - |
     | Remote Shell Host | Expose interactive shell over managed WireGuard tunnel. | Full | Full | - |
     | Remote Desktop | Run endpoint-side remote desktop service used by Apache Guacamole browser sessions. | Full | - | - |
-    | File Operations | Browse, upload, folder-upload, download, cancel transfers, copy, cut, paste, rename, move, delete, create folders, and edit text files remotely. | Full | Full | - |
+    | File Operations | Browse, upload, folder-upload, download, cancel transfers, copy, cut, paste, rename, move, delete, create folders, create text files, and edit text files remotely. | Full | Full | - |
     | Registry Operations | Browse and edit Windows registry keys and values from Device Summary. | Full | - | - |
     | Process Operations | Report live process data and accept process-control actions such as End Task. | Full | Full | - |
     | Service Operations | Report service inventory and accept start, stop, and restart actions. | Full | Full | - |


### PR DESCRIPTION
## Summary

- Adds File Management `New File` action that creates a zero-byte text file through existing Agent upload transfer flow.
- Opens newly created file in lightweight editor after upload completes.
- Adds helper coverage for new file name validation and remote child path construction.
- Updates File Management docs and overview feature matrix.

## Validation

- `git diff --check` passed.
- `./Engine_Unit_Tests.sh --domain webui` blocked: runtime WebUI unit test cache missing at `Engine/Services/webui-frontend/cache/web-interface/Unit_Tests`; script instructs Engine redeploy before rerun.
- `./Engine_Unit_Tests.sh --domain files` blocked: runner found no Engine Python tests for `files` domain under `Data/Engine/Unit_Tests`.

Closes #253