### PR TITLE
issue/file-management-upload-invalid-request

### DIFF
--- a/Data/Engine/Containers/api-backend/cmd/api-backend/remote_files.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/remote_files.go
@@ -290,6 +290,14 @@ func remoteFileUploadHandler(auth *authService) func(http.ResponseWriter, *http.
 			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "upload_manifest_mismatch"})
 			return
 		}
+		deviceGUID := remoteFileTransferDeviceGUID(snapshot)
+		if deviceGUID == "" {
+			writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+				"error":   "device_guid_unavailable",
+				"message": "File transfer requires a device GUID. Reconnect the Agent or refresh device inventory before uploading.",
+			})
+			return
+		}
 
 		conflictResolutions := normalizeConflictResolutionMap(r.FormValue("conflict_resolutions"))
 		conflictPayload, status, workerErr := remoteFileUploadConflictsPayload(r.Context(), auth, snapshot, operatorID, targetPath, manifestItems)
@@ -376,7 +384,7 @@ func remoteFileUploadHandler(auth *authService) func(http.ResponseWriter, *http.
 		workerURLs := remoteOpsWorkerURLs(r, snapshot.Route)
 		session, workerStatus, workerErr := remoteFilePostWorkerUpload(r.Context(), auth, snapshot.Route, remoteFileUploadWorkerRequest{
 			Hostname:        snapshot.Hostname,
-			DeviceGUID:      snapshot.GUID,
+			DeviceGUID:      deviceGUID,
 			AgentID:         snapshot.AgentID,
 			OperatorID:      operatorID,
 			TargetPath:      targetPath,
@@ -413,11 +421,19 @@ func remoteFileDownloadHandler(auth *authService) func(http.ResponseWriter, *htt
 			kind := strings.ToLower(cleanText(selections[0]["kind"]))
 			archiveRequired = kind == "directory"
 		}
+		deviceGUID := remoteFileTransferDeviceGUID(snapshot)
+		if deviceGUID == "" {
+			writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+				"error":   "device_guid_unavailable",
+				"message": "File transfer requires a device GUID. Reconnect the Agent or refresh device inventory before downloading.",
+			})
+			return
+		}
 		archiveName := guessRemoteFileDownloadName(snapshot.Hostname, selections, archiveRequired)
 		workerURLs := remoteOpsWorkerURLs(r, snapshot.Route)
 		session, workerStatus, workerErr := remoteFilePostWorkerJSON(r.Context(), auth, snapshot.Route, "/remote-files/transfers/download", map[string]any{
 			"hostname":          snapshot.Hostname,
-			"device_guid":       snapshot.GUID,
+			"device_guid":       deviceGUID,
 			"agent_id":          snapshot.AgentID,
 			"operator_id":       operatorID,
 			"items":             selections,
@@ -720,6 +736,10 @@ func decodeRemoteFileJSON(w http.ResponseWriter, r *http.Request, limit int64) (
 		body = map[string]any{}
 	}
 	return body, true
+}
+
+func remoteFileTransferDeviceGUID(snapshot deviceProcessContext) string {
+	return firstText(normalizeCanonicalGUID(snapshot.GUID), guidFromAgentID(snapshot.AgentID))
 }
 
 func requireRemoteFileContext(w http.ResponseWriter, r *http.Request, auth *authService, hostname string) (deviceProcessContext, string, bool) {

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/remote_files.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/remote_files.go
@@ -7,6 +7,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -805,51 +806,63 @@ func remoteFilePostWorkerUpload(ctx context.Context, auth *authService, route *a
 	if target == "" {
 		return nil, http.StatusServiceUnavailable, map[string]any{"error": "site_worker_unavailable", "message": "The site-worker route did not answer."}
 	}
-	pipeReader, pipeWriter := io.Pipe()
-	writer := multipart.NewWriter(pipeWriter)
-	errCh := make(chan error, 1)
-	go func() {
-		err := writeRemoteFileUploadMultipart(writer, request)
-		closeErr := writer.Close()
-		if err == nil {
-			err = closeErr
-		}
-		if err != nil {
-			_ = pipeWriter.CloseWithError(err)
-		} else {
-			_ = pipeWriter.Close()
-		}
-		errCh <- err
-	}()
+	body, contentType, contentLength, cleanup, err := remoteFileUploadMultipartBody(request)
+	if err != nil {
+		return nil, http.StatusBadGateway, map[string]any{"error": "worker_request_failed", "message": err.Error()}
+	}
+	defer cleanup()
 
 	requestCtx, cancel := context.WithTimeout(ctx, 900*time.Second)
 	defer cancel()
-	req, err := http.NewRequestWithContext(requestCtx, http.MethodPost, target, pipeReader)
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodPost, target, body)
 	if err != nil {
-		_ = pipeReader.Close()
 		return nil, http.StatusBadGateway, map[string]any{"error": "worker_request_failed", "message": err.Error()}
 	}
+	req.ContentLength = contentLength
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("Content-Type", contentType)
 	req.Header.Set(internalTokenHeader, goInternalToken(auth.verifier.secret))
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		_ = pipeReader.Close()
 		return nil, http.StatusServiceUnavailable, map[string]any{"error": "site_worker_unavailable", "message": "The site-worker route did not answer."}
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode < 400 {
-		if writeErr := <-errCh; writeErr != nil {
-			return nil, http.StatusBadGateway, map[string]any{"error": "worker_request_failed", "message": writeErr.Error()}
-		}
-	} else {
-		_ = pipeReader.Close()
-		select {
-		case <-errCh:
-		default:
+	return decodeRemoteFileWorkerJSONResponse(resp)
+}
+
+func remoteFileUploadMultipartBody(request remoteFileUploadWorkerRequest) (io.ReadCloser, string, int64, func(), error) {
+	file, err := os.CreateTemp("", "borealis-remote-file-upload-*.multipart")
+	if err != nil {
+		return nil, "", 0, func() {}, err
+	}
+	cleanup := func() {
+		name := file.Name()
+		_ = file.Close()
+		if name != "" {
+			_ = os.Remove(name)
 		}
 	}
-	return decodeRemoteFileWorkerJSONResponse(resp)
+	writer := multipart.NewWriter(file)
+	contentType := writer.FormDataContentType()
+	writeErr := writeRemoteFileUploadMultipart(writer, request)
+	closeErr := writer.Close()
+	if writeErr == nil {
+		writeErr = closeErr
+	}
+	if writeErr != nil {
+		cleanup()
+		return nil, "", 0, func() {}, writeErr
+	}
+	stat, err := file.Stat()
+	if err != nil {
+		cleanup()
+		return nil, "", 0, func() {}, err
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		cleanup()
+		return nil, "", 0, func() {}, err
+	}
+	return file, contentType, stat.Size(), cleanup, nil
 }
 
 func writeRemoteFileUploadMultipart(writer *multipart.Writer, request remoteFileUploadWorkerRequest) error {

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/remote_files_test.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/remote_files_test.go
@@ -179,7 +179,7 @@ func TestRemoteFileUploadStartsWorkerTransfer(t *testing.T) {
 			if err := r.ParseMultipartForm(1 << 20); err != nil {
 				t.Fatalf("multipart parse failed: %v", err)
 			}
-			if r.FormValue("hostname") != "LAB-OPERATOR-01" || r.FormValue("device_guid") == "" || r.FormValue("target_path") != "C:\\Temp" {
+			if r.FormValue("hostname") != "LAB-OPERATOR-01" || r.FormValue("device_guid") != "00000000-0000-4000-8000-000000000123" || r.FormValue("target_path") != "C:\\Temp" {
 				t.Fatalf("unexpected upload form host=%q guid=%q target=%q", r.FormValue("hostname"), r.FormValue("device_guid"), r.FormValue("target_path"))
 			}
 			if files := r.MultipartForm.File["files"]; len(files) != 1 || files[0].Filename != "one.txt" {
@@ -204,9 +204,8 @@ func TestRemoteFileUploadStartsWorkerTransfer(t *testing.T) {
 	store := &fakeProcessStore{
 		profile: operatorProfile{Username: "operator", Role: "Admin"},
 		snapshot: deviceProcessContext{
-			GUID:     "00000000-0000-4000-8000-000000000123",
 			Hostname: "LAB-OPERATOR-01",
-			AgentID:  "LAB-OPERATOR-01_SYSTEM",
+			AgentID:  "LAB-OPERATOR-01_00000000-0000-4000-8000-000000000123_SYSTEM",
 			Route:    routeForTestWorker(t, worker.URL),
 		},
 	}

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/remote_files_test.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/remote_files_test.go
@@ -176,6 +176,9 @@ func TestRemoteFileUploadStartsWorkerTransfer(t *testing.T) {
 			})
 		case "/remote-files/transfers/upload":
 			sawUpload = true
+			if r.ContentLength <= 0 {
+				t.Fatalf("expected upload transfer request to set content length, got %d", r.ContentLength)
+			}
 			if err := r.ParseMultipartForm(1 << 20); err != nil {
 				t.Fatalf("multipart parse failed: %v", err)
 			}

--- a/Data/Engine/Containers/api-backend/data/services/job_scheduler/worker_socket.py
+++ b/Data/Engine/Containers/api-backend/data/services/job_scheduler/worker_socket.py
@@ -547,6 +547,8 @@ class SiteWorkerSocketRuntime:
             hostname = _normalize_file_text(request.form.get("hostname"))
             device_guid = _normalize_file_text(request.form.get("device_guid"))
             agent_id = _normalize_file_text(request.form.get("agent_id"))
+            if not device_guid:
+                device_guid = normalize_guid(infer_guid_from_agent_id(agent_id))
             operator_id = _normalize_file_text(request.form.get("operator_id")) or "unknown"
             target_path = _normalize_file_text(request.form.get("target_path"))
             transfer_base_url = _normalize_file_text(request.form.get("transfer_base_url"))
@@ -627,6 +629,8 @@ class SiteWorkerSocketRuntime:
             hostname = _normalize_file_text(data.get("hostname"))
             device_guid = _normalize_file_text(data.get("device_guid"))
             agent_id = _normalize_file_text(data.get("agent_id"))
+            if not device_guid:
+                device_guid = normalize_guid(infer_guid_from_agent_id(agent_id))
             operator_id = _normalize_file_text(data.get("operator_id")) or "unknown"
             transfer_base_url = _normalize_file_text(data.get("transfer_base_url"))
             selections = _normalize_transfer_entries(data.get("items") or data.get("paths") or data.get("path"))

--- a/Data/Engine/Containers/api-backend/data/services/job_scheduler/worker_socket.py
+++ b/Data/Engine/Containers/api-backend/data/services/job_scheduler/worker_socket.py
@@ -571,7 +571,11 @@ class SiteWorkerSocketRuntime:
             if not files and not manifest_only_empty_upload:
                 missing_fields.append("files")
             if missing_fields:
-                return jsonify({"error": "invalid_request", "missing": missing_fields}), 400
+                return jsonify({
+                    "error": "invalid_request",
+                    "message": "Upload transfer request is missing: {0}.".format(", ".join(missing_fields)),
+                    "missing": missing_fields,
+                }), 400
             try:
                 snapshot = self._file_transfer_store.create_upload_session(
                     hostname=hostname,

--- a/Data/Engine/Unit_Tests/test_site_worker_socket.py
+++ b/Data/Engine/Unit_Tests/test_site_worker_socket.py
@@ -505,7 +505,6 @@ def test_site_worker_file_upload_route_stores_transfer_and_emits_worker_url(tmp_
         headers={INTERNAL_TOKEN_HEADER: internal_token("unit-internal-secret")},
         data={
             "hostname": AGENT_HOSTNAME,
-            "device_guid": AGENT_GUID,
             "agent_id": AGENT_ID,
             "operator_id": "unit",
             "target_path": r"C:\Temp",
@@ -521,6 +520,7 @@ def test_site_worker_file_upload_route_stores_transfer_and_emits_worker_url(tmp_
     stored_session = runtime._file_transfer_store.get_session(transfer_id)
     assert stored_session is not None
     assert stored_session["hostname"] == AGENT_HOSTNAME
+    assert stored_session["device_guid"] == AGENT_GUID.upper()
     assert emitted == [
         {
             "hostname": AGENT_HOSTNAME,


### PR DESCRIPTION
## Issue

Fixes #327.

## Goal

- Restore File Management upload, folder upload, and new file creation transfer paths so they no longer fail with `Upload Failed - invalid_request`.
- Preserve existing browse, folder create, delete, and text edit behavior.

## Changes

- Engine remote file upload/download derive transfer `device_guid` from canonical device GUID first, then AgentID GUID fallback.
- Worker transfer routes infer `device_guid` from `agent_id` when old callers omit it.
- Engine upload staging now sends multipart transfer requests to the site-worker with a fixed `Content-Length` instead of chunked streaming. Live Traefik logs showed `/upload` returning a 98-byte 400 body, matching worker `invalid_request` with all upload fields missing.
- Worker missing-field responses now include a human-readable message.
- Engine and worker tests cover fallback behavior and fixed-length upload transfer requests.

## Validation

- `BOREALIS_ENGINE_TEST_PYTHON=/opt/Borealis/.cache/codex-engine-tests/bin/python ./Engine_Unit_Tests.sh --domain files`
- `/opt/Borealis/Dependencies/Go/go1.23.12/bin/go test ./cmd/api-backend -run 'TestRemoteFile'`\n- `/opt/Borealis/.cache/codex-engine-tests/bin/python -m pytest Data/Engine/Unit_Tests/test_site_worker_socket.py -k 'file_upload_route_stores_transfer_and_emits_worker_url or file_download_route'`\n\n## Notes\n\n- `./Engine_Unit_Tests.sh --domain files` with system Python could not start because pytest is not installed; repo cached pytest environment was used instead.\n- `BOREALIS_ENGINE_TEST_PYTHON=/opt/Borealis/.cache/codex-engine-tests/bin/python ./Engine_Unit_Tests.sh --domain remote-access` is blocked by unrelated missing VPN/VNC modules before file-management tests run.