### PR TITLE
issue/security-hardening-pass-2-scheduler-port-bounds

### DIFF
--- a/Data/Engine/Containers/api-backend/cmd/api-backend/scheduler_manager.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/scheduler_manager.go
@@ -2801,7 +2801,7 @@ func schedulerWorkerPort(workerGUID string, siteID int64, baseEnv, rangeEnv stri
 	if portRange <= 0 || portRange > int64(^uint32(0)) {
 		portRange = 1
 	}
-	return base + int64(hash%uint32(portRange))
+	return base + (int64(hash) % portRange)
 }
 
 func fnv32(value string) uint32 {

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/scheduler_manager_test.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/scheduler_manager_test.go
@@ -312,6 +312,23 @@ func TestSchedulerK3sSiteWorkerGUIDStableBySite(t *testing.T) {
 	}
 }
 
+func TestSchedulerWorkerPortBoundsRangeBeforeHashModulo(t *testing.T) {
+	t.Setenv("BOREALIS_TEST_WORKER_PORT_BASE", "65000")
+	t.Setenv("BOREALIS_TEST_WORKER_PORT_RANGE", "999999")
+
+	port := schedulerWorkerPort(
+		"worker-1",
+		7,
+		"BOREALIS_TEST_WORKER_PORT_BASE",
+		"BOREALIS_TEST_WORKER_PORT_RANGE",
+		56000,
+		2000,
+	)
+	if port < 65000 || port > 65534 {
+		t.Fatalf("worker port out of bounded range: %d", port)
+	}
+}
+
 func TestSchedulerRemoveOrphanRouteFiles(t *testing.T) {
 	routeDir := t.TempDir()
 	t.Setenv("BOREALIS_TRAEFIK_DYNAMIC_CONFIG_DIR", routeDir)


### PR DESCRIPTION
## Summary

Fixes the remaining non-protocol CodeQL finding after Security Hardening Pass 1 by removing the scheduler worker-port conversion from an environment-parsed integer into `uint32`.

The worker port calculation keeps the same deterministic FNV hash behavior, but computes modulo in `int64` after range clamping instead of converting the range to `uint32`.

Refs #395

## Security Alert

- [CodeQL #11 - go/incorrect-integer-conversion](https://github.com/bunny-lab-io/Borealis/security/code-scanning/11)

## Validation

- `/opt/Borealis/Dependencies/Go/go1.25.12/bin/go test ./cmd/api-backend -run 'TestSchedulerWorkerPortBoundsRangeBeforeHashModulo|TestSchedulerManager'`
- `/opt/Borealis/Dependencies/Go/go1.25.12/bin/go test ./...`
- `BOREALIS_ENGINE_TEST_PYTHON=/tmp/borealis-pytest-venv/bin/python ./Engine_Unit_Tests.sh --domain scheduler`
- `git diff --check`
- Static source check confirms `uint32(portRange)` and `hash%uint32` are gone from scheduler code.

## Remaining Security Queue

Post-merge pass 1 left Dependabot at 0 open alerts and CodeQL at 3 open alerts. This PR targets the only remaining real code fix. The remaining two alerts are protocol-required VNC/RFB DES challenge-response paths:

- [CodeQL #2 - py/weak-cryptographic-algorithm](https://github.com/bunny-lab-io/Borealis/security/code-scanning/2)
- [CodeQL #18 - go/weak-cryptographic-algorithm](https://github.com/bunny-lab-io/Borealis/security/code-scanning/18)
