### PR TITLE
issue/316-scheduled-job-maintenance-patch-filters

### DIFF
--- a/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/Scheduling/Scheduled_Jobs_List.filters.test.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/Scheduling/Scheduled_Jobs_List.filters.test.jsx
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildScheduledJobCategoryFlags,
+  buildScheduledJobFilterCounts,
+  filterScheduledJobRows,
+  isMaintenanceJobKind,
+  isPatchManagementJobKind,
+} from "@/Scheduling/scheduledJobFilters.js";
+
+function row(name, categoryFlags) {
+  return { name, categoryFlags };
+}
+
+describe("Scheduled Jobs list filters", () => {
+  it("classifies internal maintenance and patch jobs outside normal queues", () => {
+    const maintenance = buildScheduledJobCategoryFlags({
+      jobKind: "agent_channel_switch",
+      scheduleRaw: "immediately",
+      allTargetsEvaluated: false,
+      jobExpiredFlag: false,
+    });
+    const patchManagement = buildScheduledJobCategoryFlags({
+      jobKind: "patch_install",
+      scheduleRaw: "once",
+      allTargetsEvaluated: false,
+      jobExpiredFlag: false,
+    });
+    const normalImmediate = buildScheduledJobCategoryFlags({
+      jobKind: "automation",
+      scheduleRaw: "immediately",
+      allTargetsEvaluated: false,
+      jobExpiredFlag: false,
+    });
+
+    expect(maintenance).toMatchObject({
+      normal: false,
+      immediate: false,
+      maintenance: true,
+      patch_management: false,
+    });
+    expect(patchManagement).toMatchObject({
+      normal: false,
+      scheduled: false,
+      maintenance: false,
+      patch_management: true,
+    });
+    expect(normalImmediate).toMatchObject({
+      normal: true,
+      immediate: true,
+      maintenance: false,
+      patch_management: false,
+    });
+  });
+
+  it("keeps maintenance and patch counts separate from normal list counts", () => {
+    const rows = [
+      row("operator immediate", buildScheduledJobCategoryFlags({ jobKind: "automation", scheduleRaw: "immediately" })),
+      row("operator scheduled", buildScheduledJobCategoryFlags({ jobKind: "onboarding", scheduleRaw: "once" })),
+      row("operator completed", buildScheduledJobCategoryFlags({
+        jobKind: "automation",
+        scheduleRaw: "once",
+        allTargetsEvaluated: true,
+      })),
+      row("agent update", buildScheduledJobCategoryFlags({ jobKind: "agent_update", scheduleRaw: "immediately" })),
+      row("kb install", buildScheduledJobCategoryFlags({ jobKind: "patch_install", scheduleRaw: "once" })),
+    ];
+
+    expect(buildScheduledJobFilterCounts(rows)).toEqual({
+      normal: 3,
+      immediate: 1,
+      scheduled: 1,
+      recurring: 0,
+      completed: 1,
+      maintenance: 1,
+      patch_management: 1,
+    });
+    expect(filterScheduledJobRows(rows, "normal").map((item) => item.name)).toEqual([
+      "operator immediate",
+      "operator scheduled",
+      "operator completed",
+    ]);
+    expect(filterScheduledJobRows(rows, "maintenance").map((item) => item.name)).toEqual(["agent update"]);
+    expect(filterScheduledJobRows(rows, "patch_management").map((item) => item.name)).toEqual(["kb install"]);
+    expect(filterScheduledJobRows(rows, "unknown").map((item) => item.name)).toEqual([
+      "operator immediate",
+      "operator scheduled",
+      "operator completed",
+    ]);
+  });
+
+  it("accepts future maintenance names without broad patch false positives", () => {
+    expect(isMaintenanceJobKind("engine_maintenance")).toBe(true);
+    expect(isMaintenanceJobKind("database-maintenance")).toBe(true);
+    expect(isPatchManagementJobKind("windows_patch_policy")).toBe(true);
+    expect(isPatchManagementJobKind("dispatch")).toBe(false);
+  });
+});

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Scheduling/Scheduled_Jobs_List.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Scheduling/Scheduled_Jobs_List.jsx
@@ -35,6 +35,14 @@ import {
   parseAssembliesCollectionPayload,
   resolveAssemblyForComponent
 } from "../Assemblies/assemblyUtils";
+import {
+  FILTER_OPTIONS,
+  buildScheduledJobCategoryFlags,
+  buildScheduledJobFilterCounts,
+  filterScheduledJobRows,
+  isMaintenanceJobKind,
+  isPatchManagementJobKind,
+} from "./scheduledJobFilters.js";
 import PageBodyFrame from "../PageBodyFrame.jsx";
 import {
   DIALOG_ACTIONS_SX,
@@ -86,13 +94,6 @@ const PAGE_TITLE = "Scheduled Jobs";
 const PAGE_SUBTITLE = "Monitor scheduled, recurring, and completed Borealis jobs with live status.";
 const PAGE_ICON = HeaderIcon;
 
-const FILTER_OPTIONS = [
-  { key: "all", label: "All" },
-  { key: "immediate", label: "Immediate" },
-  { key: "scheduled", label: "Scheduled" },
-  { key: "recurring", label: "Recurring" },
-  { key: "completed", label: "Completed" },
-];
 const AUTO_SIZE_COLUMNS = [
   "componentsMeta",
   "jobType",
@@ -194,7 +195,7 @@ export default function ScheduledJobsList({ refreshToken }) {
   const [error, setError] = useState("");
   const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
   const [selectedIds, setSelectedIds] = useState(() => new Set());
-  const [jobFilterMode, setJobFilterMode] = useState("all");
+  const [jobFilterMode, setJobFilterMode] = useState("normal");
   const [assembliesPayload, setAssembliesPayload] = useState({ items: [], queue: [] });
   const [assembliesLoading, setAssembliesLoading] = useState(false);
   const [assembliesError, setAssembliesError] = useState("");
@@ -338,8 +339,10 @@ export default function ScheduledJobsList({ refreshToken }) {
           }
         };
         const mappedRows = (data?.jobs || []).map((j) => {
-          const jobKind = String(j.job_kind || "automation").toLowerCase();
+          const jobKind = String(j.job_kind || "automation").trim().toLowerCase();
           const isOnboardingJob = jobKind === "onboarding";
+          const isMaintenanceJob = isMaintenanceJobKind(jobKind);
+          const isPatchManagementJob = isPatchManagementJobKind(jobKind);
           const components = Array.isArray(j.components) ? j.components : [];
           const normalizedComponents = components.map((component) => {
             const record = resolveAssemblyForComponent(assemblyIndex, component);
@@ -372,9 +375,14 @@ export default function ScheduledJobsList({ refreshToken }) {
             label: comp.name,
             domain: comp.domain
           }));
-          const displayComponentSummaries = isOnboardingJob
-            ? [{ key: `onboarding-${j.id || j.name}`, label: "Device Onboarding", domain: "system" }]
-            : componentSummaries;
+          let displayComponentSummaries = componentSummaries;
+          if (isOnboardingJob) {
+            displayComponentSummaries = [{ key: `onboarding-${j.id || j.name}`, label: "Device Onboarding", domain: "system" }];
+          } else if (isPatchManagementJob) {
+            displayComponentSummaries = [{ key: `patch-${j.id || j.name}`, label: "Patch Install", domain: "system" }];
+          } else if (isMaintenanceJob) {
+            displayComponentSummaries = [{ key: `maintenance-${j.id || j.name}`, label: "Maintenance Task", domain: "system" }];
+          }
           const hasWorkflowComponent = normalizedComponents.some((comp) => {
             const typeRaw = String(comp?.type || comp?.assembly_type || "").trim().toLowerCase();
             const subtypeRaw = String(comp?.assembly_subtype || "").trim().toLowerCase();
@@ -433,24 +441,25 @@ export default function ScheduledJobsList({ refreshToken }) {
           const jobExpiredFlag =
             expiredCount > 0 || String(j.last_status || "").toLowerCase() === "expired";
           const scheduleRaw = String(j.schedule_type || "").toLowerCase();
-          const isImmediateType = scheduleRaw === "immediately";
-          const isScheduledType = scheduleRaw === "once";
-          const showImmediate = isImmediateType && !allTargetsEvaluated;
-          const showScheduled = isScheduledType && !allTargetsEvaluated;
-          const canComplete = isImmediateType || isScheduledType;
-          const showCompleted = canComplete && (jobExpiredFlag || allTargetsEvaluated);
-          const categoryFlags = {
-            immediate: showImmediate,
-            scheduled: showScheduled,
-            recurring: !isImmediateType && !isScheduledType,
-            completed: showCompleted
-          };
+          const categoryFlags = buildScheduledJobCategoryFlags({
+            jobKind,
+            scheduleRaw,
+            allTargetsEvaluated,
+            jobExpiredFlag,
+          });
+          const jobType = isOnboardingJob
+            ? "Device Onboarding"
+            : isPatchManagementJob
+              ? "Patch Management"
+              : isMaintenanceJob
+                ? "Maintenance"
+                : "Automation";
           return {
             id: j.id,
             name: j.name,
             scriptWorkflow: compName,
             componentsMeta: displayComponentSummaries,
-            jobType: isOnboardingJob ? "Device Onboarding" : "Automation",
+            jobType,
             target: targetText,
             occurrence,
             lastRun: fmt(j.last_run_ts),
@@ -524,20 +533,10 @@ export default function ScheduledJobsList({ refreshToken }) {
     [autoSizeTrackedColumns]
   );
 
-  const filterCounts = useMemo(() => {
-    const totals = { all: rows.length, immediate: 0, scheduled: 0, recurring: 0, completed: 0 };
-    rows.forEach((row) => {
-      if (row?.categoryFlags?.immediate) totals.immediate += 1;
-      if (row?.categoryFlags?.scheduled) totals.scheduled += 1;
-      if (row?.categoryFlags?.recurring) totals.recurring += 1;
-      if (row?.categoryFlags?.completed) totals.completed += 1;
-    });
-    return totals;
-  }, [rows]);
+  const filterCounts = useMemo(() => buildScheduledJobFilterCounts(rows), [rows]);
 
   const filteredRows = useMemo(() => {
-    if (jobFilterMode === "all") return rows;
-    return rows.filter((row) => row?.categoryFlags?.[jobFilterMode]);
+    return filterScheduledJobRows(rows, jobFilterMode);
   }, [jobFilterMode, rows]);
   const activeFilterLabel = useMemo(() => {
     const match = FILTER_OPTIONS.find((option) => option.key === jobFilterMode);
@@ -1035,6 +1034,8 @@ export default function ScheduledJobsList({ refreshToken }) {
                   borderRadius: 999,
                   border: "1px solid rgba(148,163,184,0.35)",
                   boxShadow: "0 18px 48px rgba(2,8,23,0.45)",
+                  maxWidth: "100%",
+                  overflowX: "auto",
                   padding: "4px"
                 }}
               >
@@ -1060,6 +1061,7 @@ export default function ScheduledJobsList({ refreshToken }) {
                         display: "inline-flex",
                         alignItems: "center",
                         gap: 0.6,
+                        whiteSpace: "nowrap",
                         boxShadow: active ? "0 0 18px rgba(125,211,252,0.35)" : "none",
                         transition: "all 0.2s ease",
                       }}
@@ -1087,9 +1089,7 @@ export default function ScheduledJobsList({ refreshToken }) {
                 })}
               </Box>
               <Typography variant="body2" sx={{ color: AURORA_SHELL.subtext }}>
-                {jobFilterMode === "all"
-                  ? `Showing ${filterCounts.all || 0} Jobs`
-                  : `Showing ${filterCounts[jobFilterMode] || 0} ${activeFilterLabel} job${(filterCounts[jobFilterMode] || 0) === 1 ? "" : "s"}`}
+                {`Showing ${filterCounts[jobFilterMode] || 0} ${activeFilterLabel} job${(filterCounts[jobFilterMode] || 0) === 1 ? "" : "s"}`}
               </Typography>
             </Box>
             {credentialResetWarningCount ? (

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Scheduling/scheduledJobFilters.js
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Scheduling/scheduledJobFilters.js
@@ -1,0 +1,91 @@
+export const FILTER_OPTIONS = [
+  { key: "normal", label: "Normal" },
+  { key: "immediate", label: "Immediate" },
+  { key: "scheduled", label: "Scheduled" },
+  { key: "recurring", label: "Recurring" },
+  { key: "completed", label: "Completed" },
+  { key: "maintenance", label: "Maintenance" },
+  { key: "patch_management", label: "Patch Management" },
+];
+
+const MAINTENANCE_JOB_KIND_ALIASES = new Set([
+  "agent_maintenance",
+  "agent_update",
+  "agent_channel_switch",
+  "maintenance",
+  "engine_maintenance",
+]);
+
+const PATCH_JOB_KIND_ALIASES = new Set([
+  "patch_install",
+  "patch_management",
+  "patch_deployment",
+  "ad_hoc_patch_install",
+  "policy_patch_install",
+]);
+
+function normalizeJobKind(value) {
+  return String(value || "automation").trim().toLowerCase();
+}
+
+function jobKindHasToken(jobKind, token) {
+  return normalizeJobKind(jobKind).split(/[^a-z0-9]+/).includes(token);
+}
+
+export function isMaintenanceJobKind(value) {
+  const jobKind = normalizeJobKind(value);
+  return MAINTENANCE_JOB_KIND_ALIASES.has(jobKind) || jobKindHasToken(jobKind, "maintenance");
+}
+
+export function isPatchManagementJobKind(value) {
+  const jobKind = normalizeJobKind(value);
+  return PATCH_JOB_KIND_ALIASES.has(jobKind) || jobKindHasToken(jobKind, "patch");
+}
+
+export function buildScheduledJobCategoryFlags({
+  jobKind,
+  scheduleRaw,
+  allTargetsEvaluated,
+  jobExpiredFlag,
+} = {}) {
+  const isMaintenance = isMaintenanceJobKind(jobKind);
+  const isPatchManagement = isPatchManagementJobKind(jobKind);
+  const isNormal = !isMaintenance && !isPatchManagement;
+  const normalizedSchedule = String(scheduleRaw || "").toLowerCase();
+  const isImmediateType = normalizedSchedule === "immediately";
+  const isScheduledType = normalizedSchedule === "once";
+  const showCompleted =
+    isNormal &&
+    (isImmediateType || isScheduledType) &&
+    (Boolean(jobExpiredFlag) || Boolean(allTargetsEvaluated));
+
+  return {
+    normal: isNormal,
+    immediate: isNormal && isImmediateType && !showCompleted,
+    scheduled: isNormal && isScheduledType && !showCompleted,
+    recurring: isNormal && !isImmediateType && !isScheduledType,
+    completed: showCompleted,
+    maintenance: isMaintenance,
+    patch_management: isPatchManagement,
+  };
+}
+
+export function buildScheduledJobFilterCounts(rowItems = []) {
+  const totals = FILTER_OPTIONS.reduce((acc, option) => {
+    acc[option.key] = 0;
+    return acc;
+  }, {});
+  (Array.isArray(rowItems) ? rowItems : []).forEach((row) => {
+    FILTER_OPTIONS.forEach((option) => {
+      if (row?.categoryFlags?.[option.key]) {
+        totals[option.key] += 1;
+      }
+    });
+  });
+  return totals;
+}
+
+export function filterScheduledJobRows(rowItems = [], mode = "normal") {
+  const selectedMode = FILTER_OPTIONS.some((option) => option.key === mode) ? mode : "normal";
+  return (Array.isArray(rowItems) ? rowItems : []).filter((row) => row?.categoryFlags?.[selectedMode]);
+}

--- a/Docs/Using the Platform/patch-management.md
+++ b/Docs/Using the Platform/patch-management.md
@@ -12,6 +12,8 @@ Patch Management shows Windows patch inventory collected by Borealis agents. Ope
 6. Use `Install` on a pending row to open a Schedule-only Scheduled Job draft for every visible device with that update pending. After the job is created, Borealis returns to Patch Management.
 7. Select two or more pending rows and use `Bulk Install` to open a Schedule-only draft that creates separate one-KB jobs sharing the same immediate or one-time schedule. After the jobs are created, Borealis returns to Patch Management.
 
+Scheduled patch-install jobs appear under the Scheduled Jobs `Patch Management` filter instead of the default `Normal` job list.
+
 Site-scoped navigation keeps the selected site in the URL as `?site=<site_id>` so operators with assigned sites only see patch inventory they can access.
 
 ## Read Device Patch Inventory

--- a/Docs/Using the Platform/scheduled-jobs.md
+++ b/Docs/Using the Platform/scheduled-jobs.md
@@ -34,6 +34,8 @@ Scheduled wall-clock times use the Engine host timezone. If the Engine host is c
 - Ansible playbooks store per-target or shared recap output depending on execution mode.
 - Patch install jobs store per-device install result, timeout or failure state, WUA result codes, reboot-required flags, and available Windows Update stdout/stderr detail.
 
+The job list opens on the `Normal` filter so operator-created automation and onboarding jobs stay separate from internal maintenance and patch-install noise. Use `Maintenance` to audit internal Agent or Engine maintenance jobs, and use `Patch Management` to review Windows patch-install jobs created from Patch Management. `Immediate`, `Scheduled`, `Recurring`, and `Completed` narrow normal jobs only.
+
 ## Onboarding Jobs
 
 Sites can launch local-network onboarding jobs that appear in Scheduled Jobs. They use discovery scope, exclusions, stored credentials, platform selection, install branch, remote ports, and concurrency limits. Successful install still requires Device Approval.
@@ -90,3 +92,4 @@ Sites can launch local-network onboarding jobs that appear in Scheduled Jobs. Th
     - Filter targets preserve allowed site scope from creation/edit time.
     - Remote SSH/WinRM Ansible requires active WireGuard peer IP and selected credential or service account path.
     - Patch install occurrences freeze target membership, queue `patch_install_run` work items, then call the site worker host-service bridge so the Agent SYSTEM socket performs WUA install work.
+    - `Scheduled_Jobs_List.jsx` defaults to the `Normal` filter. Normal, Immediate, Scheduled, Recurring, and Completed exclude `agent_maintenance` and `patch_install` job kinds. `Maintenance` includes Agent maintenance and future job-kind names with a standalone `maintenance` token. `Patch Management` includes patch job-kind names such as `patch_install`.


### PR DESCRIPTION
## Scope

Works on #316.

## Changes

- Scheduled Jobs now opens on a `Normal` filter that excludes internal maintenance jobs and Patch Management jobs.
- Added `Maintenance` and `Patch Management` slider segments, with counts and row classification from `job_kind`.
- Marked maintenance rows as `Maintenance` and patch install rows as `Patch Management` in the Type column.
- Added pure filter helper coverage for normal, maintenance, patch, and future maintenance-token job kinds.
- Updated Scheduled Jobs and Patch Management docs for operator-visible filter behavior.

## Validation

- `git diff --check` passed.
- `./Engine_Unit_Tests.sh --domain webui` could not run because `/opt/Borealis/Engine/Services/webui-frontend/cache/web-interface/Unit_Tests` is missing. Runner says redeploy Engine so WebUI source is staged into cache, then rerun.

## Risk

- Browser/Vitest validation still needed after WebUI runtime cache exists.