### PR TITLE
issue/assembly-editor-persistent-fields

### DIFF
--- a/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/Assemblies/Assembly_Editor.tabPersistence.test.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/Assemblies/Assembly_Editor.tabPersistence.test.jsx
@@ -1,0 +1,148 @@
+import React from "react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { RouterProvider, createMemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import AssemblyEditor from "@/Assemblies/Assembly_Editor.jsx";
+import { AuthContext } from "@/app/providers/AuthContext.jsx";
+import { PageChromeProvider, usePageChrome } from "@/app/providers/PageChromeContext.jsx";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function HeaderActionsProbe() {
+  const { pageChrome } = usePageChrome();
+  return (
+    <div>
+      {(pageChrome.actions || []).map((action) => (
+        <button
+          key={action.id}
+          type="button"
+          disabled={Boolean(action.disabled)}
+          onClick={action.onClick}
+        >
+          {action.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function buildAuthValue() {
+  return {
+    role: "Admin",
+    isAdmin: true,
+    ready: true,
+    isAuthenticated: true,
+  };
+}
+
+function renderAssemblyEditor() {
+  const createContext = {
+    name: "Original Assembly",
+    description: "Original Description",
+    defaultType: "powershell",
+    type: "powershell",
+  };
+  const router = createMemoryRouter(
+    [
+      {
+        path: "/assemblies/new/script",
+        element: (
+          <AuthContext.Provider value={buildAuthValue()}>
+            <PageChromeProvider>
+              <HeaderActionsProbe />
+              <AssemblyEditor />
+            </PageChromeProvider>
+          </AuthContext.Provider>
+        ),
+      },
+      {
+        path: "/assemblies",
+        element: <div>Assemblies Page</div>,
+      },
+    ],
+    {
+      initialEntries: [
+        {
+          pathname: "/assemblies/new/script",
+          state: {
+            initialAssembly: {
+              mode: "script",
+              createContext,
+              row: {
+                assemblyGuid: null,
+                name: createContext.name,
+                domain: "user",
+                createContext,
+              },
+              nonce: 331,
+            },
+          },
+        },
+      ],
+    }
+  );
+
+  render(<RouterProvider router={router} />);
+  return router;
+}
+
+describe("AssemblyEditor tab persistence", () => {
+  it("keeps edited fields while switching tabs and saves complete current state", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        assembly_guid: "A1F1E331-0000-4000-8000-000000000331",
+        source: "user",
+        name: "Edited Assembly",
+      }),
+      text: async () => "",
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(window, "alert").mockImplementation(() => {});
+
+    renderAssemblyEditor();
+
+    const nameInput = await screen.findByLabelText("Assembly Name");
+    fireEvent.change(nameInput, { target: { value: "Edited Assembly" } });
+    fireEvent.change(screen.getByLabelText("Description"), {
+      target: { value: "Edited Description" },
+    });
+
+    fireEvent.click(screen.getByRole("tab", { name: /Script/i }));
+    const scriptEditor = await screen.findByPlaceholderText("Start typing your script...");
+    fireEvent.change(scriptEditor, { target: { value: "Write-Output \"persisted\"" } });
+
+    fireEvent.click(screen.getByRole("tab", { name: /Variables/i }));
+    await screen.findByText("No variables defined yet");
+
+    fireEvent.click(screen.getByRole("tab", { name: /Summary/i }));
+    await waitFor(() => {
+      expect(screen.getByLabelText("Assembly Name")).toHaveValue("Edited Assembly");
+      expect(screen.getByLabelText("Description")).toHaveValue("Edited Description");
+    });
+
+    fireEvent.click(screen.getByRole("tab", { name: /Script/i }));
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("Start typing your script...")).toHaveValue(
+        "Write-Output \"persisted\""
+      );
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Save Assembly" }));
+    });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    const [, saveOptions] = fetchMock.mock.calls[0];
+    const saveBody = JSON.parse(saveOptions.body);
+    expect(saveBody.document.name).toBe("Edited Assembly");
+    expect(saveBody.document.description).toBe("Edited Description");
+    expect(window.atob(saveBody.document.script)).toBe("Write-Output \"persisted\"");
+  });
+});

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Assemblies/Assembly_Editor.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Assemblies/Assembly_Editor.jsx
@@ -465,6 +465,27 @@ function deriveInitialAssembly(locationState, assemblyGuid, mode) {
   return null;
 }
 
+function buildInitialAssemblySignature(incomingState, assemblyGuid, mode) {
+  const state = incomingState && typeof incomingState === "object" ? incomingState : null;
+  const row = state?.row && typeof state.row === "object" ? state.row : null;
+  const createContext =
+    (row?.createContext && typeof row.createContext === "object" ? row.createContext : null) ||
+    (state?.createContext && typeof state.createContext === "object" ? state.createContext : null);
+  return JSON.stringify({
+    mode,
+    routeAssemblyGuid: assemblyGuid || null,
+    stateAssemblyGuid: state?.assemblyGuid || row?.assemblyGuid || null,
+    stateMode: state?.mode || null,
+    statePath: state?.path || row?.sourcePath || row?.relPath || row?.path || "",
+    nonce: state?.nonce || null,
+    createName: createContext?.name || "",
+    createDescription: createContext?.description || "",
+    createType: createContext?.type || createContext?.defaultType || "",
+    rowName: row?.name || "",
+    rowDomain: row?.domain || "",
+  });
+}
+
 function GlassPanel({ children, sx }) {
   return <Box sx={[GLASS_PANEL_SX, sx]}>{children}</Box>;
 }
@@ -738,6 +759,13 @@ export default function AssemblyEditor() {
   const [errorMessage, setErrorMessage] = useState("");
   const [jsonPreviewOpen, setJsonPreviewOpen] = useState(false);
   const [jsonPreviewText, setJsonPreviewText] = useState("");
+  const routeInitialAssembly = location.state?.initialAssembly || null;
+  const routeInitialAssemblySignature = buildInitialAssemblySignature(
+    routeInitialAssembly,
+    routeAssemblyGuid || null,
+    normalizedMode
+  );
+  const lastInitialAssemblySignatureRef = useRef(routeInitialAssemblySignature);
   const { activeKey: activeTab, setActiveKey: setActiveTab } = useUrlTabState({
     param: "tab",
     defaultKey: "summary",
@@ -773,8 +801,12 @@ export default function AssemblyEditor() {
   );
 
   useEffect(() => {
+    if (lastInitialAssemblySignatureRef.current === routeInitialAssemblySignature) {
+      return;
+    }
+    lastInitialAssemblySignatureRef.current = routeInitialAssemblySignature;
     setInitialAssembly(deriveInitialAssembly(location.state, routeAssemblyGuid || null, normalizedMode));
-  }, [location.key, location.state, normalizedMode, routeAssemblyGuid]);
+  }, [location.key, location.state, normalizedMode, routeAssemblyGuid, routeInitialAssemblySignature]);
 
   useEffect(() => {
     let canceled = false;


### PR DESCRIPTION
## Summary

Fixes Assembly Editor tab switching so URL query changes no longer rehydrate the editor from initial route state or the server. Unsaved field edits now remain in the in-memory assembly document while operators move between Summary, Script/Playbook, Variables, and Files.

## Root Cause

`useUrlTabState` updates the `tab` query parameter when operators switch sections. That navigation changes `location.key`. `Assembly_Editor.jsx` treated every location key change as a new editor load and rebuilt `initialAssembly`, so tab-only navigation reset unsaved fields from the original route state or fetched assembly payload.

## Changes

- Added a stable initial-assembly signature in `Assembly_Editor.jsx`.
- Guarded the hydrate reset so it only runs when the assembly identity/source changes, not when only the tab query changes.
- Added `Assembly_Editor.tabPersistence.test.jsx` covering Summary and Script edits across tab switches and verifying Save posts the edited full document.

## Validation

- `git diff --cached --check` passed before commit.
- `./Engine_Unit_Tests.sh --domain webui` attempted, blocked by missing runtime WebUI test cache: `Engine/Services/webui-frontend/cache/web-interface/Unit_Tests` absent. Script reported redeploy required before rerun.

Fixes #331