### PR TITLE
issue/file-editor-basic-text-close-on-save

### DIFF
--- a/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/Devices/Tabs/Remote_File_Management.editorLanguage.test.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/Devices/Tabs/Remote_File_Management.editorLanguage.test.jsx
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { detectEditorLanguage } from "@/Devices/Tabs/Remote_File_Management.jsx";
+
+describe("Remote File Management editor language detection", () => {
+  it("recognizes INI and service-style configuration files", () => {
+    expect(detectEditorLanguage("C:\\ProgramData\\Borealis\\agent.ini")).toBe("ini");
+    expect(detectEditorLanguage("/etc/systemd/system/borealis.service")).toBe("ini");
+    expect(detectEditorLanguage("/opt/app/.env.production")).toBe("ini");
+  });
+
+  it("keeps logs and basic text-like files editable as plaintext", () => {
+    expect(detectEditorLanguage("/var/log/borealis/engine.log")).toBe("plaintext");
+    expect(detectEditorLanguage("/tmp/script.out")).toBe("plaintext");
+    expect(detectEditorLanguage("/tmp/table.tsv")).toBe("plaintext");
+    expect(detectEditorLanguage("/opt/app/README")).toBe("plaintext");
+  });
+});

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Remote_File_Management.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Remote_File_Management.jsx
@@ -713,6 +713,25 @@ const CODEMIRROR_LANGUAGE_FACTORIES = {
   xml: () => [xmlLanguage()],
   yaml: () => [yamlLanguage()],
 };
+const BASIC_TEXT_EXTENSIONS = new Set([
+  ".csv",
+  ".err",
+  ".log",
+  ".lst",
+  ".list",
+  ".out",
+  ".text",
+  ".trace",
+  ".tsv",
+  ".txt",
+]);
+const BASIC_TEXT_FILE_NAMES = new Set([
+  "authors",
+  "changelog",
+  "license",
+  "notice",
+  "readme",
+]);
 
 function normalizeText(value) {
   if (value == null) return "";
@@ -1043,9 +1062,10 @@ function getEditorFileName(pathValue) {
   return normalizeText(pathValue).toLowerCase().split(/[\\/]/).filter(Boolean).pop() || "";
 }
 
-function detectEditorLanguage(pathValue) {
+export function detectEditorLanguage(pathValue) {
   const normalizedPath = normalizeText(pathValue).toLowerCase();
   const fileName = getEditorFileName(pathValue);
+  const extension = getFileExtension(pathValue);
   if (!normalizedPath) return "plaintext";
   if (fileName === "dockerfile" || fileName === "containerfile" || fileName.endsWith(".dockerfile")) {
     return "dockerfile";
@@ -1175,7 +1195,7 @@ function detectEditorLanguage(pathValue) {
   if (normalizedPath.endsWith(".java")) {
     return "java";
   }
-  if (normalizedPath.endsWith(".log") || normalizedPath.endsWith(".txt")) {
+  if (BASIC_TEXT_EXTENSIONS.has(extension) || BASIC_TEXT_FILE_NAMES.has(fileName)) {
     return "plaintext";
   }
   return "plaintext";
@@ -2387,7 +2407,8 @@ export default function RemoteFileManagement({ device }) {
         icon: "success",
         variant: "success",
       });
-      await refreshBaseView();
+      handleCloseEditor();
+      void refreshBaseView();
     } catch (saveError) {
       const message = String(saveError?.message || saveError);
       setEditorError(message);
@@ -2408,6 +2429,7 @@ export default function RemoteFileManagement({ device }) {
     editorPath,
     editorSaving,
     hostname,
+    handleCloseEditor,
     notifyOperator,
     refreshBaseView,
   ]);

--- a/Docs/Using the Platform/file-management.md
+++ b/Docs/Using the Platform/file-management.md
@@ -29,7 +29,7 @@ Duplicate uploads show a replace-or-skip decision before transfer begins.
 ## Edit And Organize
 
 - Right-click files or folders for contextual actions.
-- Text editing opens one remote file at a time and saves back in place.
+- Text editing opens one remote INI, log, script, config, or other basic text file at a time. Successful saves close the editor and refresh the current file view.
 - Copy and cut stay operator-local until paste asks the remote agent to perform the filesystem operation.
 
 !!! warning


### PR DESCRIPTION
## Summary

- Extends File Management editor language detection for logs and common plaintext-style files (`.out`, `.err`, `.trace`, `.csv`, `.tsv`, `.list`, `README`, `LICENSE`, etc.).
- Exports `detectEditorLanguage` and adds WebUI helper coverage for INI/config/log/plaintext detection.
- Closes the editor after a successful Save while leaving failed saves open with the existing error path.
- Updates File Management docs with supported editor behavior.

## Validation

- `git diff --check` passed.
- `./Engine_Unit_Tests.sh --domain webui` blocked: runtime WebUI unit test cache missing at `Engine/Services/webui-frontend/cache/web-interface/Unit_Tests`; script instructs Engine redeploy before rerun.

Closes #237