### PR TITLE
issue/table-context-menu-buttons

### DIFF
--- a/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/Grid_Row_Context_Menu_Button.test.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/Grid_Row_Context_Menu_Button.test.jsx
@@ -14,6 +14,7 @@ describe("Grid row context menu button", () => {
     expect(columnDef.colId).toBe(ROW_CONTEXT_MENU_COL_ID);
     expect(columnDef.pinned).toBe("right");
     expect(columnDef.width).toBe(ROW_CONTEXT_MENU_COLUMN_WIDTH);
+    expect(columnDef.flex).toBe(0);
     expect(columnDef.sortable).toBe(false);
     expect(columnDef.filter).toBe(false);
     expect(columnDef.suppressHeaderContextMenu).toBe(true);

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/Grid_Row_Context_Menu_Button.test.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/Grid_Row_Context_Menu_Button.test.jsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  ROW_CONTEXT_MENU_COL_ID,
+  ROW_CONTEXT_MENU_COLUMN_WIDTH,
+  buildRowContextMenuColumnDef,
+} from "@/Grid_Row_Context_Menu_Button.jsx";
+
+describe("Grid row context menu button", () => {
+  it("builds a pinned right AG Grid action column", () => {
+    const columnDef = buildRowContextMenuColumnDef(() => {});
+
+    expect(columnDef.colId).toBe(ROW_CONTEXT_MENU_COL_ID);
+    expect(columnDef.pinned).toBe("right");
+    expect(columnDef.width).toBe(ROW_CONTEXT_MENU_COLUMN_WIDTH);
+    expect(columnDef.sortable).toBe(false);
+    expect(columnDef.filter).toBe(false);
+    expect(columnDef.suppressHeaderContextMenu).toBe(true);
+  });
+
+  it("opens a row context menu with row and node details", () => {
+    const row = { id: "row-1", name: "Example Row" };
+    const node = { id: "node-1" };
+    const openContextMenu = vi.fn();
+    const columnDef = buildRowContextMenuColumnDef(openContextMenu, {
+      tooltip: "Open row actions",
+    });
+
+    render(columnDef.cellRenderer({ data: row, node }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Open row actions" }), {
+      clientX: 230,
+      clientY: 90,
+    });
+
+    expect(openContextMenu).toHaveBeenCalledTimes(1);
+    expect(openContextMenu.mock.calls[0][1]).toBe(row);
+    expect(openContextMenu.mock.calls[0][2]).toBe(node);
+    expect(openContextMenu.mock.calls[0][0].clientX).toBe(230);
+    expect(openContextMenu.mock.calls[0][0].clientY).toBe(90);
+  });
+});

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/Row_Context_Menu.test.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/Row_Context_Menu.test.jsx
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { buildContextMenuGroups } from "@/Row_Context_Menu.jsx";
+
+describe("Row context menu grouping", () => {
+  it("keeps visible actions in Borealis group order", () => {
+    const groups = buildContextMenuGroups([
+      { id: "delete", group: "danger", label: "Delete" },
+      { id: "open", group: "primary", label: "Open" },
+      { id: "hidden", group: "primary", label: "Hidden", hidden: true },
+      { id: "archive", group: "organize", label: "Archive" },
+    ]);
+
+    expect(groups.map((group) => group.id)).toEqual(["primary", "organize", "danger"]);
+    expect(groups[0].actions.map((action) => action.id)).toEqual(["open"]);
+    expect(groups[1].actions.map((action) => action.id)).toEqual(["archive"]);
+    expect(groups[2].actions.map((action) => action.id)).toEqual(["delete"]);
+  });
+});

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Access_Management/Credential_List.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Access_Management/Credential_List.jsx
@@ -2,15 +2,13 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Alert,
   Box,
-  IconButton,
-  Menu,
-  MenuItem,
   Paper,
   Tooltip,
   Typography,
 } from "@mui/material";
-import MoreVertIcon from "@mui/icons-material/MoreVert";
 import AddIcon from "@mui/icons-material/Add";
+import DeleteRoundedIcon from "@mui/icons-material/DeleteRounded";
+import EditRoundedIcon from "@mui/icons-material/EditRounded";
 import RefreshIcon from "@mui/icons-material/Refresh";
 import LockIcon from "@mui/icons-material/Lock";
 import LockOpenIcon from "@mui/icons-material/LockOpenRounded";
@@ -26,6 +24,8 @@ import { ConfirmDeleteDialog } from "../Dialogs.jsx";
 import PageBodyFrame from "../PageBodyFrame.jsx";
 import { useRoutePageChrome } from "../app/hooks/useRoutePageChrome.js";
 import { useAuth } from "../app/providers/AuthContext.jsx";
+import { buildRowContextMenuColumnDef } from "../Grid_Row_Context_Menu_Button.jsx";
+import RowContextMenu from "../Row_Context_Menu.jsx";
 
 ModuleRegistry.registerModules([AllCommunityModule]);
 
@@ -205,7 +205,7 @@ export default function CredentialList() {
   const [loading, setLoading] = useState(false);
   const [githubLoading, setGithubLoading] = useState(false);
   const [error, setError] = useState("");
-  const [menuAnchor, setMenuAnchor] = useState(null);
+  const [contextMenu, setContextMenu] = useState(null);
   const [menuRow, setMenuRow] = useState(null);
   const [editorOpen, setEditorOpen] = useState(false);
   const [editorMode, setEditorMode] = useState("create");
@@ -224,13 +224,25 @@ export default function CredentialList() {
   );
   const gridRows = useMemo(() => [aegisRow, githubTokenRow, ...rows], [aegisRow, githubTokenRow, rows]);
 
-  const openMenu = useCallback((event, row) => {
-    setMenuAnchor(event.currentTarget);
+  const openMenu = useCallback((event, row, node = null) => {
+    const mouseEvent = event?.event || event;
+    mouseEvent?.preventDefault?.();
+    mouseEvent?.stopPropagation?.();
+    if (!row) return;
+    try {
+      if (node && !node.isSelected?.()) {
+        node.setSelected?.(true, true);
+      }
+    } catch {}
     setMenuRow(row);
+    setContextMenu({
+      top: Number(mouseEvent?.clientY || 0),
+      left: Number(mouseEvent?.clientX || 0),
+    });
   }, []);
 
   const closeMenu = useCallback(() => {
-    setMenuAnchor(null);
+    setContextMenu(null);
     setMenuRow(null);
   }, []);
 
@@ -266,24 +278,6 @@ export default function CredentialList() {
       </Box>
     );
   }, []);
-
-  const actionCellRenderer = useCallback(
-    (params) => {
-      const row = params.data;
-      if (!row) return null;
-      const handleClick = (event) => {
-        event.preventDefault();
-        event.stopPropagation();
-        openMenu(event, row);
-      };
-      return (
-        <IconButton size="small" onClick={handleClick} sx={{ color: "#7db7ff" }}>
-          <MoreVertIcon fontSize="small" />
-        </IconButton>
-      );
-    },
-    [openMenu]
-  );
 
   const nameComparator = useCallback((valueA, valueB, nodeA, nodeB) => {
     const sortWeight = (rowKind) => {
@@ -387,20 +381,9 @@ export default function CredentialList() {
         field: "updated_at",
         valueGetter: (params) => formatTs(params.data?.updated_at || params.data?.created_at)
       },
-      {
-        headerName: "",
-        field: "__actions__",
-        minWidth: 70,
-        maxWidth: 80,
-        sortable: false,
-        filter: false,
-        resizable: false,
-        suppressHeaderMenuButton: true,
-        cellRenderer: actionCellRenderer,
-        pinned: "right"
-      }
+      buildRowContextMenuColumnDef(openMenu, { tooltip: "Credential Actions" })
     ],
-    [actionCellRenderer, connectionCellRenderer, nameComparator]
+    [connectionCellRenderer, nameComparator, openMenu]
   );
 
   const defaultColDef = useMemo(
@@ -631,43 +614,64 @@ export default function CredentialList() {
     return actions;
   }, [canMutateCredentials, githubLoading, handleCreate, loading, refreshCredentialPage]);
 
-  const menuItems = useMemo(() => {
+  const menuActions = useMemo(() => {
     if (menuRow?.row_kind === "aegis") {
       return [
-        <MenuItem key="aegis-rotate" onClick={() => handleAegisMenuAction("rotate")}>
-          Rotate Aegis Cipher
-        </MenuItem>,
-        <MenuItem
-          key="aegis-force-reset"
-          onClick={() => handleAegisMenuAction("force_reset")}
-          sx={{ color: "#ff9aa5" }}
-        >
-          Force Reset Aegis Cipher
-        </MenuItem>,
+        {
+          id: "aegis-rotate",
+          label: "Rotate Aegis Cipher",
+          icon: VpnKeyIcon,
+          group: "primary",
+          description: "Re-key protected secret storage.",
+          onClick: () => handleAegisMenuAction("rotate"),
+        },
+        {
+          id: "aegis-force-reset",
+          label: "Force Reset Aegis Cipher",
+          icon: WarningAmberRoundedIcon,
+          group: "danger",
+          intent: "danger",
+          description: "Remove stored protected secret material.",
+          onClick: () => handleAegisMenuAction("force_reset"),
+        },
       ];
     }
     if (menuRow?.row_kind === "github_token") {
       return [
-        <MenuItem key="github-token-edit" disabled={!canMutateCredentials} onClick={() => handleEdit(menuRow)}>
-          Edit Token
-        </MenuItem>,
+        {
+          id: "github-token-edit",
+          label: "Edit Token",
+          icon: EditRoundedIcon,
+          group: "primary",
+          disabled: !canMutateCredentials,
+          disabledReason: !canMutateCredentials ? "Finish bootstrap before editing credentials." : "",
+          onClick: () => handleEdit(menuRow),
+        },
       ];
     }
     if (!menuRow) {
       return [];
     }
     return [
-      <MenuItem key="credential-edit" disabled={!canMutateCredentials} onClick={() => handleEdit(menuRow)}>
-        Edit
-      </MenuItem>,
-      <MenuItem
-        key="credential-delete"
-        disabled={!canMutateCredentials}
-        onClick={() => handleDelete(menuRow)}
-        sx={{ color: canMutateCredentials ? "#ff8080" : "inherit" }}
-      >
-        Delete
-      </MenuItem>,
+      {
+        id: "credential-edit",
+        label: "Edit",
+        icon: EditRoundedIcon,
+        group: "primary",
+        disabled: !canMutateCredentials,
+        disabledReason: !canMutateCredentials ? "Finish bootstrap before editing credentials." : "",
+        onClick: () => handleEdit(menuRow),
+      },
+      {
+        id: "credential-delete",
+        label: "Delete",
+        icon: DeleteRoundedIcon,
+        group: "danger",
+        intent: "danger",
+        disabled: !canMutateCredentials,
+        disabledReason: !canMutateCredentials ? "Finish bootstrap before deleting credentials." : "",
+        onClick: () => handleDelete(menuRow),
+      },
     ];
   }, [
     canMutateCredentials,
@@ -676,6 +680,24 @@ export default function CredentialList() {
     handleEdit,
     menuRow,
   ]);
+
+  const contextMenuHeaderIcon = useMemo(() => {
+    if (menuRow?.row_kind === "aegis") return VpnKeyIcon;
+    if (menuRow?.row_kind === "github_token") return GitHubIcon;
+    if (String(menuRow?.credential_type || "").toLowerCase() === "machine") return ComputerIcon;
+    return LockIcon;
+  }, [menuRow]);
+
+  const contextMenuSubtitle = useMemo(() => {
+    if (!menuRow) return "Credential actions";
+    if (menuRow.row_kind === "aegis") {
+      return menuRow.site_name || menuRow.aegis_status_label || "Protected secrets";
+    }
+    if (menuRow.row_kind === "github_token") {
+      return menuRow.github_rate_label || "GitHub API rate limit";
+    }
+    return `${formatCredentialConnectionLabel(menuRow)} - ${menuRow.site_name || "Global"}`;
+  }, [menuRow]);
 
   useRoutePageChrome({
     title: "Credentials",
@@ -781,20 +803,23 @@ export default function CredentialList() {
             getRowId={getRowId}
             overlayNoRowsTemplate="<span class='ag-overlay-no-rows-center'>No credentials have been created yet.</span>"
             suppressCellFocus
+            suppressContextMenu
+            preventDefaultOnContextMenu
+            onCellContextMenu={(params) => openMenu(params.event, params.data, params.node)}
             theme={myTheme}
           />
         </Box>
       </PageBodyFrame>
 
-      <Menu
-        anchorEl={menuAnchor}
-        open={Boolean(menuAnchor)}
+      <RowContextMenu
+        open={Boolean(contextMenu)}
         onClose={closeMenu}
-        elevation={2}
-        PaperProps={{ sx: { bgcolor: "#1f1f1f", color: "#f5f5f5" } }}
-      >
-        {menuItems}
-      </Menu>
+        position={contextMenu ? { top: contextMenu.top, left: contextMenu.left } : null}
+        headerIcon={contextMenuHeaderIcon}
+        title={menuRow?.name || "Credential Actions"}
+        subtitle={contextMenuSubtitle}
+        actions={menuActions}
+      />
 
       <CredentialEditor
         open={editorOpen}

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Access_Management/Directory_Services.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Access_Management/Directory_Services.jsx
@@ -33,6 +33,7 @@ import SettingsEthernetRoundedIcon from "@mui/icons-material/SettingsEthernetRou
 import SyncIcon from "@mui/icons-material/Sync";
 import { AgGridReact } from "ag-grid-react";
 import { ModuleRegistry, AllCommunityModule, themeQuartz } from "ag-grid-community";
+import { buildRowContextMenuColumnDef } from "../Grid_Row_Context_Menu_Button.jsx";
 import PageBodyFrame from "../PageBodyFrame.jsx";
 import {
   DIALOG_ACTIONS_SX,
@@ -960,7 +961,8 @@ export default function DirectoryServices() {
       minWidth: 180,
       valueFormatter: (params) => formatTs(params.value),
     },
-  ], []);
+    buildRowContextMenuColumnDef(openContextMenu, { tooltip: "Credential Provider Actions" }),
+  ], [openContextMenu]);
 
   const availableSitesById = useMemo(() => {
     const byId = new Map();

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Access_Management/Users.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Access_Management/Users.jsx
@@ -4,8 +4,6 @@ import {
   Paper,
   Box,
   Typography,
-  IconButton,
-  Menu,
   MenuItem,
   Button,
   Dialog,
@@ -17,11 +15,14 @@ import {
   Checkbox,
   Stack,
 } from "@mui/material";
-import MoreVertIcon from "@mui/icons-material/MoreVert";
 import AccountTreeRoundedIcon from "@mui/icons-material/AccountTreeRounded";
+import AdminPanelSettingsIcon from "@mui/icons-material/AdminPanelSettings";
+import DeleteRoundedIcon from "@mui/icons-material/DeleteRounded";
 import GroupIcon from "@mui/icons-material/Group";
 import LocationCityIcon from "@mui/icons-material/LocationCity";
+import LockResetIcon from "@mui/icons-material/LockReset";
 import PersonAddAlt1Icon from "@mui/icons-material/PersonAddAlt1";
+import SecurityRoundedIcon from "@mui/icons-material/SecurityRounded";
 import { AgGridReact } from "ag-grid-react";
 import { ModuleRegistry, AllCommunityModule, themeQuartz } from "ag-grid-community";
 import { ConfirmDeleteDialog } from "../Dialogs.jsx";
@@ -42,6 +43,8 @@ import { useAppNotifications } from "../app/hooks/useAppNotifications.js";
 import { useRoutePageChrome } from "../app/hooks/useRoutePageChrome.js";
 import { useAuth } from "../app/providers/AuthContext.jsx";
 import { buildSiteAssignmentPath } from "../app/routes/paths.js";
+import { buildRowContextMenuColumnDef } from "../Grid_Row_Context_Menu_Button.jsx";
+import RowContextMenu from "../Row_Context_Menu.jsx";
 
 ModuleRegistry.registerModules([AllCommunityModule]);
 
@@ -95,7 +98,7 @@ export default function UserManagement() {
   const navigate = useNavigate();
   const { isAdmin } = useAuth();
   const [rows, setRows] = useState([]);
-  const [menuAnchor, setMenuAnchor] = useState(null);
+  const [contextMenu, setContextMenu] = useState(null);
   const [menuUser, setMenuUser] = useState(null);
   const [resetOpen, setResetOpen] = useState(false);
   const [resetTarget, setResetTarget] = useState(null);
@@ -239,16 +242,28 @@ export default function UserManagement() {
     []
   );
 
-  const openMenu = (event, user) => {
-    setMenuAnchor(event.currentTarget);
+  const openMenu = useCallback((event, user, node = null) => {
+    const mouseEvent = event?.event || event;
+    mouseEvent?.preventDefault?.();
+    mouseEvent?.stopPropagation?.();
+    if (!user) return;
+    try {
+      if (node && !node.isSelected?.()) {
+        node.setSelected?.(true, true);
+      }
+    } catch {}
     setMenuUser(user);
-  };
-  const closeMenu = () => {
-    setMenuAnchor(null);
+    setContextMenu({
+      top: Number(mouseEvent?.clientY || 0),
+      left: Number(mouseEvent?.clientX || 0),
+    });
+  }, []);
+  const closeMenu = useCallback(() => {
+    setContextMenu(null);
     setMenuUser(null);
-  };
+  }, []);
 
-  const confirmDelete = (user) => {
+  const confirmDelete = useCallback((user) => {
     if (!user) return;
     if (isDirectoryUser(user)) {
       setWarnMessage("Directory users are managed by their source provider. Disable the cached directory user instead.");
@@ -262,7 +277,7 @@ export default function UserManagement() {
     }
     setDeleteTarget(user);
     setConfirmDeleteOpen(true);
-  };
+  }, [me]);
 
   const doDelete = async () => {
     const user = deleteTarget;
@@ -292,7 +307,7 @@ export default function UserManagement() {
     }
   };
 
-  const openChangeRole = (user) => {
+  const openChangeRole = useCallback((user) => {
     if (!user) return;
     if (isDirectoryUser(user)) {
       setWarnMessage("Directory user roles are managed by Directory Services group mappings.");
@@ -308,7 +323,7 @@ export default function UserManagement() {
     setChangeRoleTarget(user);
     setChangeRoleNext(nextRole);
     setConfirmChangeRoleOpen(true);
-  };
+  }, [me]);
 
   const doChangeRole = async () => {
     const user = changeRoleTarget;
@@ -340,7 +355,7 @@ export default function UserManagement() {
     }
   };
 
-  const openResetMfa = (user) => {
+  const openResetMfa = useCallback((user) => {
     if (!user) return;
     if (isDirectoryUser(user)) {
       setWarnMessage("Directory user MFA is reset by the operator from their own account recovery controls.");
@@ -349,9 +364,9 @@ export default function UserManagement() {
     }
     setResetMfaTarget(user);
     setResetMfaOpen(true);
-  };
+  }, []);
 
-  const openChangeMfaState = (user) => {
+  const openChangeMfaState = useCallback((user) => {
     if (!user) return;
     if (isDirectoryUser(user)) {
       setWarnMessage("Directory users must keep Borealis MFA enabled.");
@@ -361,7 +376,7 @@ export default function UserManagement() {
     setConfirmMfaStateTarget(user);
     setConfirmMfaStateNextEnabled(!Boolean(user.mfa_enabled));
     setConfirmMfaStateOpen(true);
-  };
+  }, []);
 
   const doChangeMfaState = async () => {
     const user = confirmMfaStateTarget;
@@ -542,7 +557,7 @@ export default function UserManagement() {
     }
   };
 
-  const openReset = (user) => {
+  const openReset = useCallback((user) => {
     if (!user) return;
     if (isDirectoryUser(user)) {
       setWarnMessage("Directory user passwords are managed by their source provider.");
@@ -552,7 +567,7 @@ export default function UserManagement() {
     setResetTarget(user);
     setResetOpen(true);
     setNewPassword("");
-  };
+  }, []);
 
   const openCreate = useCallback(() => {
     setCreateOpen(true);
@@ -660,6 +675,108 @@ export default function UserManagement() {
       setWarnOpen(true);
     }
   };
+
+  const userContextActions = useMemo(() => {
+    const user = menuUser;
+    if (!user) return [];
+    const directory = isDirectoryUser(user);
+    const currentUser = Boolean(
+      me && user.username && String(me.username).toLowerCase() === String(user.username).toLowerCase()
+    );
+    const mfaBusy = Boolean(
+      mfaBusyUser && String(mfaBusyUser).toLowerCase() === String(user.username || "").toLowerCase()
+    );
+    const recoveryRequired = Boolean(user.auth_reset_required);
+    const mfaEnabled = Boolean(user.mfa_enabled);
+    const protectedUserReason = directory
+      ? "Directory users are managed by their source provider."
+      : currentUser
+      ? "Cannot change current signed-in operator."
+      : "";
+    const resetMfaDisabledReason = directory
+      ? "Directory user MFA is reset by account recovery controls."
+      : !mfaEnabled
+      ? "MFA is not enabled."
+      : recoveryRequired
+      ? "Recover account before resetting MFA."
+      : "";
+    const mfaToggleDisabledReason = directory
+      ? "Directory users must keep Borealis MFA enabled."
+      : recoveryRequired
+      ? "Recover account before changing MFA."
+      : mfaBusy
+      ? "MFA update already in progress."
+      : "";
+
+    return [
+      {
+        id: "user-reset-password",
+        label: recoveryRequired ? "Recover Account" : "Reset Password",
+        icon: LockResetIcon,
+        group: "primary",
+        disabled: directory,
+        disabledReason: directory ? "Directory passwords are managed by their source provider." : "",
+        onClick: () => openReset(user),
+      },
+      {
+        id: "user-change-role",
+        label: "Change Role",
+        icon: AdminPanelSettingsIcon,
+        group: "primary",
+        disabled: directory || currentUser,
+        disabledReason: protectedUserReason,
+        onClick: () => openChangeRole(user),
+      },
+      {
+        id: "user-toggle-mfa",
+        label: mfaEnabled ? "Disable MFA" : "Enable MFA",
+        icon: SecurityRoundedIcon,
+        group: "primary",
+        disabled: directory || recoveryRequired || mfaBusy,
+        disabledReason: mfaToggleDisabledReason,
+        onClick: () => openChangeMfaState(user),
+      },
+      {
+        id: "user-reset-mfa",
+        label: "Reset MFA",
+        icon: LockResetIcon,
+        group: "primary",
+        disabled: directory || !mfaEnabled || recoveryRequired,
+        disabledReason: resetMfaDisabledReason,
+        onClick: () => openResetMfa(user),
+      },
+      {
+        id: "user-disable-directory-cache",
+        label: "Disable Directory Cache",
+        icon: AccountTreeRoundedIcon,
+        group: "organize",
+        hidden: !directory,
+        disabled: Boolean(user.directory_disabled),
+        disabledReason: Boolean(user.directory_disabled) ? "Directory cache is already disabled." : "",
+        onClick: () => {
+          setDisableDirectoryTarget(user);
+          setDisableDirectoryOpen(true);
+        },
+      },
+      {
+        id: "user-delete",
+        label: "Delete User",
+        icon: DeleteRoundedIcon,
+        group: "danger",
+        intent: "danger",
+        disabled: directory || currentUser,
+        disabledReason: protectedUserReason,
+        onClick: () => confirmDelete(user),
+      },
+    ];
+  }, [confirmDelete, me, menuUser, mfaBusyUser, openChangeMfaState, openChangeRole, openReset, openResetMfa]);
+
+  const contextMenuSubtitle = useMemo(() => {
+    if (!menuUser) return "User actions";
+    const username = String(menuUser.username || "").trim();
+    const source = userSourceLabel(menuUser);
+    return [username, source].filter(Boolean).join(" - ");
+  }, [menuUser]);
 
   const columnDefs = useMemo(
     () => [
@@ -831,35 +948,9 @@ export default function UserManagement() {
           );
         },
       },
-      {
-        headerName: "Actions",
-        field: "actions",
-        minWidth: 140,
-        flex: 1,
-        sortable: false,
-        filter: false,
-        suppressHeaderMenuButton: true,
-        suppressHeaderContextMenu: true,
-        cellRenderer: (params) => {
-          const user = params.data || {};
-          return (
-            <Box sx={{ display: "flex", alignItems: "center", justifyContent: "flex-end", width: "100%" }}>
-              <IconButton
-                size="small"
-                onClick={(event) => {
-                  event.stopPropagation();
-                  openMenu(event, user);
-                }}
-                sx={{ color: "#cbd5e1" }}
-              >
-                <MoreVertIcon fontSize="inherit" />
-              </IconButton>
-            </Box>
-          );
-        },
-      },
+      buildRowContextMenuColumnDef(openMenu, { tooltip: "User Actions" }),
     ],
-    [mfaBusyUser, recoveryTokenTheme, sourceTheme]
+    [mfaBusyUser, openMenu, recoveryTokenTheme, sourceTheme]
   );
 
   const defaultColDef = useMemo(
@@ -984,11 +1075,14 @@ export default function UserManagement() {
                 rowSelection={rowSelection}
                 selectionColumnDef={selectionColumnDef}
                 suppressCellFocus
+                suppressContextMenu
+                preventDefaultOnContextMenu
                 pagination
                 paginationPageSize={20}
                 paginationPageSizeSelector={[20, 50, 100]}
                 animateRows
                 getRowId={(params) => String(params.data?.username || "")}
+                onCellContextMenu={(params) => openMenu(params.event, params.data, params.node)}
                 onGridReady={(params) => {
                   gridApiRef.current = params.api;
                   autoSizeColumns();
@@ -1008,90 +1102,15 @@ export default function UserManagement() {
           </Box>
         </PageBodyFrame>
 
-        <Menu
-          anchorEl={menuAnchor}
-          open={Boolean(menuAnchor)}
+        <RowContextMenu
+          open={Boolean(contextMenu)}
           onClose={closeMenu}
-          anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
-          transformOrigin={{ vertical: "top", horizontal: "right" }}
-          PaperProps={{ sx: { bgcolor: "#111827", color: "#e5eefc", fontSize: "0.9rem" } }}
-        >
-          <MenuItem
-            disabled={
-              isDirectoryUser(menuUser) ||
-              (me && menuUser && String(me.username).toLowerCase() === String(menuUser.username).toLowerCase())
-            }
-            onClick={() => {
-              const user = menuUser;
-              closeMenu();
-              confirmDelete(user);
-            }}
-          >
-            Delete User
-          </MenuItem>
-          <MenuItem
-            disabled={isDirectoryUser(menuUser)}
-            onClick={() => {
-              const user = menuUser;
-              closeMenu();
-              openReset(user);
-            }}
-          >
-            {Boolean(menuUser?.auth_reset_required) ? "Recover Account" : "Reset Password"}
-          </MenuItem>
-          <MenuItem
-            disabled={
-              isDirectoryUser(menuUser) ||
-              (me && menuUser && String(me.username).toLowerCase() === String(menuUser.username).toLowerCase())
-            }
-            onClick={() => {
-              const user = menuUser;
-              closeMenu();
-              openChangeRole(user);
-            }}
-          >
-            Change Role
-          </MenuItem>
-          <MenuItem
-            disabled={
-              isDirectoryUser(menuUser) ||
-              Boolean(menuUser?.auth_reset_required) ||
-              Boolean(
-                mfaBusyUser && menuUser && String(mfaBusyUser).toLowerCase() === String(menuUser.username || "").toLowerCase()
-              )
-            }
-            onClick={() => {
-              const user = menuUser;
-              closeMenu();
-              openChangeMfaState(user);
-            }}
-          >
-            {Boolean(menuUser?.mfa_enabled) ? "Disable MFA" : "Enable MFA"}
-          </MenuItem>
-          <MenuItem
-            onClick={() => {
-              const user = menuUser;
-              closeMenu();
-              openResetMfa(user);
-            }}
-            disabled={isDirectoryUser(menuUser) || !Boolean(menuUser?.mfa_enabled) || Boolean(menuUser?.auth_reset_required)}
-          >
-            Reset MFA
-          </MenuItem>
-          {isDirectoryUser(menuUser) ? (
-            <MenuItem
-              disabled={Boolean(menuUser?.directory_disabled)}
-              onClick={() => {
-                const user = menuUser;
-                closeMenu();
-                setDisableDirectoryTarget(user);
-                setDisableDirectoryOpen(true);
-              }}
-            >
-              Disable Directory Cache
-            </MenuItem>
-          ) : null}
-        </Menu>
+          position={contextMenu ? { top: contextMenu.top, left: contextMenu.left } : null}
+          headerIcon={isDirectoryUser(menuUser) ? AccountTreeRoundedIcon : GroupIcon}
+          title={menuUser?.display_name || menuUser?.username || "User Actions"}
+          subtitle={contextMenuSubtitle}
+          actions={userContextActions}
+        />
 
         <Dialog open={resetOpen} onClose={() => setResetOpen(false)} maxWidth="xs" fullWidth PaperProps={{ sx: DIALOG_PAPER_SX }}>
           <DialogTitle sx={DIALOG_TITLE_SX}>

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Assemblies/Assembly_List.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Assemblies/Assembly_List.jsx
@@ -30,6 +30,7 @@ import DeleteOutlineRoundedIcon from "@mui/icons-material/DeleteOutlineRounded";
 import { AgGridReact } from "ag-grid-react";
 import { ModuleRegistry, AllCommunityModule, themeQuartz } from "ag-grid-community";
 import { ConfirmDeleteDialog, NewWorkflowDialog } from "../Dialogs";
+import { buildRowContextMenuColumnDef } from "../Grid_Row_Context_Menu_Button.jsx";
 import {
   DIALOG_ACTIONS_SX,
   DIALOG_BODY_TEXT_SX,
@@ -926,6 +927,13 @@ export default function AssemblyList() {
     });
   }, []);
 
+  const handleRowContextMenuButton = useCallback(
+    (event, row, node, params = {}) => {
+      handleCellContextMenu({ ...params, event, data: row, node });
+    },
+    [handleCellContextMenu],
+  );
+
   const closeContextMenu = useCallback(() => setContextMenu(null), []);
 
   const startRename = useCallback(() => {
@@ -1513,8 +1521,9 @@ export default function AssemblyList() {
         cellClass: "auto-col-tight",
         cellRenderer: OfficialUpdateCellRenderer,
       },
+      buildRowContextMenuColumnDef(handleRowContextMenuButton, { tooltip: "Assembly Actions" }),
     ],
-    [compareAssemblyNames],
+    [compareAssemblyNames, handleRowContextMenuButton],
   );
 
   const defaultColDef = useMemo(

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Device_List.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Device_List.jsx
@@ -9,7 +9,6 @@ import {
   Typography,
   Button,
   IconButton,
-  Menu,
   MenuItem,
   Popover,
   TextField,
@@ -18,9 +17,12 @@ import {
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import ViewColumnIcon from "@mui/icons-material/ViewColumn";
 import AddIcon from "@mui/icons-material/Add";
+import AltRouteRoundedIcon from "@mui/icons-material/AltRouteRounded";
 import CachedIcon from "@mui/icons-material/Cached";
 import DevicesOtherIcon from "@mui/icons-material/DevicesOther";
 import DeleteRoundedIcon from "@mui/icons-material/DeleteRounded";
+import DriveFileRenameOutlineRoundedIcon from "@mui/icons-material/DriveFileRenameOutlineRounded";
+import LocationCityRoundedIcon from "@mui/icons-material/LocationCityRounded";
 import AccountTreeRoundedIcon from "@mui/icons-material/AccountTreeRounded";
 import { AgGridReact } from "ag-grid-react";
 import { ModuleRegistry, AllCommunityModule, themeQuartz } from "ag-grid-community";
@@ -29,6 +31,7 @@ import {
   ROW_CONTEXT_MENU_BUTTON_SX,
   ROW_CONTEXT_MENU_COLUMN_WIDTH,
 } from "../Grid_Row_Context_Menu_Button.jsx";
+import RowContextMenu from "../Row_Context_Menu.jsx";
 import AddDevice from "./Add_Device.jsx";
 import PageBodyFrame from "../PageBodyFrame.jsx";
 import { useAppNotifications } from "../app/hooks/useAppNotifications.js";
@@ -951,7 +954,7 @@ export default function DeviceList({
   const [rows, setRows] = useState(() => initialRows);
   const [metadataFields, setMetadataFields] = useState(() => initialMetadataFields);
   const [loading, setLoading] = useState(false);
-  const [menuAnchor, setMenuAnchor] = useState(null);
+  const [deviceContextMenu, setDeviceContextMenu] = useState({ open: false, top: 0, left: 0, row: null });
   const [selected, setSelected] = useState(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [deleteBusy, setDeleteBusy] = useState(false);
@@ -1046,8 +1049,11 @@ export default function DeviceList({
   const [renameDialogOpen, setRenameDialogOpen] = useState(false);
   const [renameViewName, setRenameViewName] = useState("");
   const [renameTarget, setRenameTarget] = useState(null); // {id, name}
-  const [viewActionAnchor, setViewActionAnchor] = useState(null); // anchor for per-item actions
-  const [viewActionTarget, setViewActionTarget] = useState(null); // view object for actions
+  const [viewActionMenu, setViewActionMenu] = useState({ open: false, top: 0, left: 0, target: null });
+  const viewActionTarget = viewActionMenu.target;
+  const closeViewActionMenu = useCallback(() => {
+    setViewActionMenu({ open: false, top: 0, left: 0, target: null });
+  }, []);
 
   // Column configuration and rearranging state
   const STATIC_COL_LABELS = useMemo(
@@ -1651,6 +1657,50 @@ export default function DeviceList({
     }
   }, [COL_LABELS, defaultColumns, replaceFilters]);
 
+  const viewActionMenuActions = useMemo(
+    () => [
+      {
+        id: "rename-view",
+        label: "Rename View",
+        icon: DriveFileRenameOutlineRoundedIcon,
+        group: "primary",
+        disabled: !viewActionTarget,
+        disabledReason: !viewActionTarget ? "Select a custom view first." : "",
+        description: "Change saved custom view name.",
+        onClick: () => {
+          const view = viewActionTarget;
+          if (!view) return;
+          setRenameTarget(view);
+          setRenameViewName(view.name || "");
+          setRenameDialogOpen(true);
+        },
+      },
+      {
+        id: "delete-view",
+        label: "Delete View",
+        icon: DeleteRoundedIcon,
+        group: "danger",
+        intent: "danger",
+        disabled: !viewActionTarget,
+        disabledReason: !viewActionTarget ? "Select a custom view first." : "",
+        description: "Remove this saved custom Device List view.",
+        onClick: async () => {
+          const view = viewActionTarget;
+          if (!view) return;
+          try {
+            await fetch(`/api/device_list_views/${encodeURIComponent(view.id)}`, { method: "DELETE" });
+          } catch {}
+          setViews((prev) => prev.filter((item) => String(item.id) !== String(view.id)));
+          if (String(selectedViewId) === String(view.id)) {
+            setSelectedViewId("default");
+            applyView({ id: "default" });
+          }
+        },
+      },
+    ],
+    [applyView, selectedViewId, viewActionTarget]
+  );
+
   const statusTokenTheme = useMemo(
     () => ({
       Online: {
@@ -1747,12 +1797,25 @@ export default function DeviceList({
     [deleteTargetIds, rows]
   );
 
-  const closeMenu = useCallback(() => setMenuAnchor(null), []);
+  const closeMenu = useCallback(() => {
+    setDeviceContextMenu({ open: false, top: 0, left: 0, row: null });
+  }, []);
 
-  const openMenu = useCallback((event, row) => {
+  const openMenu = useCallback((event, row, rowNode = null) => {
+    event?.preventDefault?.();
+    event?.stopPropagation?.();
+    if (!row) return;
+    if (rowNode && !rowNode.isSelected?.()) {
+      rowNode.setSelected?.(true, true);
+    }
     setDeleteError("");
-    setMenuAnchor(event.currentTarget);
     setSelected(row);
+    setDeviceContextMenu({
+      open: true,
+      top: Number(event?.clientY || 0),
+      left: Number(event?.clientX || 0),
+      row,
+    });
   }, []);
 
   const openPurgeDialog = useCallback((targetRows) => {
@@ -1791,6 +1854,19 @@ export default function DeviceList({
     return selectedDeviceRows;
   }, [selected, selectedDeviceRows, selectedIds]);
 
+  const openSiteAssignmentDialog = useCallback(async () => {
+    closeMenu();
+    await fetchSites();
+    const targets = getContextTargetRows();
+    const hostnames = targets
+      .map((row) => String(row?.hostname || row?.summary?.hostname || "").trim())
+      .filter(Boolean);
+    if (!hostnames.length) return;
+    setAssignTargets(hostnames);
+    setAssignSiteId(null);
+    setAssignDialogOpen(true);
+  }, [closeMenu, fetchSites, getContextTargetRows]);
+
   const fetchAgentBranches = useCallback(async () => {
     setAgentBranchesLoading(true);
     setAgentBranchLoadError("");
@@ -1827,6 +1903,97 @@ export default function DeviceList({
       void fetchAgentBranches();
     },
     [agentBranchChannelSaving, fetchAgentBranches, isAdmin, selectedDeviceRows]
+  );
+
+  const contextTargetRows = getContextTargetRows();
+  const contextTargetCount = contextTargetRows.length;
+  const contextTargetHasPurgeGuid = contextTargetRows.some((row) => resolveDevicePurgeGuid(row));
+  const deviceContextTitle =
+    contextTargetCount > 1
+      ? `${contextTargetCount.toLocaleString()} Devices Selected`
+      : getDeviceDisplayLabel(contextTargetRows[0] || selected);
+  const deviceContextSubtitle =
+    contextTargetCount > 1
+      ? selected
+        ? `Context row: ${getDeviceDisplayLabel(selected)}`
+        : "Bulk device actions"
+      : String(contextTargetRows[0]?.site || contextTargetRows[0]?.summary?.site_name || "Not Configured").trim();
+  const deviceContextActions = useMemo(
+    () => [
+      {
+        id: "add-to-site",
+        label: "Add to Site",
+        icon: AddIcon,
+        group: "primary",
+        disabled: !contextTargetCount,
+        disabledReason: !contextTargetCount ? "Select a device first." : "",
+        description: `Choose a site for ${contextTargetCount || 1} device${contextTargetCount === 1 ? "" : "s"}.`,
+        onClick: () => {
+          void openSiteAssignmentDialog();
+        },
+      },
+      {
+        id: "move-to-site",
+        label: "Move to Another Site",
+        icon: LocationCityRoundedIcon,
+        group: "primary",
+        disabled: !contextTargetCount,
+        disabledReason: !contextTargetCount ? "Select a device first." : "",
+        description: "Reassign selected device inventory to a different site.",
+        onClick: () => {
+          void openSiteAssignmentDialog();
+        },
+      },
+      {
+        id: "change-branch-channel",
+        label: "Change Branch/Channel",
+        icon: AltRouteRoundedIcon,
+        group: "organize",
+        disabled: !isAdmin || !contextTargetHasPurgeGuid || agentBranchChannelSaving,
+        disabledReason: !isAdmin
+          ? "Administrator access is required."
+          : !contextTargetHasPurgeGuid
+            ? "No selected device has an Agent GUID."
+            : agentBranchChannelSaving
+              ? "Branch/channel change already running."
+              : "",
+        description: "Set Agent release channel and branch for selected devices.",
+        onClick: () => {
+          const targets = getContextTargetRows();
+          closeMenu();
+          openAgentBranchChannelDialog(targets);
+        },
+      },
+      {
+        id: "purge-device",
+        label: contextTargetCount > 1 ? "Purge Selected" : "Purge Device",
+        icon: DeleteRoundedIcon,
+        group: "danger",
+        intent: "danger",
+        disabled: !isAdmin || !contextTargetCount || deleteBusy,
+        disabledReason: !isAdmin
+          ? "Administrator access is required."
+          : !contextTargetCount
+            ? "Select a device first."
+            : deleteBusy
+              ? "Device purge already running."
+              : "",
+        description: "Remove selected Agent inventory and related scheduled job links.",
+        onClick: confirmDelete,
+      },
+    ],
+    [
+      agentBranchChannelSaving,
+      closeMenu,
+      confirmDelete,
+      contextTargetCount,
+      contextTargetHasPurgeGuid,
+      deleteBusy,
+      getContextTargetRows,
+      isAdmin,
+      openAgentBranchChannelDialog,
+      openSiteAssignmentDialog,
+    ]
   );
 
   const closeAgentBranchChannelDialog = useCallback(() => {
@@ -2319,8 +2486,7 @@ export default function DeviceList({
       const row = params.data;
       if (!row) return null;
       const handleClick = (event) => {
-        event.stopPropagation();
-        openMenu(event, row);
+        openMenu(event, row, params.node);
       };
       return (
         <IconButton size="small" onClick={handleClick} sx={ROW_CONTEXT_MENU_BUTTON_SX}>
@@ -2819,9 +2985,14 @@ export default function DeviceList({
                         <IconButton
                           size="small"
                           onClick={(e) => {
+                            e.preventDefault();
                             e.stopPropagation();
-                            setViewActionAnchor(e.currentTarget);
-                            setViewActionTarget(v);
+                            setViewActionMenu({
+                              open: true,
+                              top: Number(e.clientY || 0),
+                              left: Number(e.clientX || 0),
+                              target: v,
+                            });
                           }}
                           sx={ROW_CONTEXT_MENU_BUTTON_SX}
                         >
@@ -2945,55 +3116,31 @@ export default function DeviceList({
             rowSelection={rowSelection}
             selectionColumnDef={selectionColumnDef}
             suppressCellFocus
+            suppressContextMenu
+            preventDefaultOnContextMenu
             pagination
             paginationPageSize={100}
             paginationPageSizeSelector={[20, 50, 100]}
             animateRows
             onSelectionChanged={handleSelectionChanged}
             onFilterChanged={handleFilterChanged}
+            onCellContextMenu={(params) => openMenu(params.event, params.data, params.node)}
             onGridReady={handleGridReady}
             getRowId={getRowId}
             theme={myTheme}
           />
         </Box>
       </PageBodyFrame>
-      {/* View actions menu (rename/delete for custom views) */}
-      <Menu
-        anchorEl={viewActionAnchor}
-        open={Boolean(viewActionAnchor)}
-        onClose={() => { setViewActionAnchor(null); setViewActionTarget(null); }}
-        PaperProps={{
-          sx: {
-            bgcolor: "rgba(8,12,24,0.96)",
-            color: "#fff",
-            fontSize: "13px",
-            border: "1px solid rgba(148,163,184,0.3)",
-            backdropFilter: "blur(16px)",
-          },
-        }}
-      >
-        <MenuItem onClick={() => {
-          const v = viewActionTarget;
-          setViewActionAnchor(null);
-          if (!v) return;
-          setRenameTarget(v);
-          setRenameViewName(v.name || "");
-          setRenameDialogOpen(true);
-        }}>Rename</MenuItem>
-        <MenuItem sx={{ color: '#ff4f4f' }} onClick={async () => {
-          const v = viewActionTarget;
-          setViewActionAnchor(null);
-          if (!v) return;
-          try {
-            await fetch(`/api/device_list_views/${encodeURIComponent(v.id)}`, { method: 'DELETE' });
-          } catch {}
-          setViews((prev) => prev.filter((x) => String(x.id) !== String(v.id)));
-          if (String(selectedViewId) === String(v.id)) {
-            setSelectedViewId('default');
-            applyView({ id: 'default' });
-          }
-        }}>Delete</MenuItem>
-      </Menu>
+      <RowContextMenu
+        open={Boolean(viewActionMenu.open)}
+        onClose={closeViewActionMenu}
+        position={viewActionMenu.open ? { top: viewActionMenu.top, left: viewActionMenu.left } : null}
+        headerIcon={ViewColumnIcon}
+        title={viewActionTarget?.name || "Custom View"}
+        subtitle="Device List view"
+        actions={viewActionMenuActions}
+        widthVariant="compact"
+      />
 
       {/* Create new custom view dialog */}
       <CreateCustomViewDialog
@@ -3219,60 +3366,15 @@ export default function DeviceList({
           ))}
         </Box>
       </Popover>
-      <Menu
-        anchorEl={menuAnchor}
-        open={Boolean(menuAnchor)}
+      <RowContextMenu
+        open={Boolean(deviceContextMenu.open)}
         onClose={closeMenu}
-        PaperProps={{
-          sx: {
-            bgcolor: "rgba(8,12,24,0.96)",
-            color: "#fff",
-            fontSize: "13px",
-            border: "1px solid rgba(148,163,184,0.3)",
-            backdropFilter: "blur(16px)",
-          },
-        }}
-      >
-        <MenuItem onClick={async () => {
-          closeMenu();
-          await fetchSites();
-          const targets = new Set(selectedIds);
-          if (selected && !targets.has(selected.id)) targets.add(selected.id);
-          const idToHost = new Map(rows.map((r) => [r.id, r.hostname]));
-          const hostnames = Array.from(targets).map((id) => idToHost.get(id)).filter(Boolean);
-          setAssignTargets(hostnames);
-          setAssignSiteId(null);
-          setAssignDialogOpen(true);
-        }}>Add to Site</MenuItem>
-        <MenuItem onClick={async () => {
-          closeMenu();
-          await fetchSites();
-          const targets = new Set(selectedIds);
-          if (selected && !targets.has(selected.id)) targets.add(selected.id);
-          const idToHost = new Map(rows.map((r) => [r.id, r.hostname]));
-          const hostnames = Array.from(targets).map((id) => idToHost.get(id)).filter(Boolean);
-          setAssignTargets(hostnames);
-          setAssignSiteId(null);
-          setAssignDialogOpen(true);
-        }}>Move to Another Site</MenuItem>
-        {isAdmin ? (
-          <MenuItem
-            disabled={!getContextTargetRows().some((row) => resolveDevicePurgeGuid(row)) || agentBranchChannelSaving}
-            onClick={() => {
-              const targets = getContextTargetRows();
-              closeMenu();
-              openAgentBranchChannelDialog(targets);
-            }}
-          >
-            Change Branch/Channel
-          </MenuItem>
-        ) : null}
-        {isAdmin ? (
-          <MenuItem onClick={confirmDelete} sx={{ color: '#ff8a8a' }}>
-            {selected?.id != null && selectedIds.has(selected.id) && selectedDeviceRows.length > 1 ? "Purge Selected" : "Purge"}
-          </MenuItem>
-        ) : null}
-      </Menu>
+        position={deviceContextMenu.open ? { top: deviceContextMenu.top, left: deviceContextMenu.left } : null}
+        headerIcon={DevicesOtherIcon}
+        title={deviceContextTitle}
+        subtitle={deviceContextSubtitle}
+        actions={deviceContextActions}
+      />
       <DeleteDeviceDialog
         open={confirmOpen}
         onCancel={() => {

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Device_List.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Device_List.jsx
@@ -25,6 +25,10 @@ import AccountTreeRoundedIcon from "@mui/icons-material/AccountTreeRounded";
 import { AgGridReact } from "ag-grid-react";
 import { ModuleRegistry, AllCommunityModule, themeQuartz } from "ag-grid-community";
 import { DeleteDeviceDialog, CreateCustomViewDialog, RenameCustomViewDialog } from "../Dialogs.jsx";
+import {
+  ROW_CONTEXT_MENU_BUTTON_SX,
+  ROW_CONTEXT_MENU_COLUMN_WIDTH,
+} from "../Grid_Row_Context_Menu_Button.jsx";
 import AddDevice from "./Add_Device.jsx";
 import PageBodyFrame from "../PageBodyFrame.jsx";
 import { useAppNotifications } from "../app/hooks/useAppNotifications.js";
@@ -2319,7 +2323,7 @@ export default function DeviceList({
         openMenu(event, row);
       };
       return (
-        <IconButton size="small" onClick={handleClick} sx={{ color: "#ccc" }}>
+        <IconButton size="small" onClick={handleClick} sx={ROW_CONTEXT_MENU_BUTTON_SX}>
           <MoreVertIcon fontSize="small" />
         </IconButton>
       );
@@ -2626,8 +2630,9 @@ export default function DeviceList({
       {
         headerName: "",
         field: "__actions__",
-        width: 64,
-        maxWidth: 64,
+        width: ROW_CONTEXT_MENU_COLUMN_WIDTH,
+        minWidth: ROW_CONTEXT_MENU_COLUMN_WIDTH,
+        maxWidth: ROW_CONTEXT_MENU_COLUMN_WIDTH,
         resizable: false,
         sortable: false,
         suppressHeaderMenuButton: true,
@@ -2818,7 +2823,7 @@ export default function DeviceList({
                             setViewActionAnchor(e.currentTarget);
                             setViewActionTarget(v);
                           }}
-                          sx={{ color: "#ccc" }}
+                          sx={ROW_CONTEXT_MENU_BUTTON_SX}
                         >
                           <MoreVertIcon fontSize="small" />
                         </IconButton>

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Filters/Filter_List.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Filters/Filter_List.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useLoaderData, useNavigate, useSearchParams } from "react-router-dom";
 import {
   Alert,
@@ -69,16 +69,6 @@ const gridTheme = themeQuartz.withParams({
   foregroundColor: "#f4f7ff",
   headerFontSize: 13,
 });
-
-const AUTO_SIZE_COLUMNS = [
-  "name",
-  "description",
-  "site_mode",
-  "matching_device_count",
-  "usage",
-  "last_edited_by",
-  "updated_at",
-];
 
 const GRID_WRAPPER_SX = {
   width: "100%",
@@ -303,7 +293,6 @@ export default function DeviceFilterList({ refreshToken }) {
   const loaderData = useLoaderData();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const gridRef = useRef(null);
   const [tab, setTab] = useState("active");
   const [filterCollections, setFilterCollections] = useState(
     () => loaderData?.filterCollections || { active: [], archived: [] }
@@ -433,22 +422,6 @@ export default function DeviceFilterList({ refreshToken }) {
     Icon: PAGE_ICON,
     actions: pageHeaderActions,
   });
-
-  const autoSize = useCallback(() => {
-    const api = gridRef.current;
-    if (!api || !filters.length) return;
-    requestAnimationFrame(() => {
-      try {
-        api.autoSizeColumns(AUTO_SIZE_COLUMNS, true);
-      } catch {
-        /* ignore */
-      }
-    });
-  }, [filters.length]);
-
-  useEffect(() => {
-    autoSize();
-  }, [autoSize]);
 
   const performAction = useCallback(
     async (path, options = {}) => {
@@ -622,8 +595,8 @@ export default function DeviceFilterList({ refreshToken }) {
       {
         field: "name",
         headerName: "Filter Name",
-        minWidth: 350,
-        flex: 1.4,
+        minWidth: 260,
+        flex: 6,
         cellRenderer: (params) => (
           <Box
             component="a"
@@ -651,15 +624,15 @@ export default function DeviceFilterList({ refreshToken }) {
       {
         field: "description",
         headerName: "Description",
-        minWidth: 220,
-        flex: 1.2,
+        minWidth: 260,
+        flex: 6,
         valueFormatter: (params) => params.value || "—",
       },
       {
         field: "site_mode",
         headerName: "Scope",
-        minWidth: 120,
-        flex: 1,
+        minWidth: 130,
+        flex: 1.3,
         cellRenderer: (params) => (
           <Tooltip title={scopeSummary(params.data)}>
             <Box sx={{ display: "inline-flex", alignItems: "center" }}>
@@ -672,15 +645,15 @@ export default function DeviceFilterList({ refreshToken }) {
         field: "matching_device_count",
         headerName: "Devices",
         minWidth: 110,
-        flex: 0.8,
+        flex: 0.9,
         valueFormatter: (params) =>
           typeof params.value === "number" ? params.value.toLocaleString() : "0",
       },
       {
         field: "usage",
         headerName: "Jobs Using this Filter",
-        minWidth: 170,
-        flex: 1,
+        minWidth: 165,
+        flex: 1.5,
         sortable: false,
         filter: false,
         cellRenderer: (params) => {
@@ -713,14 +686,14 @@ export default function DeviceFilterList({ refreshToken }) {
         field: "last_edited_by",
         headerName: "Last Edited By",
         minWidth: 150,
-        flex: 0.9,
+        flex: 1.1,
         valueFormatter: (params) => params.value || "Unknown",
       },
       {
         field: "updated_at",
         headerName: "Last Updated",
-        minWidth: 180,
-        flex: 1,
+        minWidth: 170,
+        flex: 1.2,
         valueFormatter: (params) => formatTimestamp(params.value),
       },
       {
@@ -801,10 +774,6 @@ export default function DeviceFilterList({ refreshToken }) {
               pagination
               paginationPageSize={20}
               paginationPageSizeSelector={[20, 50, 100]}
-              onGridReady={(params) => {
-                gridRef.current = params.api;
-                autoSize();
-              }}
               getRowId={(params) => String(params.data?.id || "")}
               onCellContextMenu={(params) => openFilterContextMenu(params.event, params.data, params.node)}
               theme={gridTheme}

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Filters/Filter_List.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Filters/Filter_List.jsx
@@ -8,7 +8,6 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
-  IconButton,
   LinearProgress,
   Stack,
   Tooltip,
@@ -28,6 +27,8 @@ import { AgGridReact } from "ag-grid-react";
 import { ModuleRegistry, AllCommunityModule, themeQuartz } from "ag-grid-community";
 
 import PageBodyFrame from "../../PageBodyFrame.jsx";
+import { buildRowContextMenuColumnDef } from "../../Grid_Row_Context_Menu_Button.jsx";
+import RowContextMenu from "../../Row_Context_Menu.jsx";
 import {
   DIALOG_ACTIONS_SX,
   DIALOG_BUTTON_SX,
@@ -311,6 +312,7 @@ export default function DeviceFilterList({ refreshToken }) {
   const [error, setError] = useState(() => String(loaderData?.initialError || ""));
   const [actionError, setActionError] = useState("");
   const [jobsDialog, setJobsDialog] = useState({ open: false, jobs: [], title: "" });
+  const [filterContextMenu, setFilterContextMenu] = useState({ open: false, top: 0, left: 0, row: null });
   const selectedSiteId = useMemo(
     () => String(searchParams.get("site") || "").trim(),
     [searchParams]
@@ -515,6 +517,106 @@ export default function DeviceFilterList({ refreshToken }) {
     });
   }, []);
 
+  const openFilterContextMenu = useCallback((event, record, rowNode = null) => {
+    event?.preventDefault?.();
+    event?.stopPropagation?.();
+    if (!record) return;
+    if (rowNode && !rowNode.isSelected?.()) {
+      rowNode.setSelected?.(true, true);
+    }
+    setFilterContextMenu({
+      open: true,
+      top: Number(event?.clientY || 0),
+      left: Number(event?.clientX || 0),
+      row: record,
+    });
+  }, []);
+
+  const closeFilterContextMenu = useCallback(() => {
+    setFilterContextMenu({ open: false, top: 0, left: 0, row: null });
+  }, []);
+
+  const contextFilter = filterContextMenu.row || null;
+  const contextFilterDeviceCount = Number(contextFilter?.matching_device_count || 0);
+  const contextFilterJobCount = Number(contextFilter?.usage?.job_count || 0);
+  const contextFilterSubtitle = contextFilter
+    ? `${scopeSummary(contextFilter)} - ${contextFilterDeviceCount.toLocaleString()} device${contextFilterDeviceCount === 1 ? "" : "s"}`
+    : "Device filter";
+  const filterContextActions = useMemo(
+    () => [
+      {
+        id: "view-devices",
+        label: "View Devices",
+        icon: LaunchIcon,
+        group: "primary",
+        disabled: !contextFilter,
+        disabledReason: !contextFilter ? "Select a filter first." : "",
+        description: "Open Device List with this saved filter preview.",
+        onClick: () => handleViewDevices(contextFilter),
+      },
+      {
+        id: "edit-filter",
+        label: "Edit Filter",
+        icon: HeaderIcon,
+        group: "primary",
+        disabled: !contextFilter,
+        disabledReason: !contextFilter ? "Select a filter first." : "",
+        description: "Open filter criteria, scope, and lifecycle settings.",
+        onClick: () => handleEditFilter(contextFilter),
+      },
+      {
+        id: "clone-filter",
+        label: "Clone Filter",
+        icon: CloneIcon,
+        group: "organize",
+        disabled: !contextFilter,
+        disabledReason: !contextFilter ? "Select a filter first." : "",
+        description: "Create a copy that can be edited independently.",
+        onClick: () => {
+          void handleClone(contextFilter);
+        },
+      },
+      {
+        id: "archive-filter",
+        label: contextFilter?.archived ? "Unarchive Filter" : "Archive Filter",
+        icon: contextFilter?.archived ? UnarchiveIcon : ArchiveIcon,
+        group: "organize",
+        disabled: !contextFilter,
+        disabledReason: !contextFilter ? "Select a filter first." : "",
+        description: contextFilter?.archived
+          ? "Return this filter to active use."
+          : "Hide this filter from active lists without deleting it.",
+        onClick: () => {
+          void handleArchiveToggle(contextFilter);
+        },
+      },
+      {
+        id: "delete-filter",
+        label: "Delete Filter",
+        icon: DeleteIcon,
+        group: "danger",
+        intent: "danger",
+        disabled: !contextFilter,
+        disabledReason: !contextFilter ? "Select a filter first." : "",
+        description: contextFilterJobCount
+          ? `${contextFilterJobCount.toLocaleString()} scheduled job${contextFilterJobCount === 1 ? "" : "s"} reference this filter.`
+          : "Permanently remove this saved filter.",
+        onClick: () => {
+          void handleDelete(contextFilter);
+        },
+      },
+    ],
+    [
+      contextFilter,
+      contextFilterJobCount,
+      handleArchiveToggle,
+      handleClone,
+      handleDelete,
+      handleEditFilter,
+      handleViewDevices,
+    ]
+  );
+
   const columnDefs = useMemo(
     () => [
       {
@@ -622,42 +724,22 @@ export default function DeviceFilterList({ refreshToken }) {
         valueFormatter: (params) => formatTimestamp(params.value),
       },
       {
-        field: "actions",
+        field: "__actions__",
         headerName: "",
-        minWidth: 150,
-        flex: 1.2,
-        sortable: false,
-        filter: false,
-        cellRenderer: (params) => {
-          const record = params.data;
-          return (
-            <Stack direction="row" spacing={0.5} sx={{ width: "100%", justifyContent: "flex-end" }}>
-              <Tooltip title="View Devices">
-                <IconButton size="small" onClick={() => handleViewDevices(record)}>
-                  <LaunchIcon fontSize="small" />
-                </IconButton>
-              </Tooltip>
-              <Tooltip title="Clone">
-                <IconButton size="small" onClick={() => handleClone(record)}>
-                  <CloneIcon fontSize="small" />
-                </IconButton>
-              </Tooltip>
-              <Tooltip title={record?.archived ? "Unarchive" : "Archive"}>
-                <IconButton size="small" onClick={() => handleArchiveToggle(record)}>
-                  {record?.archived ? <UnarchiveIcon fontSize="small" /> : <ArchiveIcon fontSize="small" />}
-                </IconButton>
-              </Tooltip>
-              <Tooltip title="Delete">
-                <IconButton size="small" onClick={() => handleDelete(record)} sx={{ color: "#fb7185" }}>
-                  <DeleteIcon fontSize="small" />
-                </IconButton>
-              </Tooltip>
-            </Stack>
-          );
-        },
+        ...buildRowContextMenuColumnDef(openFilterContextMenu, { tooltip: "Filter Actions" }),
       },
     ],
-    [handleArchiveToggle, handleClone, handleDelete, handleEditFilter, handleViewDevices, openJobs]
+    [handleEditFilter, openFilterContextMenu, openJobs]
+  );
+
+  const rowSelection = useMemo(
+    () => ({
+      mode: "singleRow",
+      checkboxes: false,
+      headerCheckbox: false,
+      enableClickSelection: true,
+    }),
+    []
   );
 
   const defaultColDef = useMemo(
@@ -711,7 +793,10 @@ export default function DeviceFilterList({ refreshToken }) {
               rowData={filters}
               columnDefs={columnDefs}
               defaultColDef={defaultColDef}
+              rowSelection={rowSelection}
               suppressCellFocus
+              suppressContextMenu
+              preventDefaultOnContextMenu
               animateRows
               pagination
               paginationPageSize={20}
@@ -721,6 +806,7 @@ export default function DeviceFilterList({ refreshToken }) {
                 autoSize();
               }}
               getRowId={(params) => String(params.data?.id || "")}
+              onCellContextMenu={(params) => openFilterContextMenu(params.event, params.data, params.node)}
               theme={gridTheme}
               style={{
                 width: "100%",
@@ -738,6 +824,15 @@ export default function DeviceFilterList({ refreshToken }) {
         title={jobsDialog.title}
         onClose={() => setJobsDialog({ open: false, jobs: [], title: "" })}
         onOpenJob={handleOpenJob}
+      />
+      <RowContextMenu
+        open={Boolean(filterContextMenu.open)}
+        onClose={closeFilterContextMenu}
+        position={filterContextMenu.open ? { top: filterContextMenu.top, left: filterContextMenu.left } : null}
+        headerIcon={HeaderIcon}
+        title={contextFilter?.name || "Filter Actions"}
+        subtitle={contextFilterSubtitle}
+        actions={filterContextActions}
       />
     </>
   );

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Installed_Software.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Installed_Software.jsx
@@ -23,6 +23,7 @@ import LockOpenRoundedIcon from "@mui/icons-material/LockOpenRounded";
 import TerminalRoundedIcon from "@mui/icons-material/TerminalRounded";
 import { AgGridReact } from "ag-grid-react";
 import { ConfirmDeleteDialog } from "../../Dialogs.jsx";
+import { buildRowContextMenuColumnDef } from "../../Grid_Row_Context_Menu_Button.jsx";
 import {
   DIALOG_ACTIONS_SX,
   DIALOG_BUTTON_SX,
@@ -2075,8 +2076,9 @@ export default function InstalledSoftwareTab({
           />
         ),
       },
+      buildRowContextMenuColumnDef(handleOpenSoftwareActionMenu, { tooltip: "Software Actions" }),
     ],
-    [busyActionKey, hostname, requestUninstall]
+    [busyActionKey, handleOpenSoftwareActionMenu, hostname, requestUninstall]
   );
 
   const getSoftwareRowId = useCallback(

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Process_Management.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Process_Management.jsx
@@ -19,6 +19,7 @@ import TerminalRoundedIcon from "@mui/icons-material/TerminalRounded";
 import KeyboardArrowRightRoundedIcon from "@mui/icons-material/KeyboardArrowRightRounded";
 import ContentCopyRoundedIcon from "@mui/icons-material/ContentCopyRounded";
 import StopCircleRoundedIcon from "@mui/icons-material/StopCircleRounded";
+import { buildRowContextMenuColumnDef } from "../../Grid_Row_Context_Menu_Button.jsx";
 import { DEFAULT_GRID_COL_DEF, GridShell, MAGIC_UI } from "./Shared.jsx";
 import { CountSliderGroup } from "../../Automation/Watchdogs/shared.jsx";
 import { useAppNotifications } from "../../app/hooks/useAppNotifications.js";
@@ -1023,6 +1024,13 @@ export default function ProcessManagement({ device }) {
     });
   }, []);
 
+  const handleRowContextMenuButton = useCallback(
+    (event, row, node, params = {}) => {
+      handleCellContextMenu({ ...params, event, data: row, node, api: params?.api || gridApiRef.current?.api });
+    },
+    [handleCellContextMenu]
+  );
+
   const copyLocationToClipboard = useCallback(async () => {
     const row = contextMenuSubject.row;
     const location = getProcessLocation(row);
@@ -1389,8 +1397,9 @@ export default function ProcessManagement({ device }) {
         cellClass: "auto-col-tight",
         cellRenderer: (params) => <CommandLineCell row={params.data} />,
       },
+      buildRowContextMenuColumnDef(handleRowContextMenuButton, { tooltip: "Process Actions" }),
     ],
-    []
+    [handleRowContextMenuButton]
   );
 
   const defaultColDef = useMemo(

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Remote_File_Management.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Remote_File_Management.jsx
@@ -82,6 +82,7 @@ import FindReplaceRoundedIcon from "@mui/icons-material/FindReplaceRounded";
 import MoreVertRoundedIcon from "@mui/icons-material/MoreVertRounded";
 import SearchRoundedIcon from "@mui/icons-material/SearchRounded";
 import UnfoldMoreRoundedIcon from "@mui/icons-material/UnfoldMoreRounded";
+import { buildRowContextMenuColumnDef } from "../../Grid_Row_Context_Menu_Button.jsx";
 import {
   DEFAULT_GRID_COL_DEF,
   DEVICE_DETAILS_GRID_THEME,
@@ -3325,6 +3326,13 @@ export default function RemoteFileManagement({ device }) {
     [handleOpenContextMenuAtPointer]
   );
 
+  const handleRowContextMenuButton = useCallback(
+    (event, row, node, params = {}) => {
+      handleGridCellContextMenu({ ...params, event, data: row, node, api: params?.api || gridRef.current?.api });
+    },
+    [handleGridCellContextMenu]
+  );
+
   const handleGridShellContextMenu = useCallback(
     (event) => {
       if (event?.target?.closest?.(".ag-cell")) return;
@@ -3859,8 +3867,9 @@ export default function RemoteFileManagement({ device }) {
         minWidth: 170,
         valueFormatter: (params) => formatModifiedAt(params?.value),
       },
+      buildRowContextMenuColumnDef(handleRowContextMenuButton, { tooltip: "File Row Actions" }),
     ],
-    [currentPath, platform]
+    [currentPath, handleRowContextMenuButton, platform]
   );
 
   const gridContext = useMemo(

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Remote_Registry_Editor.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Remote_Registry_Editor.jsx
@@ -34,6 +34,7 @@ import DriveFileRenameOutlineRoundedIcon from "@mui/icons-material/DriveFileRena
 import EditRoundedIcon from "@mui/icons-material/EditRounded";
 import RefreshRoundedIcon from "@mui/icons-material/RefreshRounded";
 import UnfoldLessRoundedIcon from "@mui/icons-material/UnfoldLessRounded";
+import { buildRowContextMenuColumnDef } from "../../Grid_Row_Context_Menu_Button.jsx";
 import {
   DEFAULT_GRID_COL_DEF,
   DEVICE_DETAILS_GRID_THEME,
@@ -888,6 +889,13 @@ export default function RemoteRegistryEditor({ device }) {
     [handleOpenContextMenuAtPointer]
   );
 
+  const handleRowContextMenuButton = useCallback(
+    (event, row, node, params = {}) => {
+      handleGridCellContextMenu({ ...params, event, data: row, node, api: params?.api || gridRef.current?.api });
+    },
+    [handleGridCellContextMenu]
+  );
+
   const handleGridShellContextMenu = useCallback(
     (event) => {
       if (event?.target?.closest?.(".ag-cell")) return;
@@ -1192,8 +1200,9 @@ export default function RemoteRegistryEditor({ device }) {
         resizable: false,
         cellRenderer: (params) => <Typography component="span" sx={GRID_MUTED_CELL_SX}>{params?.value || ""}</Typography>,
       },
+      buildRowContextMenuColumnDef(handleRowContextMenuButton, { tooltip: "Registry Row Actions" }),
     ],
-    []
+    [handleRowContextMenuButton]
   );
 
   const rowSelection = useMemo(() => ({ mode: "singleRow", enableClickSelection: true }), []);

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Grid_Row_Context_Menu_Button.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Grid_Row_Context_Menu_Button.jsx
@@ -1,0 +1,137 @@
+import React, { useCallback } from "react";
+import { Box, IconButton, Tooltip } from "@mui/material";
+import MoreVertIcon from "@mui/icons-material/MoreVert";
+
+export const ROW_CONTEXT_MENU_COL_ID = "__row_context_menu";
+export const ROW_CONTEXT_MENU_COLUMN_WIDTH = 52;
+
+const ROW_CONTEXT_MENU_CELL_SX = {
+  width: "100%",
+  height: "100%",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+};
+
+const ROW_CONTEXT_MENU_BUTTON_SX = {
+  width: 30,
+  height: 30,
+  borderRadius: "50%",
+  color: "rgba(226,232,240,0.86)",
+  border: "1px solid rgba(148,163,184,0.2)",
+  background: "rgba(8,12,24,0.52)",
+  transition: "background-color 0.16s ease, border-color 0.16s ease, color 0.16s ease",
+  "&:hover": {
+    color: "#f8fbff",
+    borderColor: "rgba(125,211,252,0.55)",
+    background: "rgba(14,22,42,0.92)",
+  },
+  "&:focus-visible": {
+    color: "#f8fbff",
+    borderColor: "rgba(125,211,252,0.72)",
+    boxShadow: "0 0 0 2px rgba(125,211,252,0.18)",
+  },
+};
+
+function eventWithFallbackCoordinates(event) {
+  const clientX = Number(event?.clientX || 0);
+  const clientY = Number(event?.clientY || 0);
+  if (clientX || clientY || !event?.currentTarget?.getBoundingClientRect) {
+    return event;
+  }
+  const rect = event.currentTarget.getBoundingClientRect();
+  return {
+    clientX: rect.left + rect.width / 2,
+    clientY: rect.top + rect.height / 2,
+    currentTarget: event.currentTarget,
+    target: event.target,
+    preventDefault: () => event.preventDefault?.(),
+    stopPropagation: () => event.stopPropagation?.(),
+  };
+}
+
+export function GridRowContextMenuButtonCell({
+  params = {},
+  onOpenContextMenu,
+  tooltip = "Row Actions",
+  disabled = false,
+}) {
+  const row = params?.data || null;
+  const label = typeof tooltip === "function" ? tooltip(row, params) : tooltip;
+  const resolvedLabel = String(label || "Row Actions");
+
+  const handlePointerDown = useCallback((event) => {
+    event.preventDefault();
+    event.stopPropagation();
+  }, []);
+
+  const handleClick = useCallback(
+    (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (!row || disabled) return;
+      onOpenContextMenu?.(eventWithFallbackCoordinates(event), row, params?.node || null, params);
+    },
+    [disabled, onOpenContextMenu, params, row]
+  );
+
+  if (!row) return null;
+
+  return (
+    <Box sx={ROW_CONTEXT_MENU_CELL_SX}>
+      <Tooltip title={resolvedLabel} placement="left" arrow>
+        <span>
+          <IconButton
+            aria-label={resolvedLabel}
+            size="small"
+            disabled={disabled}
+            onMouseDown={handlePointerDown}
+            onClick={handleClick}
+            sx={ROW_CONTEXT_MENU_BUTTON_SX}
+          >
+            <MoreVertIcon fontSize="small" />
+          </IconButton>
+        </span>
+      </Tooltip>
+    </Box>
+  );
+}
+
+export function buildRowContextMenuColumnDef(onOpenContextMenu, options = {}) {
+  const width = Number(options.width || ROW_CONTEXT_MENU_COLUMN_WIDTH);
+  const tooltip = options.tooltip || "Row Actions";
+  return {
+    colId: options.colId || ROW_CONTEXT_MENU_COL_ID,
+    headerName: options.headerName || "",
+    width,
+    minWidth: width,
+    maxWidth: width,
+    pinned: "right",
+    lockPinned: true,
+    lockPosition: true,
+    sortable: false,
+    filter: false,
+    resizable: false,
+    suppressMovable: true,
+    suppressHeaderMenuButton: true,
+    suppressHeaderContextMenu: true,
+    cellClass: "row-context-menu-cell",
+    cellStyle: {
+      padding: 0,
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    cellRendererParams: {
+      suppressMouseEventHandling: () => true,
+    },
+    cellRenderer: (params) => (
+      <GridRowContextMenuButtonCell
+        params={params}
+        onOpenContextMenu={onOpenContextMenu}
+        tooltip={tooltip}
+        disabled={Boolean(options.disabled)}
+      />
+    ),
+  };
+}

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Grid_Row_Context_Menu_Button.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Grid_Row_Context_Menu_Button.jsx
@@ -106,6 +106,7 @@ export function buildRowContextMenuColumnDef(onOpenContextMenu, options = {}) {
     width,
     minWidth: width,
     maxWidth: width,
+    flex: 0,
     pinned: "right",
     lockPinned: true,
     lockPosition: true,

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Grid_Row_Context_Menu_Button.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Grid_Row_Context_Menu_Button.jsx
@@ -13,7 +13,7 @@ const ROW_CONTEXT_MENU_CELL_SX = {
   justifyContent: "center",
 };
 
-const ROW_CONTEXT_MENU_BUTTON_SX = {
+export const ROW_CONTEXT_MENU_BUTTON_SX = {
   width: 30,
   height: 30,
   borderRadius: "50%",

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Row_Context_Menu.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Row_Context_Menu.jsx
@@ -1,0 +1,285 @@
+import React from "react";
+import { Box, Divider, Menu, MenuItem, Tooltip, Typography } from "@mui/material";
+
+const TEXT_BRIGHT = "#e2e8f0";
+const TEXT_MUTED = "rgba(148,163,184,0.78)";
+
+export const ROW_CONTEXT_MENU_GROUP_LABELS = {
+  primary: "Primary",
+  organize: "Organize",
+  danger: "Danger Zone",
+  view: "View",
+};
+
+export const ROW_CONTEXT_MENU_GROUP_ORDER = ["primary", "organize", "danger", "view"];
+
+export const ROW_CONTEXT_MENU_PAPER_WIDTHS = {
+  compact: 236,
+  standard: 288,
+  extended: 340,
+};
+
+export const ROW_CONTEXT_MENU_PAPER_SX = {
+  bgcolor: "rgba(8,12,24,0.96)",
+  border: "1px solid rgba(148,163,184,0.35)",
+  backdropFilter: "blur(14px)",
+  borderRadius: 2,
+  px: 0.8,
+  py: 0.8,
+  boxShadow: "0 18px 46px rgba(2,8,23,0.85)",
+};
+
+const ROW_CONTEXT_MENU_HEADER_SX = {
+  display: "flex",
+  alignItems: "center",
+  gap: 1,
+  px: 1.1,
+  pt: 0.55,
+  pb: 0.85,
+};
+
+const ROW_CONTEXT_MENU_HEADER_ICON_SX = {
+  width: 32,
+  height: 32,
+  borderRadius: 1.35,
+  flexShrink: 0,
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  border: "1px solid rgba(148,163,184,0.14)",
+  background: "rgba(255,255,255,0.04)",
+  color: "#8fd3ff",
+};
+
+const ROW_CONTEXT_MENU_SECTION_LABEL_SX = {
+  px: 1.2,
+  pt: 0.65,
+  pb: 0.45,
+  color: "rgba(148,163,184,0.72)",
+  fontSize: "0.68rem",
+  fontWeight: 700,
+  letterSpacing: "0.08em",
+  textTransform: "uppercase",
+};
+
+const ROW_CONTEXT_MENU_DIVIDER_SX = {
+  my: 0.55,
+  borderColor: "rgba(148,163,184,0.16)",
+};
+
+const ROW_CONTEXT_MENU_ITEM_SX = {
+  minHeight: 42,
+  borderRadius: 1.6,
+  color: TEXT_BRIGHT,
+  alignItems: "center",
+  px: 1,
+  py: 0.85,
+  position: "relative",
+  overflow: "hidden",
+  "&:hover": {
+    backgroundColor: "rgba(88,166,255,0.12)",
+  },
+  "&::before": {
+    content: '""',
+    position: "absolute",
+    left: 0,
+    top: 8,
+    bottom: 8,
+    width: 3,
+    borderRadius: 999,
+    background: "transparent",
+    transition: "background-color 0.16s ease",
+  },
+  "&:hover::before": {
+    background: "#58a6ff",
+  },
+};
+
+const ROW_CONTEXT_MENU_DANGER_ITEM_SX = {
+  ...ROW_CONTEXT_MENU_ITEM_SX,
+  "&:hover": {
+    backgroundColor: "rgba(248,113,113,0.1)",
+  },
+  "&:hover::before": {
+    background: "#58a6ff",
+  },
+};
+
+const ROW_CONTEXT_MENU_ROW_ICON_SX = {
+  mt: 0.18,
+  mr: 1,
+  fontSize: 18,
+  flexShrink: 0,
+};
+
+const ROW_CONTEXT_MENU_LABEL_SX = {
+  color: TEXT_BRIGHT,
+  fontSize: "0.84rem",
+  fontWeight: 500,
+  lineHeight: 1.2,
+  whiteSpace: "nowrap",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+};
+
+const ROW_CONTEXT_MENU_DESCRIPTION_SX = {
+  color: TEXT_MUTED,
+  fontSize: "0.73rem",
+  lineHeight: 1.25,
+  mt: 0.25,
+};
+
+const ROW_CONTEXT_MENU_TITLE_TRUNCATE_SX = {
+  whiteSpace: "nowrap",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+};
+
+function menuWidthForVariant(widthVariant) {
+  return ROW_CONTEXT_MENU_PAPER_WIDTHS[widthVariant] || ROW_CONTEXT_MENU_PAPER_WIDTHS.standard;
+}
+
+function renderIcon(icon, sx = {}) {
+  if (!icon) return null;
+  if (React.isValidElement(icon)) {
+    return React.cloneElement(icon, {
+      sx: {
+        ...sx,
+        ...(icon.props?.sx || {}),
+      },
+    });
+  }
+  const IconComponent = icon;
+  return <IconComponent sx={sx} />;
+}
+
+export function buildContextMenuGroups(actions = [], groupOrder = ROW_CONTEXT_MENU_GROUP_ORDER) {
+  const visibleActions = (Array.isArray(actions) ? actions : []).filter((action) => action && !action.hidden);
+  return groupOrder
+    .map((groupId) => ({
+      id: groupId,
+      label: ROW_CONTEXT_MENU_GROUP_LABELS[groupId] || groupId,
+      actions: visibleActions.filter((action) => (action.group || "primary") === groupId),
+    }))
+    .filter((group) => group.actions.length);
+}
+
+export default function RowContextMenu({
+  open,
+  onClose,
+  position,
+  headerIcon,
+  title = "",
+  subtitle = "",
+  actions = [],
+  widthVariant = "standard",
+  groupOrder = ROW_CONTEXT_MENU_GROUP_ORDER,
+}) {
+  const groups = buildContextMenuGroups(actions, groupOrder);
+  const width = menuWidthForVariant(widthVariant);
+  const titleMaxWidth = Math.max(180, width - 48);
+  const actionNodes = [];
+
+  if (groups.length) {
+    groups.forEach((group) => {
+      actionNodes.push(<Divider key={`divider-before-${group.id}`} component="li" sx={ROW_CONTEXT_MENU_DIVIDER_SX} />);
+      actionNodes.push(
+        <Box key={`label-${group.id}`} component="li" role="presentation" sx={ROW_CONTEXT_MENU_SECTION_LABEL_SX}>
+          {group.label}
+        </Box>
+      );
+      group.actions.forEach((action) => {
+        const helperText = action.disabledReason || action.description || "";
+        actionNodes.push(
+          <MenuItem
+            key={action.id}
+            disabled={Boolean(action.disabled)}
+            onClick={() => {
+              onClose?.();
+              action.onClick?.();
+            }}
+            sx={action.intent === "danger" ? ROW_CONTEXT_MENU_DANGER_ITEM_SX : ROW_CONTEXT_MENU_ITEM_SX}
+          >
+            {renderIcon(action.icon, {
+              ...ROW_CONTEXT_MENU_ROW_ICON_SX,
+              color: action.intent === "danger" ? "rgba(248,113,113,0.92)" : "rgba(226,232,240,0.92)",
+            })}
+            <Box
+              sx={{
+                flex: 1,
+                minWidth: 0,
+                display: "flex",
+                flexDirection: "column",
+                justifyContent: helperText ? "flex-start" : "center",
+              }}
+            >
+              <Typography sx={ROW_CONTEXT_MENU_LABEL_SX}>{action.label}</Typography>
+              {helperText ? <Typography sx={ROW_CONTEXT_MENU_DESCRIPTION_SX}>{helperText}</Typography> : null}
+            </Box>
+          </MenuItem>
+        );
+      });
+    });
+  } else {
+    actionNodes.push(
+      <MenuItem key="no-actions" disabled sx={ROW_CONTEXT_MENU_ITEM_SX}>
+        <Box sx={{ minWidth: 0 }}>
+          <Typography sx={ROW_CONTEXT_MENU_LABEL_SX}>No Actions Available</Typography>
+        </Box>
+      </MenuItem>
+    );
+  }
+
+  return (
+    <Menu
+      open={Boolean(open)}
+      onClose={onClose}
+      anchorReference="anchorPosition"
+      anchorPosition={
+        open && position
+          ? {
+              top: Number(position.top || 0),
+              left: Number(position.left || 0),
+            }
+          : undefined
+      }
+      PaperProps={{ sx: { ...ROW_CONTEXT_MENU_PAPER_SX, minWidth: width, maxWidth: width } }}
+    >
+      <Box component="li" role="presentation" sx={ROW_CONTEXT_MENU_HEADER_SX}>
+        <Box sx={ROW_CONTEXT_MENU_HEADER_ICON_SX}>{renderIcon(headerIcon, { fontSize: 19 })}</Box>
+        <Box sx={{ minWidth: 0 }}>
+          <Tooltip title={title || ""} placement="top-start">
+            <Typography
+              sx={{
+                ...ROW_CONTEXT_MENU_TITLE_TRUNCATE_SX,
+                color: TEXT_BRIGHT,
+                fontSize: "0.88rem",
+                fontWeight: 600,
+                lineHeight: 1.2,
+                maxWidth: titleMaxWidth,
+              }}
+            >
+              {title || "Actions"}
+            </Typography>
+          </Tooltip>
+          <Tooltip title={subtitle || ""} placement="top-start">
+            <Typography
+              sx={{
+                ...ROW_CONTEXT_MENU_TITLE_TRUNCATE_SX,
+                color: "rgba(148,163,184,0.82)",
+                fontSize: "0.73rem",
+                lineHeight: 1.25,
+                mt: 0.22,
+                maxWidth: titleMaxWidth,
+              }}
+            >
+              {subtitle || "Row actions"}
+            </Typography>
+          </Tooltip>
+        </Box>
+      </Box>
+
+      {actionNodes}
+    </Menu>
+  );
+}

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Sites/Site_List.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Sites/Site_List.jsx
@@ -33,6 +33,7 @@ import dayjs from "dayjs";
 import { AgGridReact } from "ag-grid-react";
 import { ModuleRegistry, AllCommunityModule, themeQuartz } from "ag-grid-community";
 import { CreateSiteDialog, RenameSiteDialog } from "../Dialogs.jsx";
+import { buildRowContextMenuColumnDef } from "../Grid_Row_Context_Menu_Button.jsx";
 import PageBodyFrame from "../PageBodyFrame.jsx";
 import { useAppNotifications } from "../app/hooks/useAppNotifications.js";
 import { useRoutePageChrome } from "../app/hooks/useRoutePageChrome.js";
@@ -2698,6 +2699,20 @@ export default function SiteList() {
     []
   );
 
+  const handleOpenSiteContextMenu = useCallback((event, row, rowNode = null) => {
+    event?.preventDefault?.();
+    event?.stopPropagation?.();
+    if (rowNode && !rowNode.isSelected?.()) {
+      rowNode.setSelected?.(true, true);
+    }
+    setSiteContextMenu({
+      open: true,
+      top: Number(event?.clientY || 0),
+      left: Number(event?.clientX || 0),
+      row: row || null,
+    });
+  }, []);
+
   const columnDefs = useMemo(() => [
     {
       headerName: "Name",
@@ -2837,7 +2852,8 @@ export default function SiteList() {
         );
       },
     },
-  ], [handleOpenDevicesForSite]);
+    buildRowContextMenuColumnDef(handleOpenSiteContextMenu, { tooltip: "Site Actions" }),
+  ], [handleOpenDevicesForSite, handleOpenSiteContextMenu]);
 
   const defaultColDef = useMemo(() => ({
     sortable: false,
@@ -2875,20 +2891,6 @@ export default function SiteList() {
     setInstallMenuAnchorEl(event.currentTarget);
     setInstallMenuSite(singleSelectedSite);
   }, [singleSelectedSite]);
-
-  const handleOpenSiteContextMenu = useCallback((event, row, rowNode = null) => {
-    event?.preventDefault?.();
-    event?.stopPropagation?.();
-    if (rowNode && !rowNode.isSelected?.()) {
-      rowNode.setSelected?.(true, true);
-    }
-    setSiteContextMenu({
-      open: true,
-      top: Number(event?.clientY || 0),
-      left: Number(event?.clientX || 0),
-      row: row || null,
-    });
-  }, []);
 
   const handleCloseSiteContextMenu = useCallback(() => {
     setSiteContextMenu({ open: false, top: 0, left: 0, row: null });

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Software/Software_List.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Software/Software_List.jsx
@@ -25,6 +25,7 @@ import TerminalRoundedIcon from "@mui/icons-material/TerminalRounded";
 import { AgGridReact } from "ag-grid-react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { ConfirmDeleteDialog } from "../Dialogs.jsx";
+import { buildRowContextMenuColumnDef } from "../Grid_Row_Context_Menu_Button.jsx";
 import {
   DIALOG_ACTIONS_SX,
   DIALOG_BUTTON_SX,
@@ -1017,6 +1018,7 @@ export default function SoftwareList() {
           <ActionCell row={params.data} busyKey={busyKey} onUninstall={(row) => setConfirmRow(row)} />
         ),
       },
+      buildRowContextMenuColumnDef(openContextMenu, { tooltip: "Software Actions" }),
     ],
     [busyKey, openContextMenu, openInstalledDevices]
   );

--- a/Docs/Reference/ui-and-notifications.md
+++ b/Docs/Reference/ui-and-notifications.md
@@ -232,6 +232,7 @@ Treat this document as the single source of truth for Borealis WebUI design rule
       - row-level AG Grid context menus should also expose a pinned-right `MoreVert` icon button for each data row
       - the button must open the same menu as right-click for that row, select the row first when needed, and keep existing right-click behavior intact
       - use `Data/Engine/Containers/webui-frontend/data/web-interface/src/Grid_Row_Context_Menu_Button.jsx` for the shared button and column definition instead of recreating per-page icon button styling
+      - use `Data/Engine/Containers/webui-frontend/data/web-interface/src/Row_Context_Menu.jsx` for standard grouped row-context menus when a page does not already have a local menu renderer
     - Native browser menu suppression:
       - when Borealis intentionally exposes its own right-click context menu, suppress the browser's native context menu for that interaction target so the operator receives the Borealis menu consistently
       - wire suppression at every menu entrypoint, including DOM `onContextMenu` handlers and component-library context-menu hooks

--- a/Docs/Reference/ui-and-notifications.md
+++ b/Docs/Reference/ui-and-notifications.md
@@ -228,6 +228,10 @@ Treat this document as the single source of truth for Borealis WebUI design rule
       - if the operator right-clicks an unselected row, select that row first and then open the menu
       - if the operator right-clicks an already selected row, preserve the existing selection
       - right-clicking empty grid space may still open a context menu when the page has useful non-row actions such as `New Folder` or `Collapse All`
+    - Visible row affordance:
+      - row-level AG Grid context menus should also expose a pinned-right `MoreVert` icon button for each data row
+      - the button must open the same menu as right-click for that row, select the row first when needed, and keep existing right-click behavior intact
+      - use `Data/Engine/Containers/webui-frontend/data/web-interface/src/Grid_Row_Context_Menu_Button.jsx` for the shared button and column definition instead of recreating per-page icon button styling
     - Native browser menu suppression:
       - when Borealis intentionally exposes its own right-click context menu, suppress the browser's native context menu for that interaction target so the operator receives the Borealis menu consistently
       - wire suppression at every menu entrypoint, including DOM `onContextMenu` handlers and component-library context-menu hooks


### PR DESCRIPTION
## Summary

Closes #251.

- Added shared `MoreVert` AG Grid row action column and shared grouped row-context menu renderer.
- Wired row action button into context menus for Assemblies, Device List, Device Filters, Software Audit, Directory Services, Sites, Process Management, Installed Software, Remote Files, and Remote Registry.
- Redesigned Device Filters so inline row action buttons are condensed into one row `MoreVert` button plus right-click context menu.
- Fixed Device Filters grid sizing: Filter Name gets 1/3 of center-table flex space, Description gets 1/3, and remaining data columns share the last 1/3 while row actions stay fixed right.
- Redesigned Device List row actions and custom-view actions from simple dropdowns into grouped Borealis context menus.
- Matched Device List row and saved-view `MoreVert` buttons to the same circular dark-glass button style.
- Upgraded Credentials and User Management row action menus to the shared circular `MoreVert` button plus grouped right-click context menu design.
- Documented the shared button and grouped menu components in the UI reference.

## Validation

- `git diff --check` passed.
- `./Engine_Unit_Tests.sh --domain webui` could not reach Vitest because the prepared runtime WebUI test cache is missing at `Engine/Services/webui-frontend/cache/web-interface/Unit_Tests`; latest script run wrote results to `Unit_Test_Results/engine-20260731T205126Z`.

## Notes

No dependency or SBOM change.