### PR TITLE
issue/security-hardening-pass-5-dependabot-policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -199,9 +199,6 @@ updates:
     open-pull-requests-limit: 2
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 3
     ignore:
       - dependency-name: "postgres"
         update-types:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,9 @@ updates:
       day: "monday"
       time: "04:00"
       timezone: "America/Denver"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 2
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "deps"
       include: "scope"
@@ -18,40 +20,88 @@ updates:
         patterns:
           - "*"
       github-actions:
+        applies-to: "version-updates"
         patterns:
           - "*"
 
   - package-ecosystem: "gomod"
-    directories:
-      - "/Data/Agent"
-      - "/Data/Engine/Containers/api-backend"
+    directory: "/Data/Agent"
     schedule:
       interval: "weekly"
       day: "tuesday"
       time: "04:00"
       timezone: "America/Denver"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
     commit-message:
       prefix: "deps"
       include: "scope"
     groups:
-      go-security:
+      agent-go-security:
         applies-to: "security-updates"
         patterns:
           - "*"
-      go-minor-patch:
+      agent-go-minor-patch:
+        applies-to: "version-updates"
         patterns:
           - "*"
         update-types:
           - "minor"
           - "patch"
-        group-by: "dependency-name"
-      go-major:
+      agent-go-major:
+        applies-to: "version-updates"
         patterns:
           - "*"
         update-types:
           - "major"
-        group-by: "dependency-name"
+
+  - package-ecosystem: "gomod"
+    directory: "/Data/Engine/Containers/api-backend"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "04:30"
+      timezone: "America/Denver"
+    open-pull-requests-limit: 2
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    groups:
+      engine-go-security:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+      engine-go-passkey-sensitive:
+        applies-to: "version-updates"
+        patterns:
+          - "github.com/go-webauthn/webauthn"
+        update-types:
+          - "minor"
+          - "patch"
+      engine-go-minor-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "github.com/go-webauthn/webauthn"
+        update-types:
+          - "minor"
+          - "patch"
+      engine-go-major:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "major"
 
   - package-ecosystem: "pip"
     directory: "/Data/Engine/Containers/api-backend/data"
@@ -60,7 +110,12 @@ updates:
       day: "wednesday"
       time: "04:00"
       timezone: "America/Denver"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 2
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
     commit-message:
       prefix: "deps"
       include: "scope"
@@ -70,12 +125,14 @@ updates:
         patterns:
           - "*"
       python-minor-patch:
+        applies-to: "version-updates"
         patterns:
           - "*"
         update-types:
           - "minor"
           - "patch"
       python-major:
+        applies-to: "version-updates"
         patterns:
           - "*"
         update-types:
@@ -88,8 +145,13 @@ updates:
       day: "thursday"
       time: "04:00"
       timezone: "America/Denver"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 2
     versioning-strategy: "increase-if-necessary"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
     commit-message:
       prefix: "deps"
       prefix-development: "deps-dev"
@@ -101,6 +163,7 @@ updates:
           - "*"
       webui-production-minor-patch:
         dependency-type: "production"
+        applies-to: "version-updates"
         patterns:
           - "*"
         update-types:
@@ -108,12 +171,14 @@ updates:
           - "patch"
       webui-development-minor-patch:
         dependency-type: "development"
+        applies-to: "version-updates"
         patterns:
           - "*"
         update-types:
           - "minor"
           - "patch"
       webui-major:
+        applies-to: "version-updates"
         patterns:
           - "*"
         update-types:
@@ -135,7 +200,23 @@ updates:
       day: "friday"
       time: "04:00"
       timezone: "America/Denver"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 2
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+    ignore:
+      - dependency-name: "postgres"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "python"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+      - dependency-name: "node"
+        update-types:
+          - "version-update:semver-major"
     commit-message:
       prefix: "deps"
       include: "scope"
@@ -145,5 +226,9 @@ updates:
         patterns:
           - "*"
       engine-container-base-images:
+        applies-to: "version-updates"
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -116,6 +116,10 @@ updates:
       semver-major-days: 30
       semver-minor-days: 7
       semver-patch-days: 3
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     commit-message:
       prefix: "deps"
       include: "scope"
@@ -131,12 +135,6 @@ updates:
         update-types:
           - "minor"
           - "patch"
-      python-major:
-        applies-to: "version-updates"
-        patterns:
-          - "*"
-        update-types:
-          - "major"
 
   - package-ecosystem: "npm"
     directory: "/Data/Engine/Containers/webui-frontend/data/web-interface"
@@ -152,6 +150,10 @@ updates:
       semver-major-days: 30
       semver-minor-days: 7
       semver-patch-days: 3
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     commit-message:
       prefix: "deps"
       prefix-development: "deps-dev"
@@ -177,12 +179,6 @@ updates:
         update-types:
           - "minor"
           - "patch"
-      webui-major:
-        applies-to: "version-updates"
-        patterns:
-          - "*"
-        update-types:
-          - "major"
 
   - package-ecosystem: "docker"
     directories:

--- a/Docs/Reference/SBOM.md
+++ b/Docs/Reference/SBOM.md
@@ -177,3 +177,5 @@ Use `shared-engine` for dependencies that support host deployment, build orchest
 - Keep Agent and Engine inventories separate so deployment reviewers can quickly assess licensing impact by runtime.
 - Keep Engine dependency entries under the service that installs or vendors them. Use `shared-engine` for deployment or cross-container orchestration dependencies.
 - If Borealis later adopts lockfiles or generated SBOM tooling, this file can be expanded to include resolved transitive dependencies.
+- Dependabot security updates stay enabled across monitored ecosystems, but routine version updates are rate-limited and grouped by runtime blast radius. Treat Agent Go, Engine Go, Python, WebUI, GitHub Actions, and Docker base-image updates as separate review lanes.
+- Docker base-image major runtime changes need planned upgrade work before merging. PostgreSQL major, Node major, and Python runtime-line jumps are intentionally suppressed from routine Dependabot version-update PRs.

--- a/Docs/Reference/SBOM.md
+++ b/Docs/Reference/SBOM.md
@@ -178,4 +178,4 @@ Use `shared-engine` for dependencies that support host deployment, build orchest
 - Keep Engine dependency entries under the service that installs or vendors them. Use `shared-engine` for deployment or cross-container orchestration dependencies.
 - If Borealis later adopts lockfiles or generated SBOM tooling, this file can be expanded to include resolved transitive dependencies.
 - Dependabot security updates stay enabled across monitored ecosystems, but routine version updates are rate-limited and grouped by runtime blast radius. Treat Agent Go, Engine Go, Python, WebUI, GitHub Actions, and Docker base-image updates as separate review lanes.
-- Docker base-image major runtime changes need planned upgrade work before merging. PostgreSQL major, Node major, and Python runtime-line jumps are intentionally suppressed from routine Dependabot version-update PRs.
+- Python package majors, WebUI package majors, and Docker base-image major/runtime-line changes need planned upgrade work before merging. PostgreSQL major, Node major, and Python base-image minor/major jumps are intentionally suppressed from routine Dependabot version-update PRs.


### PR DESCRIPTION
## Summary
- Tunes Dependabot version-update behavior so security coverage stays enabled while routine update PRs become bounded and easier to triage.
- Splits Go monitoring into Agent and Engine lanes instead of one cross-runtime `directories` block.
- Caps routine version-update PR fan-out to 1 Agent Go PR and 2 PRs per other ecosystem lane.
- Adds cooldown windows for routine version updates: 30 days for majors, 7 days for minors, 3 days for patches where SemVer applies.
- Keeps WebAuthn in a separate Engine Go group because recent upstream minor releases include breaking/passkey-sensitive behavior.
- Suppresses routine Python and WebUI semver-major version-update PRs so major package upgrades become planned work.
- Suppresses routine Docker version updates for PostgreSQL major, Node major, and Python runtime-line minor/major jumps.
- Restricts Docker base-image grouping to minor/patch updates so runtime major upgrades need planned PRs.
- Documents update-lane policy in SBOM maintenance notes.

## Issue
- Closes #412

## Existing Dependabot Queue Actions
- Closed #409 because it mixed PostgreSQL 17->18, Python 3.12->3.14, Node 22->26, and Traefik 3.3->3.5 in one Docker group.
- Closed #411 because it grouped 13 WebUI semver-major updates into one PR.
- Left lower-risk queued PRs open for intentional follow-up validation: #403, #404, #405, #406, #407, #408, #410.

## Why
- Dependabot opened multiple PRs immediately after coverage was enabled.
- Current open Dependabot security alerts are empty, so these are version-maintenance updates rather than urgent vulnerability remediations.
- Routine version-update PRs should preserve security visibility without forcing broad runtime, passkey, database, or WebUI major upgrades into one merge decision.

## Validation
- `python3` YAML parse of `.github/dependabot.yml`.
- Custom structural assertions for update entries, runtime split, PR limits, WebAuthn isolation, removed `group-by`, Python/WebUI major suppression, and Docker ignore rules.
- `git diff --check`.
- Current Dependabot queue inspected after closing unsafe broad PRs.

## References
- GitHub Dependabot options reference: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference
- GitHub Dependabot version-update optimization: https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/optimizing-pr-creation-version-updates
- GitHub Docker ecosystem support: https://docs.github.com/code-security/dependabot/ecosystems-supported-by-dependabot/supported-ecosystems-and-repositories