### PR TITLE
issue/engine-input-sanitization-validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -371,6 +371,7 @@ Stop and ask operator before destructive DB operations, schema migrations, produ
 * Visual example: `Data/Engine/Containers/webui-frontend/data/web-interface/src/DevTools/Page_Style_Template.jsx`.
 * Treat `Page_Style_Template.jsx` as reference only. Do not add business logic there.
 * Mirror layout, spacing, card treatment, selection column behavior, toast patterns, and route conventions from documented UI guidance.
+* Every new WebUI text entry path must declare its field class, frontend validation/sanitization, backend validation/sanitization, maximum length, and test coverage. Use shared WebUI/API input-validation helpers where possible. Never rely on frontend-only validation for operator-controlled or agent-controlled text.
 * For UI changes, provide local preview path, screenshot instructions, or browser verification notes when practical.
 * Do not rely on visual judgment alone when tests or route checks exist.
 

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/admin_approvals.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/admin_approvals.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"errors"
 	"net/http"
 	"strconv"
@@ -151,8 +150,10 @@ func handleApprovalStatusMutation(w http.ResponseWriter, r *http.Request, auth *
 	}
 	var body map[string]any
 	if status == "approved" {
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil && !errors.Is(err, http.ErrBodyReadAfterClose) {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json"})
+		var err error
+		body, err = readJSONMap(r)
+		if err != nil {
+			invalidJSONOrValidation(w, err)
 			return
 		}
 	}

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/agent_enrollment.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/agent_enrollment.go
@@ -9,7 +9,6 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"encoding/hex"
-	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -130,8 +129,11 @@ func agentEnrollmentRequestHandler(auth *authService, scriptSigner *agentScriptS
 			return
 		}
 
-		body := map[string]any{}
-		_ = json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&body)
+		body, err := readJSONMap(r)
+		if err != nil {
+			invalidJSONOrValidation(w, err)
+			return
+		}
 		hostname := cleanText(body["hostname"])
 		enrollmentCode := cleanText(body["enrollment_code"])
 		agentPubkeyB64, pubkeyOK := body["agent_pubkey"].(string)
@@ -219,9 +221,10 @@ func agentEnrollmentPollHandler(auth *authService, jwtSigner *agentJWTSigner, sc
 			return
 		}
 
-		var body map[string]any
-		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&body); err != nil {
-			body = map[string]any{}
+		body, err := readJSONMap(r)
+		if err != nil {
+			invalidJSONOrValidation(w, err)
+			return
 		}
 		approvalReference, referenceOK := body["approval_reference"].(string)
 		clientNonceB64, nonceOK := body["client_nonce"].(string)

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/agent_hash.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/agent_hash.go
@@ -82,7 +82,11 @@ func agentHashHandler(auth *authService, signer *agentJWTSigner, dpop *dpopVerif
 		var status int
 		var err error
 		if r.Method == http.MethodGet {
-			agentGUID, agentID := parseAgentHashLookupRequest(r)
+			agentGUID, agentID, badRequest := parseAgentHashLookupRequest(r)
+			if badRequest != nil {
+				writeJSON(w, http.StatusBadRequest, badRequest)
+				return
+			}
 			payload, status, err = store.lookupAgentHash(ctx, deviceCtx.GUID, agentGUID, agentID)
 		} else {
 			updateRequest, badRequest := parseAgentHashUpdateRequest(r)
@@ -284,24 +288,25 @@ func (s *agentJWTSigner) verifyAccessToken(token string) (map[string]any, error)
 	return claims, nil
 }
 
-func parseAgentHashLookupRequest(r *http.Request) (string, string) {
+func parseAgentHashLookupRequest(r *http.Request) (string, string, map[string]any) {
 	agentGUID := normalizeCanonicalGUID(r.URL.Query().Get("agent_guid"))
 	agentID := cleanText(firstText(r.URL.Query().Get("agent_id"), r.URL.Query().Get("id")))
 	if agentGUID != "" || agentID != "" {
-		return agentGUID, agentID
+		return agentGUID, agentID, nil
 	}
-	var body map[string]any
-	if err := json.NewDecoder(http.MaxBytesReader(nilResponseWriter{}, r.Body, 1<<20)).Decode(&body); err == nil {
-		agentGUID = normalizeCanonicalGUID(body["agent_guid"])
-		agentID = cleanText(firstText(cleanText(body["agent_id"]), cleanText(body["id"])))
+	body, err := readJSONMapWithLimit(r, 1<<20)
+	if err != nil {
+		return "", "", publicValidationErrorPayload(err, "invalid_request")
 	}
-	return agentGUID, agentID
+	agentGUID = normalizeCanonicalGUID(body["agent_guid"])
+	agentID = cleanText(firstText(cleanText(body["agent_id"]), cleanText(body["id"])))
+	return agentGUID, agentID, nil
 }
 
 func parseAgentHashUpdateRequest(r *http.Request) (agentHashUpdateRequest, map[string]any) {
-	var body map[string]any
-	if err := json.NewDecoder(http.MaxBytesReader(nilResponseWriter{}, r.Body, 1<<20)).Decode(&body); err != nil {
-		return agentHashUpdateRequest{}, map[string]any{"error": "invalid_request"}
+	body, err := readJSONMapWithLimit(r, 1<<20)
+	if err != nil {
+		return agentHashUpdateRequest{}, publicValidationErrorPayload(err, "invalid_request")
 	}
 	request := agentHashUpdateRequest{
 		AgentHash: cleanText(body["agent_hash"]),
@@ -313,12 +318,6 @@ func parseAgentHashUpdateRequest(r *http.Request) (agentHashUpdateRequest, map[s
 	}
 	return request, nil
 }
-
-type nilResponseWriter struct{}
-
-func (nilResponseWriter) Header() http.Header       { return http.Header{} }
-func (nilResponseWriter) Write([]byte) (int, error) { return 0, nil }
-func (nilResponseWriter) WriteHeader(int)           {}
 
 func (s *postgresOperatorStore) requiredDeviceTokenVersion(ctx context.Context, guid string) (*int, error) {
 	conn, err := s.db.Conn(ctx)

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/agent_ingest.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/agent_ingest.go
@@ -101,6 +101,10 @@ func agentHeartbeatHandler(auth *authService, signer *agentJWTSigner, dpop *dpop
 		}
 		payload, err := readAgentJSONMap(w, r, 8<<20)
 		if err != nil {
+			if errs, ok := asPublicValidationErrors(err); ok {
+				writePublicValidationErrors(w, errs)
+				return
+			}
 			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_request"})
 			return
 		}
@@ -133,6 +137,10 @@ func agentStatusHandler(auth *authService, signer *agentJWTSigner, dpop *dpopVer
 		}
 		payload, err := readAgentJSONMap(w, r, 1<<20)
 		if err != nil {
+			if errs, ok := asPublicValidationErrors(err); ok {
+				writePublicValidationErrors(w, errs)
+				return
+			}
 			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_request"})
 			return
 		}
@@ -179,6 +187,9 @@ func readAgentJSONMap(w http.ResponseWriter, r *http.Request, limit int64) (map[
 	if body == nil {
 		body = map[string]any{}
 	}
+	if errs := validateJSONTransportMap(body); len(errs) > 0 {
+		return nil, publicValidationErrors(errs)
+	}
 	return body, nil
 }
 
@@ -201,6 +212,9 @@ func readAgentJSONMapWithHash(w http.ResponseWriter, r *http.Request, limit int6
 	if body == nil {
 		body = map[string]any{}
 	}
+	if errs := validateJSONTransportMap(body); len(errs) > 0 {
+		return nil, bodyHash, publicValidationErrors(errs)
+	}
 	return body, bodyHash, nil
 }
 
@@ -217,6 +231,10 @@ func agentDetailsHandler(auth *authService, signer *agentJWTSigner, dpop *dpopVe
 		}
 		payload, payloadHash, err := readAgentJSONMapWithHash(w, r, 24<<20)
 		if err != nil {
+			if errs, ok := asPublicValidationErrors(err); ok {
+				writePublicValidationErrors(w, errs)
+				return
+			}
 			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_request"})
 			return
 		}

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/agent_maintenance.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/agent_maintenance.go
@@ -67,7 +67,7 @@ func agentMaintenanceBulkHandler(auth *authService) http.HandlerFunc {
 		}
 		body, err := readJSONMap(r)
 		if err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json", "message": "Request body must be valid JSON."})
+			invalidJSONOrValidation(w, err)
 			return
 		}
 		action := normalizeAgentMaintenanceAction(firstNonEmpty(body["action"], body["kind"], agentMaintenanceUpdateAction))

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/agent_tokens.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/agent_tokens.go
@@ -111,16 +111,13 @@ func agentTokenRefreshHandler(auth *authService, signer *agentJWTSigner, dpop *d
 			return
 		}
 
-		var body struct {
-			GUID         string `json:"guid"`
-			RefreshToken string `json:"refresh_token"`
-		}
-		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&body); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_request"})
+		body, err := readJSONMap(r)
+		if err != nil {
+			invalidJSONOrValidation(w, err)
 			return
 		}
-		guid := normalizeCanonicalGUID(body.GUID)
-		refreshToken := strings.TrimSpace(body.RefreshToken)
+		guid := normalizeCanonicalGUID(body["guid"])
+		refreshToken := strings.TrimSpace(cleanText(body["refresh_token"]))
 		if guid == "" || refreshToken == "" {
 			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_request"})
 			return

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/agent_vpn_runtime.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/agent_vpn_runtime.go
@@ -219,13 +219,10 @@ func deviceRemoteAccessBlockedPayload(status string) map[string]any {
 }
 
 func readOptionalJSONMap(w http.ResponseWriter, r *http.Request) map[string]any {
-	var body map[string]any
-	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&body); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_request"})
+	body, err := readJSONMap(r)
+	if err != nil {
+		invalidJSONOrValidation(w, err)
 		return nil
-	}
-	if body == nil {
-		body = map[string]any{}
 	}
 	return body
 }

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/assemblies.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/assemblies.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -531,15 +530,25 @@ func assemblyMutationAllowed(w http.ResponseWriter, r *http.Request, auth *authS
 }
 
 func readAssemblyJSON(w http.ResponseWriter, r *http.Request) (map[string]any, bool) {
+	raw, err := readLimitedRequestBody(r, assemblyDocumentMaxBytes)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, publicValidationErrorPayload(err, "invalid json"))
+		return nil, false
+	}
+	if len(strings.TrimSpace(string(raw))) == 0 {
+		return map[string]any{}, true
+	}
 	var body map[string]any
-	reader := http.MaxBytesReader(w, r.Body, assemblyDocumentMaxBytes)
-	err := json.NewDecoder(reader).Decode(&body)
-	if err != nil && !errors.Is(err, io.EOF) {
+	if err := json.Unmarshal(raw, &body); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid json"})
 		return nil, false
 	}
 	if body == nil {
 		body = map[string]any{}
+	}
+	if errs := validateJSONTransportMap(body); len(errs) > 0 {
+		writePublicValidationErrors(w, errs)
+		return nil, false
 	}
 	return body, true
 }

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/auth_login.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/auth_login.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
-	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -598,9 +597,9 @@ func readAuthJSONRaw(w http.ResponseWriter, r *http.Request) ([]byte, map[string
 	if r.Body == nil {
 		return nil, map[string]any{}, true
 	}
-	raw, err := io.ReadAll(io.LimitReader(r.Body, 64<<10))
+	raw, err := readLimitedRequestBody(r, publicAuthJSONMaxBytes)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json"})
+		invalidJSONOrValidation(w, err)
 		return nil, nil, false
 	}
 	if len(raw) == 0 {
@@ -613,6 +612,10 @@ func readAuthJSONRaw(w http.ResponseWriter, r *http.Request) ([]byte, map[string
 	}
 	if body == nil {
 		body = map[string]any{}
+	}
+	if errs := sanitizeJSONInputMap(body); len(errs) > 0 {
+		writePublicValidationErrors(w, errs)
+		return nil, nil, false
 	}
 	return raw, body, true
 }

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/auth_passkey_ceremonies.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/auth_passkey_ceremonies.go
@@ -925,8 +925,12 @@ func passkeyProtocolTransports(raw string) []protocol.AuthenticatorTransport {
 }
 
 func readPasskeyJSON(w http.ResponseWriter, r *http.Request) (map[string]any, bool) {
-	_, body, ok := readPasskeyJSONRaw(w, r)
-	return body, ok
+	body, err := readJSONMapWithLimit(r, 1<<20)
+	if err != nil {
+		invalidJSONOrValidation(w, err)
+		return nil, false
+	}
+	return body, true
 }
 
 func readPasskeyJSONRaw(w http.ResponseWriter, r *http.Request) ([]byte, map[string]any, bool) {
@@ -949,7 +953,7 @@ func readPasskeyJSONRaw(w http.ResponseWriter, r *http.Request) ([]byte, map[str
 	if body == nil {
 		body = map[string]any{}
 	}
-	if errs := sanitizeJSONInputMap(body); len(errs) > 0 {
+	if errs := validateJSONTransportMap(body); len(errs) > 0 {
 		writePublicValidationErrors(w, errs)
 		return nil, nil, false
 	}

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/auth_passkey_ceremonies.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/auth_passkey_ceremonies.go
@@ -9,7 +9,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"io"
 	"math"
 	"net/http"
 	"net/url"
@@ -934,12 +933,12 @@ func readPasskeyJSONRaw(w http.ResponseWriter, r *http.Request) ([]byte, map[str
 	if r.Body == nil {
 		return nil, map[string]any{}, true
 	}
-	raw, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	raw, err := readLimitedRequestBody(r, 1<<20)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json"})
+		writeJSON(w, http.StatusBadRequest, publicValidationErrorPayload(err, "invalid_json"))
 		return nil, nil, false
 	}
-	if len(raw) == 0 {
+	if len(strings.TrimSpace(string(raw))) == 0 {
 		return raw, map[string]any{}, true
 	}
 	var body map[string]any
@@ -949,6 +948,10 @@ func readPasskeyJSONRaw(w http.ResponseWriter, r *http.Request) ([]byte, map[str
 	}
 	if body == nil {
 		body = map[string]any{}
+	}
+	if errs := sanitizeJSONInputMap(body); len(errs) > 0 {
+		writePublicValidationErrors(w, errs)
+		return nil, nil, false
 	}
 	return raw, body, true
 }

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/auth_passkeys.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/auth_passkeys.go
@@ -105,9 +105,9 @@ func authPasskeyByIDHandler(auth *authService, fallback http.Handler) http.Handl
 		defer cancel()
 		switch r.Method {
 		case http.MethodPatch:
-			var body map[string]any
-			if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&body); err != nil {
-				writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json"})
+			body, err := readJSONMapWithLimit(r, 1<<20)
+			if err != nil {
+				invalidJSONOrValidation(w, err)
 				return
 			}
 			label := cleanText(body["label"])

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/credentials.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/credentials.go
@@ -3,9 +3,7 @@ package main
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"errors"
-	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -151,7 +149,7 @@ func handleCredentialCreate(w http.ResponseWriter, r *http.Request, auth *authSe
 	}
 	payload, err := readCredentialJSONMap(w, r)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json"})
+		invalidJSONOrValidation(w, err)
 		return
 	}
 	ctx, cancel := requestTimeout(r.Context(), auth)
@@ -176,7 +174,7 @@ func handleCredentialUpdate(w http.ResponseWriter, r *http.Request, auth *authSe
 	}
 	payload, err := readCredentialJSONMap(w, r)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json"})
+		invalidJSONOrValidation(w, err)
 		return
 	}
 	ctx, cancel := requestTimeout(r.Context(), auth)
@@ -206,18 +204,7 @@ func handleCredentialDelete(w http.ResponseWriter, r *http.Request, auth *authSe
 }
 
 func readCredentialJSONMap(w http.ResponseWriter, r *http.Request) (map[string]any, error) {
-	var payload map[string]any
-	err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 2<<20)).Decode(&payload)
-	if errors.Is(err, io.EOF) {
-		return map[string]any{}, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-	if payload == nil {
-		payload = map[string]any{}
-	}
-	return payload, nil
+	return readJSONMapWithLimit(r, 2<<20)
 }
 
 func writeStoreMutationResponse(w http.ResponseWriter, payload map[string]any, status int, err error) {

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/device_filters.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/device_filters.go
@@ -185,9 +185,9 @@ func deviceFilterPreviewHandler(auth *authService) http.HandlerFunc {
 			failure.write(w)
 			return
 		}
-		var body map[string]any
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil && !errors.Is(err, http.ErrBodyReadAfterClose) {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json"})
+		body, err := readJSONMapWithLimit(r, publicJSONMapMaxBytes)
+		if err != nil {
+			invalidJSONOrValidation(w, err)
 			return
 		}
 		store, ok := auth.store.(deviceFilterStore)
@@ -233,7 +233,7 @@ func deviceFilterIDHandler(auth *authService) http.HandlerFunc {
 		case action == "" && r.Method == http.MethodPut:
 			body, err := readJSONMap(r)
 			if err != nil {
-				writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json"})
+				invalidJSONOrValidation(w, err)
 				return
 			}
 			payload, status, err := store.updateDeviceFilter(ctx, profile, filterID, body)
@@ -296,7 +296,7 @@ func handleDeviceFilterCreate(w http.ResponseWriter, r *http.Request, auth *auth
 	}
 	body, err := readJSONMap(r)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json"})
+		invalidJSONOrValidation(w, err)
 		return
 	}
 	store, ok := auth.store.(deviceFilterStore)
@@ -342,14 +342,7 @@ func parseDeviceFilterAction(path string) (int64, string, bool) {
 }
 
 func readJSONMap(r *http.Request) (map[string]any, error) {
-	var body map[string]any
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil && !errors.Is(err, http.ErrBodyReadAfterClose) {
-		return nil, err
-	}
-	if body == nil {
-		body = map[string]any{}
-	}
-	return body, nil
+	return readJSONMapWithLimit(r, publicJSONMapMaxBytes)
 }
 
 func writeFilterFoundResponse(w http.ResponseWriter, payload map[string]any, found bool, err error, key string) {

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/device_processes.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/device_processes.go
@@ -93,7 +93,7 @@ func deviceProcessTerminateHandler(auth *authService) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		body, err := readJSONMap(r)
 		if err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json", "message": "Request body must be valid JSON."})
+			invalidJSONOrValidation(w, err)
 			return
 		}
 		pid := coerceInt64(body["pid"])

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/device_security.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/device_security.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"errors"
 	"net/http"
 	"strings"
@@ -38,10 +37,12 @@ func deviceSecurityStatusHandler(auth *authService, runtime devicePurgeRuntime, 
 		}
 		reason := "operator_requested"
 		if r.Body != nil {
-			var body map[string]any
-			if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&body); err == nil {
-				reason = firstText(cleanText(body["reason"]), reason)
+			body, err := readJSONMap(r)
+			if err != nil {
+				invalidJSONOrValidation(w, err)
+				return
 			}
+			reason = firstText(cleanText(body["reason"]), reason)
 		}
 		ctx, cancel := requestTimeout(r.Context(), auth)
 		defer cancel()

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/device_services.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/device_services.go
@@ -102,7 +102,7 @@ func deviceServiceActionHandler(auth *authService) http.HandlerFunc {
 		}
 		body, err := readJSONMap(r)
 		if err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json", "message": "Request body must be valid JSON."})
+			invalidJSONOrValidation(w, err)
 			return
 		}
 		serviceName := firstText(cleanText(body["service_name"]), cleanText(body["name"]))

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/device_views.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/device_views.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
-	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -381,11 +380,17 @@ func parseDeviceViewID(path string) (int64, error) {
 func parseCreateDeviceViewMutation(r *http.Request) (deviceViewMutation, int, map[string]any) {
 	body, err := readDeviceViewBody(r)
 	if err != nil {
+		if errs, ok := asPublicValidationErrors(err); ok {
+			return deviceViewMutation{}, http.StatusBadRequest, map[string]any{"error": "validation_failed", "errors": errs}
+		}
 		return deviceViewMutation{}, http.StatusBadRequest, map[string]any{"error": "invalid json"}
 	}
 	name := strings.TrimSpace(cleanText(body["name"]))
 	if name == "" {
 		return deviceViewMutation{}, http.StatusBadRequest, map[string]any{"error": "name is required"}
+	}
+	if err := validateInputValue("name", name, inputClassPlainSingleLine); err != nil {
+		return deviceViewMutation{}, http.StatusBadRequest, map[string]any{"error": "validation_failed", "errors": []publicValidationError{{Field: "name", Message: err.Error()}}}
 	}
 	if strings.EqualFold(name, "default view") {
 		return deviceViewMutation{}, http.StatusBadRequest, map[string]any{"error": "reserved name"}
@@ -404,6 +409,9 @@ func parseCreateDeviceViewMutation(r *http.Request) (deviceViewMutation, int, ma
 func parseUpdateDeviceViewMutation(r *http.Request) (deviceViewMutation, int, map[string]any) {
 	body, err := readDeviceViewBody(r)
 	if err != nil {
+		if errs, ok := asPublicValidationErrors(err); ok {
+			return deviceViewMutation{}, http.StatusBadRequest, map[string]any{"error": "validation_failed", "errors": errs}
+		}
 		return deviceViewMutation{}, http.StatusBadRequest, map[string]any{"error": "invalid json"}
 	}
 	mutation := deviceViewMutation{}
@@ -411,6 +419,9 @@ func parseUpdateDeviceViewMutation(r *http.Request) (deviceViewMutation, int, ma
 		name := strings.TrimSpace(cleanText(value))
 		if name == "" {
 			return deviceViewMutation{}, http.StatusBadRequest, map[string]any{"error": "name cannot be empty"}
+		}
+		if err := validateInputValue("name", name, inputClassPlainSingleLine); err != nil {
+			return deviceViewMutation{}, http.StatusBadRequest, map[string]any{"error": "validation_failed", "errors": []publicValidationError{{Field: "name", Message: err.Error()}}}
 		}
 		if strings.EqualFold(name, "default view") {
 			return deviceViewMutation{}, http.StatusBadRequest, map[string]any{"error": "reserved name"}
@@ -441,17 +452,7 @@ func readDeviceViewBody(r *http.Request) (map[string]any, error) {
 		return map[string]any{}, nil
 	}
 	defer r.Body.Close()
-	var body map[string]any
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		if errors.Is(err, io.EOF) {
-			return map[string]any{}, nil
-		}
-		return nil, err
-	}
-	if body == nil {
-		body = map[string]any{}
-	}
-	return body, nil
+	return readJSONMapWithLimit(r, publicJSONMapMaxBytes)
 }
 
 func stringSliceFromAny(value any) ([]string, bool) {

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/devices.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/devices.go
@@ -418,9 +418,9 @@ func deviceDescriptionHandler(auth *authService) http.HandlerFunc {
 			writeJSON(w, http.StatusBadGateway, map[string]any{"error": "auth_unavailable", "detail": err.Error()})
 			return
 		}
-		var body map[string]any
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json"})
+		body, err := readJSONMap(r)
+		if err != nil {
+			invalidJSONOrValidation(w, err)
 			return
 		}
 		store, ok := auth.store.(deviceMutationStore)
@@ -445,9 +445,9 @@ func deviceAgentReleaseChannelHandler(auth *authService) http.HandlerFunc {
 			failure.write(w)
 			return
 		}
-		var body map[string]any
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json"})
+		body, err := readJSONMap(r)
+		if err != nil {
+			invalidJSONOrValidation(w, err)
 			return
 		}
 		store, ok := auth.store.(deviceMutationStore)

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/input_validation.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/input_validation.go
@@ -1,0 +1,589 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"regexp"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+const (
+	publicJSONMapMaxBytes     int64 = 1 << 20
+	publicAuthJSONMaxBytes    int64 = 64 << 10
+	publicBackupJSONMaxBytes  int64 = 128 << 20
+	maxInputPathTextLength          = 4096
+	maxInputPlainTextLength         = 4096
+	maxInputIdentifierLength        = 256
+	maxNotificationTextLength       = 4096
+)
+
+var (
+	errRequestBodyTooLarge = errors.New("request body too large")
+	inputIdentifierRE      = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._:@/\-]*$`)
+	inputSlugRE            = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$`)
+	hostLabelRE            = regexp.MustCompile(`^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$`)
+	portRE                 = regexp.MustCompile(`^\d{1,5}$`)
+	unsafeMarkupRE         = regexp.MustCompile(`(?i)<\s*/?\s*(script|iframe|object|embed|img|svg|math|link|style|meta|base|form|input|button|textarea|select|option|video|audio|source|body|html)\b|on[a-z]+\s*=|javascript\s*:`)
+)
+
+type publicValidationError struct {
+	Field   string `json:"field"`
+	Message string `json:"message"`
+}
+
+type inputFieldClass string
+
+const (
+	inputClassPlainSingleLine inputFieldClass = "plain_single_line"
+	inputClassPlainMultiline  inputFieldClass = "plain_multiline"
+	inputClassIdentifier      inputFieldClass = "identifier"
+	inputClassSlug            inputFieldClass = "slug"
+	inputClassHost            inputFieldClass = "host"
+	inputClassURL             inputFieldClass = "url"
+	inputClassPath            inputFieldClass = "path"
+	inputClassRegistry        inputFieldClass = "registry"
+	inputClassRegex           inputFieldClass = "regex"
+	inputClassSecret          inputFieldClass = "secret"
+	inputClassCode            inputFieldClass = "code"
+)
+
+func withPublicInputValidation(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !publicInputValidationApplies(r) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		if errs := validatePublicRequestTarget(r); len(errs) > 0 {
+			writePublicValidationErrors(w, errs)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func publicInputValidationApplies(r *http.Request) bool {
+	if r == nil || r.URL == nil {
+		return false
+	}
+	path := r.URL.Path
+	if !strings.HasPrefix(path, "/api/") {
+		return false
+	}
+	if strings.HasPrefix(path, "/api/internal/") {
+		return false
+	}
+	return path != "/api/server/k3s/operator"
+}
+
+func validatePublicRequestTarget(r *http.Request) []publicValidationError {
+	errs := make([]publicValidationError, 0)
+	if err := validateInputUTF8AndControls("path", r.URL.Path, maxInputPathTextLength, false); err != nil {
+		errs = append(errs, publicValidationError{Field: "path", Message: err.Error()})
+	} else if err := validateNoUnsafeMarkup("path", r.URL.Path); err != nil {
+		errs = append(errs, publicValidationError{Field: "path", Message: err.Error()})
+	}
+	for key, values := range r.URL.Query() {
+		field := "query." + key
+		if err := validateInputUTF8AndControls(field, key, maxInputIdentifierLength, false); err != nil {
+			errs = append(errs, publicValidationError{Field: field, Message: err.Error()})
+			continue
+		}
+		class := classifyInputField(key)
+		for _, value := range values {
+			if err := validateInputValue(field, value, class); err != nil {
+				errs = append(errs, publicValidationError{Field: field, Message: err.Error()})
+			}
+		}
+	}
+	return errs
+}
+
+func readJSONMapWithLimit(r *http.Request, limit int64) (map[string]any, error) {
+	raw, err := readLimitedRequestBody(r, limit)
+	if err != nil {
+		return nil, err
+	}
+	if len(strings.TrimSpace(string(raw))) == 0 {
+		return map[string]any{}, nil
+	}
+	var body map[string]any
+	if err := json.Unmarshal(raw, &body); err != nil {
+		return nil, err
+	}
+	if body == nil {
+		body = map[string]any{}
+	}
+	if errs := sanitizeJSONInputMap(body); len(errs) > 0 {
+		return nil, publicValidationErrors(errs)
+	}
+	return body, nil
+}
+
+func readLimitedRequestBody(r *http.Request, limit int64) ([]byte, error) {
+	if r == nil || r.Body == nil {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = publicJSONMapMaxBytes
+	}
+	raw, err := io.ReadAll(io.LimitReader(r.Body, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(raw)) > limit {
+		return nil, errRequestBodyTooLarge
+	}
+	return raw, nil
+}
+
+func sanitizeJSONInputMap(body map[string]any) []publicValidationError {
+	return sanitizeJSONInputValue("", body, inputClassPlainSingleLine)
+}
+
+func validateJSONTransportMap(body map[string]any) []publicValidationError {
+	return validateJSONTransportValue("", body)
+}
+
+func validateJSONTransportValue(path string, value any) []publicValidationError {
+	errs := make([]publicValidationError, 0)
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, child := range typed {
+			fieldPath := key
+			if path != "" {
+				fieldPath = path + "." + key
+			}
+			errs = append(errs, validateJSONTransportValue(fieldPath, child)...)
+		}
+	case []any:
+		for index, child := range typed {
+			fieldPath := fmt.Sprintf("%s[%d]", path, index)
+			errs = append(errs, validateJSONTransportValue(fieldPath, child)...)
+		}
+	case string:
+		if err := validateInputUTF8AndControls(firstText(path, "body"), typed, 16<<20, true); err != nil {
+			errs = append(errs, publicValidationError{Field: firstText(path, "body"), Message: err.Error()})
+		}
+	}
+	return errs
+}
+
+func sanitizeJSONInputValue(path string, value any, parentClass inputFieldClass) []publicValidationError {
+	errs := make([]publicValidationError, 0)
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, child := range typed {
+			fieldPath := key
+			if path != "" {
+				fieldPath = path + "." + key
+			}
+			class := classifyInputField(key)
+			if text, ok := child.(string); ok {
+				sanitized, _ := sanitizeInputValueByClass(text, class)
+				if err := validateInputValue(fieldPath, sanitized, class); err != nil {
+					errs = append(errs, publicValidationError{Field: firstText(fieldPath, "body"), Message: err.Error()})
+					continue
+				}
+				typed[key] = sanitized
+				continue
+			}
+			childErrs := sanitizeJSONInputValue(fieldPath, child, class)
+			if len(childErrs) > 0 {
+				errs = append(errs, childErrs...)
+			}
+		}
+	case []any:
+		for index, child := range typed {
+			fieldPath := fmt.Sprintf("%s[%d]", path, index)
+			if text, ok := child.(string); ok {
+				sanitized, _ := sanitizeInputValueByClass(text, parentClass)
+				if err := validateInputValue(fieldPath, sanitized, parentClass); err != nil {
+					errs = append(errs, publicValidationError{Field: firstText(fieldPath, "body"), Message: err.Error()})
+					continue
+				}
+				typed[index] = sanitized
+				continue
+			}
+			childErrs := sanitizeJSONInputValue(fieldPath, child, parentClass)
+			if len(childErrs) > 0 {
+				errs = append(errs, childErrs...)
+			}
+		}
+	case string:
+		sanitized, _ := sanitizeInputValueByClass(typed, parentClass)
+		if err := validateInputValue(path, sanitized, parentClass); err != nil {
+			errs = append(errs, publicValidationError{Field: firstText(path, "body"), Message: err.Error()})
+		}
+	}
+	return errs
+}
+
+func sanitizeInputValueByClass(value string, class inputFieldClass) (string, bool) {
+	switch class {
+	case inputClassPlainSingleLine, inputClassIdentifier, inputClassSlug, inputClassHost, inputClassURL:
+		sanitized := sanitizeSingleLineInput(value)
+		return sanitized, sanitized != value
+	case inputClassPlainMultiline:
+		sanitized := sanitizeMultilineInput(value)
+		return sanitized, sanitized != value
+	default:
+		return value, false
+	}
+}
+
+func validateInputValue(field string, value string, class inputFieldClass) error {
+	switch class {
+	case inputClassSecret, inputClassCode:
+		return validateInputUTF8AndControls(field, value, 16<<20, true)
+	case inputClassPath:
+		return validatePathInput(field, value)
+	case inputClassRegistry:
+		return validateRegistryInput(field, value)
+	case inputClassRegex:
+		return validateRegexInput(field, value)
+	case inputClassURL:
+		return validateURLInput(field, value)
+	case inputClassHost:
+		return validateHostInput(field, value)
+	case inputClassSlug:
+		return validateSlugInput(field, value)
+	case inputClassIdentifier:
+		return validateIdentifierInput(field, value)
+	case inputClassPlainMultiline:
+		if err := validateInputUTF8AndControls(field, value, maxInputPlainTextLength, true); err != nil {
+			return err
+		}
+		return validateNoUnsafeMarkup(field, value)
+	default:
+		if err := validateInputUTF8AndControls(field, value, maxInputPlainTextLength, false); err != nil {
+			return err
+		}
+		return validateNoUnsafeMarkup(field, value)
+	}
+}
+
+func validateInputUTF8AndControls(field string, value string, maxLen int, allowNewlines bool) error {
+	if !utf8.ValidString(value) {
+		return fmt.Errorf("%s must be valid UTF-8", field)
+	}
+	if maxLen > 0 && len(value) > maxLen {
+		return fmt.Errorf("%s exceeds %d bytes", field, maxLen)
+	}
+	for _, r := range value {
+		if r == 0 || r == '\u007f' {
+			return fmt.Errorf("%s cannot include control characters", field)
+		}
+		if unicode.IsControl(r) {
+			if allowNewlines && (r == '\n' || r == '\r' || r == '\t') {
+				continue
+			}
+			return fmt.Errorf("%s cannot include control characters", field)
+		}
+	}
+	return nil
+}
+
+func validateNoUnsafeMarkup(field string, value string) error {
+	if unsafeMarkupRE.MatchString(value) {
+		return fmt.Errorf("%s cannot include executable markup", field)
+	}
+	return nil
+}
+
+func validateIdentifierInput(field string, value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	if err := validateInputUTF8AndControls(field, value, maxInputIdentifierLength, false); err != nil {
+		return err
+	}
+	if strings.ContainsAny(value, "<>\\") || !inputIdentifierRE.MatchString(value) {
+		return fmt.Errorf("%s must be an identifier, enum, or safe ref", field)
+	}
+	return nil
+}
+
+func validateSlugInput(field string, value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	if err := validateInputUTF8AndControls(field, value, 63, false); err != nil {
+		return err
+	}
+	if !inputSlugRE.MatchString(value) {
+		return fmt.Errorf("%s must be a lowercase slug", field)
+	}
+	return nil
+}
+
+func validateHostInput(field string, value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	if err := validateInputUTF8AndControls(field, value, 253, false); err != nil {
+		return err
+	}
+	if strings.ContainsAny(value, "<>\"'`\\ ") {
+		return fmt.Errorf("%s must be a hostname, IP address, or CIDR", field)
+	}
+	if _, err := netip.ParseAddr(value); err == nil {
+		return nil
+	}
+	if _, err := netip.ParsePrefix(value); err == nil {
+		return nil
+	}
+	if strings.ContainsAny(value, "/:") {
+		return fmt.Errorf("%s must be a hostname, IP address, or CIDR", field)
+	}
+	for _, label := range strings.Split(value, ".") {
+		if !hostLabelRE.MatchString(label) {
+			return fmt.Errorf("%s must be a valid hostname", field)
+		}
+	}
+	return nil
+}
+
+func validateURLInput(field string, value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	if err := validateInputUTF8AndControls(field, value, 4096, false); err != nil {
+		return err
+	}
+	parsed, err := url.Parse(value)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return fmt.Errorf("%s must be an absolute URL", field)
+	}
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme != "http" && scheme != "https" && scheme != "ldap" && scheme != "ldaps" {
+		return fmt.Errorf("%s uses an unsupported URL scheme", field)
+	}
+	if strings.ContainsAny(parsed.Host, "<>\"'` ") {
+		return fmt.Errorf("%s has an invalid host", field)
+	}
+	return nil
+}
+
+func validatePathInput(field string, value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	if err := validateInputUTF8AndControls(field, value, maxInputPathTextLength, false); err != nil {
+		return err
+	}
+	if strings.Contains(value, "\x00") {
+		return fmt.Errorf("%s cannot include NUL bytes", field)
+	}
+	return nil
+}
+
+func validateRemoteFileName(field string, value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	if err := validateInputUTF8AndControls(field, value, 255, false); err != nil {
+		return err
+	}
+	if value == "." || value == ".." || strings.Contains(value, "/") || strings.Contains(value, "\\") {
+		return fmt.Errorf("%s cannot include path separators or traversal segments", field)
+	}
+	if strings.ContainsAny(value, `<>:"|?*`) {
+		return fmt.Errorf("%s contains characters Windows file systems do not allow", field)
+	}
+	if strings.HasSuffix(value, ".") || strings.HasSuffix(value, " ") {
+		return fmt.Errorf("%s cannot end with a space or period", field)
+	}
+	return nil
+}
+
+func validateRegistryInput(field string, value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	if err := validateInputUTF8AndControls(field, value, maxInputPathTextLength, false); err != nil {
+		return err
+	}
+	if strings.Contains(value, "/") || strings.ContainsAny(value, "<>\"|?*") {
+		return fmt.Errorf("%s must be a Windows registry path or value name", field)
+	}
+	return nil
+}
+
+func validateRegexInput(field string, value string) error {
+	if value == "" {
+		return nil
+	}
+	if err := validateInputUTF8AndControls(field, value, maxInputPlainTextLength, true); err != nil {
+		return err
+	}
+	if _, err := regexp.Compile(value); err != nil {
+		return fmt.Errorf("%s must be a valid regular expression", field)
+	}
+	return nil
+}
+
+func sanitizeSingleLineInput(value string) string {
+	value = strings.Map(func(r rune) rune {
+		if r == 0 || unicode.IsControl(r) {
+			return ' '
+		}
+		return r
+	}, value)
+	return strings.Join(strings.Fields(value), " ")
+}
+
+func sanitizeMultilineInput(value string) string {
+	value = strings.ReplaceAll(value, "\r\n", "\n")
+	value = strings.ReplaceAll(value, "\r", "\n")
+	value = strings.Map(func(r rune) rune {
+		if r == 0 {
+			return -1
+		}
+		if unicode.IsControl(r) && r != '\n' && r != '\t' {
+			return ' '
+		}
+		return r
+	}, value)
+	return strings.TrimSpace(value)
+}
+
+func sanitizeNotificationText(value string) string {
+	value = sanitizeMultilineInput(value)
+	if value == "" {
+		return ""
+	}
+	value = strings.ReplaceAll(value, "<B>", "<b>")
+	value = strings.ReplaceAll(value, "</B>", "</b>")
+	value = strings.ReplaceAll(value, "<b>", "\x00BOLD_OPEN\x00")
+	value = strings.ReplaceAll(value, "</b>", "\x00BOLD_CLOSE\x00")
+	value = strings.ReplaceAll(value, "<", "")
+	value = strings.ReplaceAll(value, ">", "")
+	value = strings.ReplaceAll(value, "\x00BOLD_OPEN\x00", "<b>")
+	value = strings.ReplaceAll(value, "\x00BOLD_CLOSE\x00", "</b>")
+	if len(value) > maxNotificationTextLength {
+		value = value[:maxNotificationTextLength]
+	}
+	return value
+}
+
+func classifyInputField(field string) inputFieldClass {
+	key := strings.ToLower(strings.TrimSpace(field))
+	key = strings.Trim(key, "[]")
+	switch {
+	case strings.Contains(key, "password"), strings.Contains(key, "cipher"), strings.Contains(key, "secret"),
+		strings.Contains(key, "token"), strings.Contains(key, "pem"), strings.Contains(key, "private_key"),
+		strings.Contains(key, "backup"):
+		return inputClassSecret
+	case strings.Contains(key, "script"), strings.Contains(key, "code"), strings.Contains(key, "content"),
+		strings.Contains(key, "stdout"), strings.Contains(key, "stderr"), strings.Contains(key, "command"),
+		strings.Contains(key, "argument"), strings.Contains(key, "json"), strings.Contains(key, "payload"),
+		key == "data" || key == "value_data":
+		return inputClassCode
+	case strings.Contains(key, "regex"):
+		return inputClassRegex
+	case strings.Contains(key, "registry"):
+		return inputClassRegistry
+	case key == "path" || strings.HasSuffix(key, "_path") || strings.Contains(key, "directory") || strings.Contains(key, "folder"):
+		return inputClassPath
+	case strings.Contains(key, "url") || strings.Contains(key, "uri") || strings.Contains(key, "endpoint"):
+		return inputClassURL
+	case key == "hostname" || strings.Contains(key, "host_name") || strings.HasSuffix(key, "_host") || strings.Contains(key, "cidr") || strings.Contains(key, "ip_address"):
+		return inputClassHost
+	case strings.Contains(key, "slug"):
+		return inputClassSlug
+	case key == "id" || strings.HasSuffix(key, "_id") || strings.Contains(key, "guid") || strings.Contains(key, "uuid") ||
+		key == "role" || key == "action" || strings.HasSuffix(key, "_action") || key == "platform" ||
+		key == "artifact" || key == "branch" || key == "service_mode":
+		return inputClassIdentifier
+	case strings.Contains(key, "description") || strings.Contains(key, "notes") || strings.Contains(key, "message") || strings.Contains(key, "comment"):
+		return inputClassPlainMultiline
+	default:
+		return inputClassPlainSingleLine
+	}
+}
+
+type publicValidationErrors []publicValidationError
+
+func (e publicValidationErrors) Error() string {
+	return "validation_failed"
+}
+
+func asPublicValidationErrors(err error) ([]publicValidationError, bool) {
+	var errs publicValidationErrors
+	if errors.As(err, &errs) {
+		return []publicValidationError(errs), true
+	}
+	return nil, false
+}
+
+func writePublicValidationErrors(w http.ResponseWriter, errs []publicValidationError) {
+	if len(errs) == 0 {
+		errs = []publicValidationError{{Field: "body", Message: "Request input is invalid."}}
+	}
+	writeJSON(w, http.StatusBadRequest, map[string]any{
+		"error":  "validation_failed",
+		"errors": errs,
+	})
+}
+
+func publicValidationErrorPayload(err error, fallbackError string) map[string]any {
+	if errors.Is(err, errRequestBodyTooLarge) {
+		return map[string]any{"error": "request_body_too_large"}
+	}
+	if errs, ok := asPublicValidationErrors(err); ok {
+		if len(errs) == 0 {
+			errs = []publicValidationError{{Field: "body", Message: "Request input is invalid."}}
+		}
+		return map[string]any{"error": "validation_failed", "errors": errs}
+	}
+	return map[string]any{"error": firstText(fallbackError, "invalid_json")}
+}
+
+func invalidJSONOrValidation(w http.ResponseWriter, err error) {
+	if errors.Is(err, errRequestBodyTooLarge) {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "request_body_too_large"})
+		return
+	}
+	if errs, ok := asPublicValidationErrors(err); ok {
+		writePublicValidationErrors(w, errs)
+		return
+	}
+	writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json"})
+}
+
+func requestHasJSONBody(r *http.Request) bool {
+	if r == nil || r.Body == nil {
+		return false
+	}
+	mediaType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return strings.Contains(strings.ToLower(r.Header.Get("Content-Type")), "json")
+	}
+	return mediaType == "application/json" || strings.HasSuffix(mediaType, "+json")
+}
+
+func validHostPort(host string, port string) bool {
+	if strings.TrimSpace(host) == "" {
+		return false
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return true
+	}
+	return validateHostInput("host", host) == nil && (port == "" || portRE.MatchString(port))
+}

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/input_validation_test.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/input_validation_test.go
@@ -78,6 +78,31 @@ func TestReadJSONMapWithLimitRejectsInvalidRegex(t *testing.T) {
 	}
 }
 
+func TestPasskeyVerifyPayloadUsesTransportValidation(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/passkeys/authenticate/verify", strings.NewReader(`{
+		"request_id":"pending.token.value",
+		"credential":{
+			"id":"abc+/=",
+			"rawId":"abc+/=",
+			"type":"public-key",
+			"response":{
+				"clientDataJSON":"abc+/=",
+				"authenticatorData":"abc+/=",
+				"signature":"abc+/="
+			}
+		}
+	}`))
+	rec := httptest.NewRecorder()
+	_, body, ok := readPasskeyJSONRaw(rec, req)
+	if !ok {
+		t.Fatalf("expected passkey payload to pass transport validation, status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	credential, ok := body["credential"].(map[string]any)
+	if !ok || credential["id"] != "abc+/=" {
+		t.Fatalf("expected opaque credential id preserved, got %#v", body["credential"])
+	}
+}
+
 func TestHostValidationRejectsSlashHostname(t *testing.T) {
 	if err := validateHostInput("hostname", "borealis/evil"); err == nil {
 		t.Fatal("expected slash hostname to fail")

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/input_validation_test.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/input_validation_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestPublicInputValidationRejectsUnsafeQuery(t *testing.T) {
+	handler := withPublicInputValidation(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/api/devices/search?hostname=%3Cscript%3Ealert(1)%3C%2Fscript%3E", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "validation_failed") {
+		t.Fatalf("expected validation payload, got %s", rec.Body.String())
+	}
+}
+
+func TestPublicInputValidationSkipsInternalRoutes(t *testing.T) {
+	handler := withPublicInputValidation(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/api/internal/job-scheduler/test?hostname=%3Cscript%3E", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected internal route bypass, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestPublicInputValidationRejectsUnsafePath(t *testing.T) {
+	handler := withPublicInputValidation(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/api/devices/%3Cscript%3E", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected unsafe path to fail, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestReadJSONMapWithLimitSanitizesPlainText(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/test", strings.NewReader("{\"name\":\"  Alpha\\nBeta  \",\"content\":\"if (1 < 2) {\\n  echo ok\\n}\"}"))
+	body, err := readJSONMapWithLimit(req, 1<<20)
+	if err != nil {
+		t.Fatalf("expected payload, got %v", err)
+	}
+	if got := cleanText(body["name"]); got != "Alpha Beta" {
+		t.Fatalf("expected single-line name sanitation, got %q", got)
+	}
+	if got := body["content"].(string); !strings.Contains(got, "1 < 2") || !strings.Contains(got, "\n") {
+		t.Fatalf("expected code content preserved, got %q", got)
+	}
+}
+
+func TestReadJSONMapWithLimitRejectsInvalidRegex(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/test", strings.NewReader(`{"regex":"["}`))
+	_, err := readJSONMapWithLimit(req, 1<<20)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	errs, ok := asPublicValidationErrors(err)
+	if !ok || len(errs) == 0 || errs[0].Field != "regex" {
+		t.Fatalf("expected regex validation errors, got %#v ok=%v", errs, ok)
+	}
+}
+
+func TestHostValidationRejectsSlashHostname(t *testing.T) {
+	if err := validateHostInput("hostname", "borealis/evil"); err == nil {
+		t.Fatal("expected slash hostname to fail")
+	}
+	if err := validateHostInput("hostname", "fd00::1/64"); err != nil {
+		t.Fatalf("expected IPv6 CIDR to pass, got %v", err)
+	}
+}
+
+func TestSanitizeNotificationTextPreservesOnlyBoldMarkup(t *testing.T) {
+	got := sanitizeNotificationText("Hello <b>World</b> <script>alert(1)</script>")
+	if !strings.Contains(got, "<b>World</b>") {
+		t.Fatalf("expected bold markup preserved, got %q", got)
+	}
+	if strings.Contains(strings.ToLower(got), "<script") {
+		t.Fatalf("expected script tag removed, got %q", got)
+	}
+}

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/main.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/main.go
@@ -166,7 +166,7 @@ func main() {
 
 	server := &http.Server{
 		Addr:              net.JoinHostPort(cfg.ListenHost, cfg.ListenPort),
-		Handler:           withRequestHeaders(mux),
+		Handler:           withRequestHeaders(withPublicInputValidation(mux)),
 		ReadHeaderTimeout: 15 * time.Second,
 	}
 

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/metadata_fields.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/metadata_fields.go
@@ -149,9 +149,10 @@ func metadataFieldDefinitionHandler(auth *authService) http.HandlerFunc {
 			return
 		}
 
-		var body map[string]any
-		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&body); err != nil {
-			body = map[string]any{}
+		body, err := readJSONMap(r)
+		if err != nil {
+			invalidJSONOrValidation(w, err)
+			return
 		}
 		description := cleanText(body["description"])
 
@@ -295,9 +296,10 @@ func deviceMetadataFieldsHandler(auth *authService) http.HandlerFunc {
 		if r.Method == http.MethodGet && !parsed.hasField {
 			payload, status, err = store.deviceMetadataFields(ctx, profile, parsed.deviceID)
 		} else if r.Method == http.MethodPut && parsed.hasField {
-			var body map[string]any
-			if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&body); err != nil {
-				body = map[string]any{}
+			body, err := readJSONMap(r)
+			if err != nil {
+				invalidJSONOrValidation(w, err)
+				return
 			}
 			payload, status, err = store.updateDeviceMetadataField(ctx, profile, parsed.deviceID, parsed.fieldNumber, normalizeMetadataValue(cleanText(body["value"])))
 		} else {

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/notifications.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/notifications.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -29,15 +28,13 @@ func notificationNotifyHandler(auth *authService, broadcaster notificationBroadc
 			return
 		}
 
-		var body map[string]any
-		if r.Body != nil {
-			_ = json.NewDecoder(http.MaxBytesReader(w, r.Body, 64<<10)).Decode(&body)
-		}
-		if body == nil {
-			body = map[string]any{}
+		body, err := readJSONMapWithLimit(r, 64<<10)
+		if err != nil {
+			invalidJSONOrValidation(w, err)
+			return
 		}
 
-		message := cleanText(body["message"])
+		message := sanitizeNotificationText(cleanText(body["message"]))
 		if message == "" {
 			writeJSON(w, http.StatusBadRequest, map[string]any{
 				"error":   "invalid_payload",
@@ -61,9 +58,9 @@ func notificationNotifyHandler(auth *authService, broadcaster notificationBroadc
 
 		payload := map[string]any{
 			"id":         fmt.Sprintf("notif-%d-%d", now.Unix(), now.UnixMilli()%1000),
-			"title":      firstText(cleanText(body["title"]), "Notification"),
+			"title":      firstText(sanitizeSingleLineInput(cleanText(body["title"])), "Notification"),
 			"message":    message,
-			"icon":       firstText(cleanText(body["icon"]), "NotificationsActive"),
+			"icon":       firstText(sanitizeSingleLineInput(cleanText(body["icon"])), "NotificationsActive"),
 			"variant":    variant,
 			"username":   user.Username,
 			"role":       firstText(user.Role, "User"),

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/patch_policies.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/patch_policies.go
@@ -283,7 +283,7 @@ func patchPolicySave(w http.ResponseWriter, r *http.Request, auth *authService, 
 	}
 	body, err := readJSONMap(r)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json", "message": "Request body must be valid JSON."})
+		invalidJSONOrValidation(w, err)
 		return
 	}
 	ctx, cancel := requestTimeout(r.Context(), auth)
@@ -322,6 +322,10 @@ func patchPolicyPreview(w http.ResponseWriter, r *http.Request, auth *authServic
 	}
 	body, err := readJSONMap(r)
 	if err != nil {
+		if errs, ok := asPublicValidationErrors(err); ok {
+			writePublicValidationErrors(w, errs)
+			return
+		}
 		body = map[string]any{}
 	}
 	ctx, cancel := requestTimeout(r.Context(), auth)
@@ -361,6 +365,10 @@ func patchPolicyEvaluate(w http.ResponseWriter, r *http.Request, auth *authServi
 	}
 	body, err := readJSONMap(r)
 	if err != nil {
+		if errs, ok := asPublicValidationErrors(err); ok {
+			writePublicValidationErrors(w, errs)
+			return
+		}
 		body = map[string]any{}
 	}
 	ctx, cancel := patchPolicyEvaluateContext(r.Context(), auth)

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/patch_progress.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/patch_progress.go
@@ -38,7 +38,7 @@ func agentPatchInstallProgressHandler(auth *authService, signer *agentJWTSigner,
 		}
 		body, err := readJSONMap(r)
 		if err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json"})
+			invalidJSONOrValidation(w, err)
 			return
 		}
 		timeout := auth.timeout

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/patches.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/patches.go
@@ -217,7 +217,7 @@ func devicePatchInstallHandler(auth *authService) http.HandlerFunc {
 		}
 		body, err := readJSONMap(r)
 		if err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json", "message": "Request body must be valid JSON."})
+			invalidJSONOrValidation(w, err)
 			return
 		}
 		request := patchInstallLookupFromBody(body)
@@ -268,7 +268,7 @@ func fleetPatchInstallHandler(auth *authService) http.HandlerFunc {
 		}
 		body, err := readJSONMap(r)
 		if err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json", "message": "Request body must be valid JSON."})
+			invalidJSONOrValidation(w, err)
 			return
 		}
 		request := patchInstallLookupFromBody(body)

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/quick_run.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/quick_run.go
@@ -52,7 +52,7 @@ func quickRunHandler(auth *authService, realtime *operatorRealtimeHub) http.Hand
 		}
 		body, err := readJSONMap(r)
 		if err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json", "message": "Request body must be valid JSON."})
+			invalidJSONOrValidation(w, err)
 			return
 		}
 		hostnames := quickRunNormalizeHostnames(body["hostnames"])

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/remote_files.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/remote_files.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -193,6 +194,10 @@ func remoteFileChildrenHandler(auth *authService) func(http.ResponseWriter, *htt
 			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "path_required"})
 			return
 		}
+		if err := validatePathInput("path", requestedPath); err != nil {
+			writePublicValidationErrors(w, []publicValidationError{{Field: "path", Message: err.Error()}})
+			return
+		}
 		snapshot, operatorID, ok := requireRemoteFileContext(w, r, auth, hostname)
 		if !ok {
 			return
@@ -218,15 +223,23 @@ func remoteFileChildrenHandler(auth *authService) func(http.ResponseWriter, *htt
 
 func remoteFileUploadConflictsHandler(auth *authService) func(http.ResponseWriter, *http.Request, string) {
 	return func(w http.ResponseWriter, r *http.Request, hostname string) {
-		var body map[string]any
-		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 2<<20)).Decode(&body); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json"})
+		body, err := readJSONMapWithLimit(r, 2<<20)
+		if err != nil {
+			invalidJSONOrValidation(w, err)
 			return
 		}
 		targetPath := cleanText(body["target_path"])
 		items := normalizeUploadManifestItems(body["items"])
 		if targetPath == "" || len(items) == 0 {
 			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "target_path_and_items_required"})
+			return
+		}
+		if err := validatePathInput("target_path", targetPath); err != nil {
+			writePublicValidationErrors(w, []publicValidationError{{Field: "target_path", Message: err.Error()}})
+			return
+		}
+		if errs := validateRemoteUploadManifestItems(items); len(errs) > 0 {
+			writePublicValidationErrors(w, errs)
 			return
 		}
 		snapshot, operatorID, ok := requireRemoteFileContext(w, r, auth, hostname)
@@ -276,6 +289,10 @@ func remoteFileUploadHandler(auth *authService) func(http.ResponseWriter, *http.
 			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "target_path_required"})
 			return
 		}
+		if err := validatePathInput("target_path", targetPath); err != nil {
+			writePublicValidationErrors(w, []publicValidationError{{Field: "target_path", Message: err.Error()}})
+			return
+		}
 		files := remoteFileUploadFiles(r)
 		manifestItems := uploadManifestFromMultipartForm(r.FormValue("manifest"), files)
 		if len(manifestItems) == 0 {
@@ -289,6 +306,10 @@ func remoteFileUploadHandler(auth *authService) func(http.ResponseWriter, *http.
 		}
 		if len(files) > 0 && len(manifestItems) != len(files) {
 			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "upload_manifest_mismatch"})
+			return
+		}
+		if errs := validateRemoteUploadManifestItems(manifestItems); len(errs) > 0 {
+			writePublicValidationErrors(w, errs)
 			return
 		}
 		deviceGUID := remoteFileTransferDeviceGUID(snapshot)
@@ -457,6 +478,10 @@ func remoteFileReadTextHandler(auth *authService) func(http.ResponseWriter, *htt
 			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "path_required"})
 			return
 		}
+		if err := validatePathInput("path", requestedPath); err != nil {
+			writePublicValidationErrors(w, []publicValidationError{{Field: "path", Message: err.Error()}})
+			return
+		}
 		snapshot, operatorID, ok := requireRemoteFileContext(w, r, auth, hostname)
 		if !ok {
 			return
@@ -488,14 +513,18 @@ func remoteFileReadTextHandler(auth *authService) func(http.ResponseWriter, *htt
 
 func remoteFileWriteTextHandler(auth *authService) func(http.ResponseWriter, *http.Request, string) {
 	return func(w http.ResponseWriter, r *http.Request, hostname string) {
-		var body map[string]any
-		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4<<20)).Decode(&body); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json"})
+		body, err := readJSONMapWithLimit(r, 4<<20)
+		if err != nil {
+			invalidJSONOrValidation(w, err)
 			return
 		}
 		itemPath := cleanText(body["path"])
 		if itemPath == "" {
 			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "path_required"})
+			return
+		}
+		if err := validatePathInput("path", itemPath); err != nil {
+			writePublicValidationErrors(w, []publicValidationError{{Field: "path", Message: err.Error()}})
 			return
 		}
 		snapshot, operatorID, ok := requireRemoteFileContext(w, r, auth, hostname)
@@ -540,6 +569,14 @@ func remoteFileMkdirHandler(auth *authService) func(http.ResponseWriter, *http.R
 			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "path_and_name_required"})
 			return
 		}
+		if err := validatePathInput("path", parentPath); err != nil {
+			writePublicValidationErrors(w, []publicValidationError{{Field: "path", Message: err.Error()}})
+			return
+		}
+		if err := validateRemoteFileName("name", name); err != nil {
+			writePublicValidationErrors(w, []publicValidationError{{Field: "name", Message: err.Error()}})
+			return
+		}
 		remoteFileMutation(w, r, auth, hostname, "mkdir", map[string]any{"path": parentPath, "name": name}, remoteFileDefaultTimeoutSeconds, "entry")
 	}
 }
@@ -554,6 +591,14 @@ func remoteFileRenameHandler(auth *authService) func(http.ResponseWriter, *http.
 		newName := cleanText(body["new_name"])
 		if itemPath == "" || newName == "" {
 			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "path_and_new_name_required"})
+			return
+		}
+		if err := validatePathInput("path", itemPath); err != nil {
+			writePublicValidationErrors(w, []publicValidationError{{Field: "path", Message: err.Error()}})
+			return
+		}
+		if err := validateRemoteFileName("new_name", newName); err != nil {
+			writePublicValidationErrors(w, []publicValidationError{{Field: "new_name", Message: err.Error()}})
 			return
 		}
 		remoteFileMutation(w, r, auth, hostname, "rename", map[string]any{"path": itemPath, "new_name": newName}, remoteFileDefaultTimeoutSeconds, "entry")
@@ -572,6 +617,14 @@ func remoteFileMoveHandler(auth *authService) func(http.ResponseWriter, *http.Re
 			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "paths_and_destination_required"})
 			return
 		}
+		if err := validatePathInput("destination_path", destinationPath); err != nil {
+			writePublicValidationErrors(w, []publicValidationError{{Field: "destination_path", Message: err.Error()}})
+			return
+		}
+		if errs := validateRemoteFileSelections(selections); len(errs) > 0 {
+			writePublicValidationErrors(w, errs)
+			return
+		}
 		remoteFileMutation(w, r, auth, hostname, "move", map[string]any{"paths": selections, "destination_path": destinationPath}, 120.0, "moved")
 	}
 }
@@ -585,6 +638,10 @@ func remoteFileDeleteHandler(auth *authService) func(http.ResponseWriter, *http.
 		selections := normalizeTransferEntries(firstNonEmpty(body["paths"], body["items"], body["path"]))
 		if len(selections) == 0 {
 			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "paths_required"})
+			return
+		}
+		if errs := validateRemoteFileSelections(selections); len(errs) > 0 {
+			writePublicValidationErrors(w, errs)
 			return
 		}
 		remoteFileMutation(w, r, auth, hostname, "delete", map[string]any{"paths": selections}, 120.0, "deleted")
@@ -606,6 +663,14 @@ func remoteFilePasteHandler(auth *authService) func(http.ResponseWriter, *http.R
 		}
 		if destinationPath == "" || len(selections) == 0 {
 			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "paths_and_destination_required"})
+			return
+		}
+		if err := validatePathInput("destination_path", destinationPath); err != nil {
+			writePublicValidationErrors(w, []publicValidationError{{Field: "destination_path", Message: err.Error()}})
+			return
+		}
+		if errs := validateRemoteFileSelections(selections); len(errs) > 0 {
+			writePublicValidationErrors(w, errs)
 			return
 		}
 		remoteFileMutation(w, r, auth, hostname, "paste", map[string]any{"operation": operation, "paths": selections, "destination_path": destinationPath}, 300.0, "pasted")
@@ -728,15 +793,43 @@ func remoteFileUploadConflictsPayload(ctx context.Context, auth *authService, sn
 }
 
 func decodeRemoteFileJSON(w http.ResponseWriter, r *http.Request, limit int64) (map[string]any, bool) {
-	var body map[string]any
-	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, limit)).Decode(&body); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json"})
+	body, err := readJSONMapWithLimit(r, limit)
+	if err != nil {
+		invalidJSONOrValidation(w, err)
 		return nil, false
 	}
-	if body == nil {
-		body = map[string]any{}
-	}
 	return body, true
+}
+
+func validateRemoteFileSelections(selections []map[string]any) []publicValidationError {
+	errs := make([]publicValidationError, 0)
+	for index, selection := range selections {
+		if err := validatePathInput(fmt.Sprintf("paths[%d].path", index), cleanText(selection["path"])); err != nil {
+			errs = append(errs, publicValidationError{Field: fmt.Sprintf("paths[%d].path", index), Message: err.Error()})
+		}
+	}
+	return errs
+}
+
+func validateRemoteUploadManifestItems(items []map[string]any) []publicValidationError {
+	errs := make([]publicValidationError, 0)
+	for index, item := range items {
+		nameField := fmt.Sprintf("items[%d].name", index)
+		if err := validateRemoteFileName(nameField, cleanText(item["name"])); err != nil {
+			errs = append(errs, publicValidationError{Field: nameField, Message: err.Error()})
+		}
+		relativePath := cleanText(item["relative_path"])
+		if relativePath == "" {
+			continue
+		}
+		for _, part := range strings.Split(relativePath, "/") {
+			if err := validateRemoteFileName(fmt.Sprintf("items[%d].relative_path", index), part); err != nil {
+				errs = append(errs, publicValidationError{Field: fmt.Sprintf("items[%d].relative_path", index), Message: err.Error()})
+				break
+			}
+		}
+	}
+	return errs
 }
 
 func remoteFileTransferDeviceGUID(snapshot deviceProcessContext) string {

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/remote_ops_sessions.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/remote_ops_sessions.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"database/sql"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"net/http"
 	"os"
@@ -106,9 +105,9 @@ func remoteOpsSessionHandler(auth *authService, signer *agentJWTSigner) http.Han
 			writeJSON(w, http.StatusBadGateway, map[string]any{"error": "remote_ops_session_unavailable"})
 			return
 		}
-		var body map[string]any
-		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&body); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_request"})
+		body, err := readJSONMap(r)
+		if err != nil {
+			invalidJSONOrValidation(w, err)
 			return
 		}
 		capabilities := normalizeRemoteOpCapabilities(firstPresent(body["capabilities"], body["capability"]))

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/remote_registry.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/remote_registry.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"strings"
 	"time"
@@ -127,6 +126,10 @@ func remoteRegistryChildrenHandler(auth *authService) func(http.ResponseWriter, 
 			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "path_required"})
 			return
 		}
+		if err := validateRegistryInput("path", requestedPath); err != nil {
+			writePublicValidationErrors(w, []publicValidationError{{Field: "path", Message: err.Error()}})
+			return
+		}
 		snapshot, operatorID, ok := requireRemoteRegistryContext(w, r, auth, hostname)
 		if !ok {
 			return
@@ -155,9 +158,13 @@ func remoteRegistryChildrenHandler(auth *authService) func(http.ResponseWriter, 
 
 func remoteRegistryMutateHandler(auth *authService, action string) func(http.ResponseWriter, *http.Request, string) {
 	return func(w http.ResponseWriter, r *http.Request, hostname string) {
-		var body map[string]any
-		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&body); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json", "message": "Request body must be valid JSON."})
+		body, err := readJSONMap(r)
+		if err != nil {
+			invalidJSONOrValidation(w, err)
+			return
+		}
+		if errs := validateRemoteRegistryMutationBody(body); len(errs) > 0 {
+			writePublicValidationErrors(w, errs)
 			return
 		}
 		snapshot, operatorID, ok := requireRemoteRegistryContext(w, r, auth, hostname)
@@ -271,6 +278,30 @@ func remoteRegistryErrorPayload(status int, payload map[string]any) map[string]a
 		}
 	}
 	return result
+}
+
+func validateRemoteRegistryMutationBody(body map[string]any) []publicValidationError {
+	errs := make([]publicValidationError, 0)
+	for _, key := range []string{"path", "parent_path", "source_path", "destination_path", "target_path", "confirm_path"} {
+		if value := cleanText(body[key]); value != "" {
+			if err := validateRegistryInput(key, value); err != nil {
+				errs = append(errs, publicValidationError{Field: key, Message: err.Error()})
+			}
+		}
+	}
+	for _, key := range []string{"name", "new_name", "value_name"} {
+		if value := cleanText(body[key]); value != "" {
+			if err := validateRegistryInput(key, value); err != nil {
+				errs = append(errs, publicValidationError{Field: key, Message: err.Error()})
+			}
+		}
+	}
+	if kind := cleanText(firstNonEmpty(body["kind"], body["type"], body["value_type"])); kind != "" {
+		if err := validateIdentifierInput("value_type", kind); err != nil {
+			errs = append(errs, publicValidationError{Field: "value_type", Message: err.Error()})
+		}
+	}
+	return errs
 }
 
 func remoteRegistryTimeoutSeconds(value float64) float64 {

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/remote_shell.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/remote_shell.go
@@ -179,21 +179,10 @@ func remoteShellDisconnectHandler(auth *authService) http.HandlerFunc {
 }
 
 func readRemoteShellJSON(w http.ResponseWriter, r *http.Request) (map[string]any, bool) {
-	raw, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 1<<20))
+	body, err := readJSONMapWithLimit(r, 1<<20)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_request"})
+		writeJSON(w, http.StatusBadRequest, publicValidationErrorPayload(err, "invalid_request"))
 		return nil, false
-	}
-	if len(bytes.TrimSpace(raw)) == 0 {
-		return map[string]any{}, true
-	}
-	var body map[string]any
-	if err := json.Unmarshal(raw, &body); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_request"})
-		return nil, false
-	}
-	if body == nil {
-		body = map[string]any{}
 	}
 	return body, true
 }

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/scheduled_jobs.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/scheduled_jobs.go
@@ -226,7 +226,7 @@ func scheduledJobCreate(w http.ResponseWriter, r *http.Request, auth *authServic
 	}
 	body, err := readJSONMap(r)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json"})
+		invalidJSONOrValidation(w, err)
 		return
 	}
 	ctx, cancel := scheduledJobTimeoutContext(r.Context(), auth)
@@ -274,7 +274,7 @@ func scheduledJobUpdate(w http.ResponseWriter, r *http.Request, auth *authServic
 	}
 	body, err := readJSONMap(r)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json"})
+		invalidJSONOrValidation(w, err)
 		return
 	}
 	ctx, cancel := scheduledJobTimeoutContext(r.Context(), auth)
@@ -325,7 +325,7 @@ func scheduledJobToggle(w http.ResponseWriter, r *http.Request, auth *authServic
 	}
 	body, err := readJSONMap(r)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json"})
+		invalidJSONOrValidation(w, err)
 		return
 	}
 	enabled := true

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/server_actions.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/server_actions.go
@@ -70,7 +70,7 @@ func serverServiceActionHandler(auth *authService, fallback http.Handler) http.H
 		} else {
 			body, err := readJSONMap(r)
 			if err != nil {
-				writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json", "message": "Request body must be valid JSON."})
+				invalidJSONOrValidation(w, err)
 				return
 			}
 			action = resolveOverviewServiceAction(serviceKey, body)

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/server_agent_release_channels.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/server_agent_release_channels.go
@@ -52,7 +52,7 @@ func agentReleaseChannelsHandler(auth *authService, fallback http.Handler) http.
 		if r.Method == http.MethodPut {
 			body, err := readJSONMap(r)
 			if err != nil {
-				writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json", "message": "Request body must be valid JSON."})
+				invalidJSONOrValidation(w, err)
 				return
 			}
 			settings := collectAgentReleaseChannelSettings()

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/server_backup.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/server_backup.go
@@ -352,6 +352,14 @@ func readEngineBackupRequest(w http.ResponseWriter, r *http.Request, requireConf
 	_ = json.Unmarshal(raw["confirmation"], &req.Confirmation)
 	req.Cipher = strings.TrimSpace(req.Cipher)
 	req.Confirmation = strings.TrimSpace(req.Confirmation)
+	if err := validateInputValue("cipher", req.Cipher, inputClassSecret); err != nil {
+		writePublicValidationErrors(w, []publicValidationError{{Field: "cipher", Message: err.Error()}})
+		return engineBackupRestoreRequest{}, false
+	}
+	if err := validateInputValue("confirmation", req.Confirmation, inputClassPlainSingleLine); err != nil {
+		writePublicValidationErrors(w, []publicValidationError{{Field: "confirmation", Message: err.Error()}})
+		return engineBackupRestoreRequest{}, false
+	}
 	if req.Cipher == "" {
 		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "cipher_required", "message": "Aegis Cipher is required."})
 		return engineBackupRestoreRequest{}, false

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/server_settings.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/server_settings.go
@@ -60,13 +60,10 @@ func updateAnsibleRunnerSettings(w http.ResponseWriter, r *http.Request, auth *a
 		return
 	}
 
-	var body map[string]any
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil && err.Error() != "EOF" {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json"})
+	body, err := readJSONMap(r)
+	if err != nil {
+		invalidJSONOrValidation(w, err)
 		return
-	}
-	if body == nil {
-		body = map[string]any{}
 	}
 
 	normalized := map[string]int{}

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/server_systemd.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/server_systemd.go
@@ -89,7 +89,7 @@ func collectSystemdServiceRows() []map[string]any {
 func handleSystemdServiceRestart(w http.ResponseWriter, r *http.Request, serviceKey string) {
 	body, err := readJSONMap(r)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json", "message": "Request body must be valid JSON."})
+		invalidJSONOrValidation(w, err)
 		return
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), systemdCommandTimeout)

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/sites.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/sites.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"database/sql"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"net/http"
 	"net/url"
@@ -105,13 +104,17 @@ func handleSiteCreate(w http.ResponseWriter, r *http.Request, auth *authService)
 		failure.write(w)
 		return
 	}
-	var body map[string]any
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil && !errors.Is(err, http.ErrBodyReadAfterClose) {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json"})
+	body, err := readJSONMap(r)
+	if err != nil {
+		invalidJSONOrValidation(w, err)
 		return
 	}
 	name := cleanText(body["name"])
 	description := cleanText(body["description"])
+	if err := validateInputValue("name", name, inputClassPlainSingleLine); err != nil {
+		writePublicValidationErrors(w, []publicValidationError{{Field: "name", Message: err.Error()}})
+		return
+	}
 	store, ok := auth.store.(siteMutationStore)
 	if !ok {
 		writeJSON(w, http.StatusBadGateway, map[string]any{"error": "site_mutation_unavailable"})
@@ -222,9 +225,9 @@ func siteDeleteHandler(auth *authService) http.HandlerFunc {
 			failure.write(w)
 			return
 		}
-		var body map[string]any
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json"})
+		body, err := readJSONMap(r)
+		if err != nil {
+			invalidJSONOrValidation(w, err)
 			return
 		}
 		rawIDs, ok := body["ids"].([]any)
@@ -263,9 +266,9 @@ func siteAssignHandler(auth *authService) http.HandlerFunc {
 			failure.write(w)
 			return
 		}
-		var body map[string]any
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json"})
+		body, err := readJSONMap(r)
+		if err != nil {
+			invalidJSONOrValidation(w, err)
 			return
 		}
 		siteID, ok := parseInt64Value(body["site_id"])
@@ -281,7 +284,7 @@ func siteAssignHandler(auth *authService) http.HandlerFunc {
 		hostnames := make([]string, 0, len(rawHostnames))
 		for _, rawHostname := range rawHostnames {
 			hostname := cleanText(rawHostname)
-			if hostname == "" {
+			if hostname == "" || validateHostInput("hostnames", hostname) != nil {
 				writeJSON(w, http.StatusBadRequest, map[string]any{"error": "hostnames must be a list of strings"})
 				return
 			}
@@ -309,9 +312,9 @@ func siteRenameHandler(auth *authService) http.HandlerFunc {
 			failure.write(w)
 			return
 		}
-		var body map[string]any
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json"})
+		body, err := readJSONMap(r)
+		if err != nil {
+			invalidJSONOrValidation(w, err)
 			return
 		}
 		siteID, ok := parseInt64Value(body["id"])
@@ -320,6 +323,10 @@ func siteRenameHandler(auth *authService) http.HandlerFunc {
 			return
 		}
 		newName := cleanText(body["new_name"])
+		if err := validateInputValue("new_name", newName, inputClassPlainSingleLine); err != nil {
+			writePublicValidationErrors(w, []publicValidationError{{Field: "new_name", Message: err.Error()}})
+			return
+		}
 		store, ok := auth.store.(siteMutationStore)
 		if !ok {
 			writeJSON(w, http.StatusBadGateway, map[string]any{"error": "site_mutation_unavailable"})
@@ -347,9 +354,9 @@ func siteAutoApprovalHandler(auth *authService) http.HandlerFunc {
 			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid id"})
 			return
 		}
-		var body map[string]any
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json"})
+		body, err := readJSONMap(r)
+		if err != nil {
+			invalidJSONOrValidation(w, err)
 			return
 		}
 		var until *int64

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/software_overrides.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/software_overrides.go
@@ -59,7 +59,7 @@ func deviceSoftwareOverrideHandler(auth *authService, action string) http.Handle
 		}
 		body, err := readJSONMap(r)
 		if err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json", "message": "Request body must be valid JSON."})
+			invalidJSONOrValidation(w, err)
 			return
 		}
 		store, ok := auth.store.(softwareOverrideStore)
@@ -132,7 +132,7 @@ func bulkSoftwareActionHandler(auth *authService) http.HandlerFunc {
 		}
 		body, err := readJSONMap(r)
 		if err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json", "message": "Request body must be valid JSON."})
+			invalidJSONOrValidation(w, err)
 			return
 		}
 		store, ok := auth.store.(softwareOverrideStore)

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/software_uninstall_dispatch.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/software_uninstall_dispatch.go
@@ -46,7 +46,7 @@ func deviceSoftwareUninstallHandler(auth *authService) http.HandlerFunc {
 		}
 		body, err := readJSONMap(r)
 		if err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json", "message": "Request body must be valid JSON."})
+			invalidJSONOrValidation(w, err)
 			return
 		}
 		store, ok := auth.store.(softwareUninstallStore)
@@ -96,7 +96,7 @@ func bulkSoftwareUninstallHandler(auth *authService) http.HandlerFunc {
 		}
 		body, err := readJSONMap(r)
 		if err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json", "message": "Request body must be valid JSON."})
+			invalidJSONOrValidation(w, err)
 			return
 		}
 		store, ok := auth.store.(softwareUninstallStore)

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/user_site_assignments.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/user_site_assignments.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"errors"
 	"net/http"
 	"sort"
@@ -64,9 +63,10 @@ func userSiteAssignmentHandler(auth *authService) http.HandlerFunc {
 			writeJSON(w, http.StatusBadGateway, map[string]any{"error": "user_site_assignments_unavailable"})
 			return
 		}
-		var body map[string]any
-		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&body); err != nil {
-			body = map[string]any{}
+		body, err := readJSONMap(r)
+		if err != nil {
+			invalidJSONOrValidation(w, err)
+			return
 		}
 		usernames := normalizeAssignmentUsernames(body["usernames"])
 		siteIDs := normalizeAssignmentSiteIDs(body["site_ids"])
@@ -75,14 +75,14 @@ func userSiteAssignmentHandler(auth *authService) http.HandlerFunc {
 
 		var payload map[string]any
 		var status int
-		var err error
+		var storeErr error
 		if route == "selection" {
-			payload, status, err = store.loadUserSiteAssignmentSelection(ctx, usernames)
+			payload, status, storeErr = store.loadUserSiteAssignmentSelection(ctx, usernames)
 		} else {
-			payload, status, err = store.assignUserSites(ctx, usernames, siteIDs)
+			payload, status, storeErr = store.assignUserSites(ctx, usernames, siteIDs)
 		}
-		if err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]any{"error": err.Error()})
+		if storeErr != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]any{"error": storeErr.Error()})
 			return
 		}
 		writeJSON(w, status, payload)

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/users.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/users.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"errors"
 	"net/http"
 	"net/url"
@@ -239,9 +238,9 @@ func userRoleUpdate(w http.ResponseWriter, r *http.Request, auth *authService, u
 		return
 	}
 
-	var body map[string]any
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil && err.Error() != "EOF" {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json"})
+	body, err := readJSONMap(r)
+	if err != nil {
+		invalidJSONOrValidation(w, err)
 		return
 	}
 	role := normalizeUserRole(body["role"])
@@ -267,7 +266,7 @@ func userMFAUpdate(w http.ResponseWriter, r *http.Request, auth *authService, us
 	}
 	body, err := readJSONMap(r)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json"})
+		invalidJSONOrValidation(w, err)
 		return
 	}
 	enabled := boolFromAny(body["enabled"])

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/vnc_runtime.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/vnc_runtime.go
@@ -125,9 +125,9 @@ func vncEstablishHandler(auth *authService, runtime *vncRuntime) http.HandlerFun
 			writeJSON(w, http.StatusBadGateway, map[string]any{"error": "auth_unavailable", "detail": err.Error()})
 			return
 		}
-		var body map[string]any
-		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&body); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_request"})
+		body, err := readJSONMap(r)
+		if err != nil {
+			invalidJSONOrValidation(w, err)
 			return
 		}
 		requestedAgentID := cleanText(body["agent_id"])
@@ -873,9 +873,9 @@ func vncDisconnectHandler(auth *authService, runtime *vncRuntime) http.HandlerFu
 			writeJSON(w, http.StatusBadGateway, map[string]any{"error": "auth_unavailable", "detail": err.Error()})
 			return
 		}
-		var body map[string]any
-		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&body); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_request"})
+		body, err := readJSONMap(r)
+		if err != nil {
+			invalidJSONOrValidation(w, err)
 			return
 		}
 		sessionID := cleanText(body["session_id"])
@@ -952,9 +952,9 @@ func vncHandoffHandler(auth *authService, runtime *vncRuntime) http.HandlerFunc 
 			writeJSON(w, http.StatusBadGateway, map[string]any{"error": "auth_unavailable", "detail": err.Error()})
 			return
 		}
-		var body map[string]any
-		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&body); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_request"})
+		body, err := readJSONMap(r)
+		if err != nil {
+			invalidJSONOrValidation(w, err)
 			return
 		}
 		sessionID := cleanText(body["session_id"])

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/vpn_tunnel.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/vpn_tunnel.go
@@ -228,9 +228,9 @@ func tunnelConnectHandler(auth *authService, service *vpnTunnelService) http.Han
 			writeJSON(w, http.StatusBadGateway, map[string]any{"error": "auth_unavailable", "detail": err.Error()})
 			return
 		}
-		var body map[string]any
-		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&body); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_request"})
+		body, err := readJSONMap(r)
+		if err != nil {
+			invalidJSONOrValidation(w, err)
 			return
 		}
 		requestedAgentID := cleanText(body["agent_id"])

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/watchdogs.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/watchdogs.go
@@ -224,8 +224,11 @@ func deviceWatchdogOverrideHandler(auth *authService, broadcaster watchdogIncide
 			writeJSON(w, http.StatusBadGateway, map[string]any{"error": "watchdogs_unavailable"})
 			return
 		}
-		body := map[string]any{}
-		_ = json.NewDecoder(http.MaxBytesReader(w, r.Body, 64<<10)).Decode(&body)
+		body, err := readJSONMapWithLimit(r, 64<<10)
+		if err != nil {
+			invalidJSONOrValidation(w, err)
+			return
+		}
 		ctx, cancel := watchdogTimeoutContext(r.Context(), auth)
 		defer cancel()
 		payload, validationErrors, err := store.upsertDeviceWatchdogOverride(ctx, profile, r.PathValue("device_id"), body)
@@ -328,8 +331,11 @@ func watchdogPreview(w http.ResponseWriter, r *http.Request, auth *authService) 
 		writeJSON(w, http.StatusBadGateway, map[string]any{"error": "watchdogs_unavailable"})
 		return
 	}
-	body := map[string]any{}
-	_ = json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&body)
+	body, err := readJSONMap(r)
+	if err != nil {
+		invalidJSONOrValidation(w, err)
+		return
+	}
 	ctx, cancel := watchdogTimeoutContext(r.Context(), auth)
 	defer cancel()
 	payload, validationErrors, err := store.previewWatchdog(ctx, profile, body)
@@ -394,8 +400,11 @@ func watchdogSave(w http.ResponseWriter, r *http.Request, auth *authService, bro
 	if !ok {
 		return
 	}
-	body := map[string]any{}
-	_ = json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&body)
+	body, err := readJSONMap(r)
+	if err != nil {
+		invalidJSONOrValidation(w, err)
+		return
+	}
 	ctx, cancel := watchdogTimeoutContext(r.Context(), auth)
 	defer cancel()
 	item, validationErrors, err := store.saveWatchdog(ctx, profile, watchdogID, body)
@@ -511,8 +520,11 @@ func watchdogIncidentStateUpdate(w http.ResponseWriter, r *http.Request, auth *a
 		writeJSON(w, http.StatusNotFound, map[string]any{"error": "not_found"})
 		return
 	}
-	body := map[string]any{}
-	_ = json.NewDecoder(http.MaxBytesReader(w, r.Body, 64<<10)).Decode(&body)
+	body, err := readJSONMapWithLimit(r, 64<<10)
+	if err != nil {
+		invalidJSONOrValidation(w, err)
+		return
+	}
 	requestedState := firstText(cleanText(body["state"]), "open")
 	requestedReason := cleanText(body["reason"])
 	if normalizeIncidentMutationState(requestedState) == "suppressed" && cleanSingleLine(requestedReason) == "" {

--- a/Data/Engine/Containers/api-backend/cmd/api-backend/workflows.go
+++ b/Data/Engine/Containers/api-backend/cmd/api-backend/workflows.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"database/sql"
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"net/http"
 	"net/url"
@@ -161,9 +160,9 @@ func workflowRunStart(w http.ResponseWriter, r *http.Request, auth *authService)
 	if !ok {
 		return
 	}
-	var body map[string]any
-	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 2<<20)).Decode(&body); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json"})
+	body, err := readJSONMapWithLimit(r, 2<<20)
+	if err != nil {
+		invalidJSONOrValidation(w, err)
 		return
 	}
 	workflowGUID := assemblyCoerceGUID(firstNonEmptyAny(body["workflow_guid"], body["workflowGuid"]))
@@ -232,9 +231,14 @@ func workflowRunResolve(w http.ResponseWriter, r *http.Request, auth *authServic
 		writeJSON(w, http.StatusNotFound, map[string]any{"error": "not found"})
 		return
 	}
-	var body map[string]any
+	body := map[string]any{}
 	if r.Body != nil {
-		_ = json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&body)
+		var err error
+		body, err = readJSONMap(r)
+		if err != nil {
+			invalidJSONOrValidation(w, err)
+			return
+		}
 	}
 	ctx, cancel := workflowTimeoutContext(r.Context(), auth)
 	defer cancel()
@@ -285,9 +289,9 @@ func internalWorkflowStartHandler(auth *authService) http.HandlerFunc {
 			writeJSON(w, http.StatusServiceUnavailable, map[string]any{"error": "workflow_store_unavailable"})
 			return
 		}
-		var body map[string]any
-		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 2<<20)).Decode(&body); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_json"})
+		body, err := readJSONMapWithLimit(r, 2<<20)
+		if err != nil {
+			invalidJSONOrValidation(w, err)
 			return
 		}
 		sourceMetadata := mapStringAny(body["source_metadata"])

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/app/utils/inputValidation.test.js
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/app/utils/inputValidation.test.js
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  installBorealisInputValidationGuard,
+  sanitizeNotificationMessage,
+  sanitizePayload,
+  validateBorealisFetchRequest,
+  validateInputValue,
+} from "../../../src/app/utils/inputValidation.js";
+
+describe("inputValidation", () => {
+  it("sanitizes plain display text while preserving code content", () => {
+    const result = sanitizePayload({
+      name: "  Alpha\nBeta  ",
+      content: "if (1 < 2) {\n  echo ok\n}",
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.value.name).toBe("Alpha Beta");
+    expect(result.value.content).toContain("1 < 2");
+    expect(result.value.content).toContain("\n");
+  });
+
+  it("rejects invalid regex fields", () => {
+    const result = sanitizePayload({ regex: "[" });
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].field).toBe("regex");
+  });
+
+  it("validates hostnames, IPv6 CIDR, and malformed host input", () => {
+    expect(validateInputValue("hostname", "borealis.local")).toBe("");
+    expect(validateInputValue("cidr", "fd00::1/64")).toBe("");
+    expect(validateInputValue("hostname", "borealis/evil")).toContain("hostname");
+  });
+
+  it("sanitizes API JSON bodies before fetch sends them", () => {
+    const request = validateBorealisFetchRequest(
+      "/api/sites",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "  Bunny\nLab  ", content: "Write-Output '<ok>'" }),
+      },
+      "https://borealis.test"
+    );
+
+    expect(request.errors).toEqual([]);
+    expect(JSON.parse(request.init.body)).toEqual({
+      name: "Bunny Lab",
+      content: "Write-Output '<ok>'",
+    });
+  });
+
+  it("rejects unsafe same-origin API paths", () => {
+    const request = validateBorealisFetchRequest("/api/devices/%3Cscript%3E", {}, "https://borealis.test");
+
+    expect(request.errors).toEqual(expect.arrayContaining([expect.objectContaining({ field: "path" })]));
+  });
+
+  it("blocks unsafe same-origin API payloads before network fetch", async () => {
+    const originalFetch = vi.fn(async () => new Response("ok", { status: 200 }));
+    const win = {
+      location: { origin: "https://borealis.test" },
+      fetch: originalFetch,
+    };
+    installBorealisInputValidationGuard(win);
+
+    const response = await win.fetch("/api/sites", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "<script>alert(1)</script>" }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(originalFetch).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toMatchObject({ error: "validation_failed" });
+  });
+
+  it("leaves non-API fetches untouched", async () => {
+    const originalFetch = vi.fn(async () => new Response("ok", { status: 200 }));
+    const win = {
+      location: { origin: "https://borealis.test" },
+      fetch: originalFetch,
+    };
+    installBorealisInputValidationGuard(win);
+
+    const response = await win.fetch("https://assets.example/file.json", {
+      method: "POST",
+      body: JSON.stringify({ name: "<script>external</script>" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(originalFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves notification bold tags but strips executable tags", () => {
+    const message = sanitizeNotificationMessage("Hello <b>World</b> <script>alert(1)</script>");
+
+    expect(message).toContain("<b>World</b>");
+    expect(message.toLowerCase()).not.toContain("<script");
+  });
+});

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/app/utils/inputValidation.test.js
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/Unit_Tests/app/utils/inputValidation.test.js
@@ -51,6 +51,34 @@ describe("inputValidation", () => {
     });
   });
 
+  it("keeps passkey verify credential JSON opaque", () => {
+    const body = JSON.stringify({
+      request_id: "pending.token.value",
+      credential: {
+        id: "abc+/=",
+        rawId: "abc+/=",
+        type: "public-key",
+        response: {
+          clientDataJSON: "abc+/=",
+          authenticatorData: "abc+/=",
+          signature: "abc+/=",
+        },
+      },
+    });
+    const request = validateBorealisFetchRequest(
+      "/api/auth/passkeys/authenticate/verify",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body,
+      },
+      "https://borealis.test"
+    );
+
+    expect(request.errors).toEqual([]);
+    expect(request.init.body).toBe(body);
+  });
+
   it("rejects unsafe same-origin API paths", () => {
     const request = validateBorealisFetchRequest("/api/devices/%3Cscript%3E", {}, "https://borealis.test");
 

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Device_List.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Device_List.jsx
@@ -97,7 +97,6 @@ const MAGIC_UI = {
 const PAGE_ICON = DevicesOtherIcon;
 const DEFAULT_VISIBLE_COLUMN_IDS = [
   "status",
-  "agentChannelBranch",
   "site",
   "hostname",
   "description",

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Activity_History.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/Devices/Tabs/Activity_History.jsx
@@ -960,7 +960,10 @@ export default function ActivityHistoryTab({ hostname = "", refreshToken = 0 }) 
     try {
       return Prism.highlight(code ?? "", Prism.languages[lang] || Prism.languages.markup, lang);
     } catch {
-      return String(code || "");
+      return String(code || "")
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;");
     }
   }, []);
 

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/app/runtime/bootstrapClientRuntime.js
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/app/runtime/bootstrapClientRuntime.js
@@ -1,4 +1,5 @@
 import { io } from "socket.io-client";
+import { installBorealisInputValidationGuard } from "../utils/inputValidation.js";
 
 let bootstrapped = false;
 const GO_REALTIME_EVENTS = [
@@ -170,6 +171,7 @@ export function bootstrapClientRuntime() {
   if (!window.BorealisUpdateRate) {
     window.BorealisUpdateRate = 200;
   }
+  installBorealisInputValidationGuard(window);
   bootstrapped = true;
 }
 

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/app/utils/inputValidation.js
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/app/utils/inputValidation.js
@@ -214,12 +214,22 @@ export function validateBorealisFetchRequest(input, init = {}, baseOrigin = glob
   if (typeof body === "string" && (contentType.includes("json") || /^[\s\r\n]*[\[{]/.test(body))) {
     try {
       const parsedBody = JSON.parse(body);
-      const result = sanitizePayload(parsedBody);
-      errors.push(...result.errors);
-      if (!errors.length) {
+      if (usesTransportOnlyBodyValidation(parsed.pathname)) {
+        errors.push(...validateTransportPayload(parsedBody));
+      } else {
+        const result = sanitizePayload(parsedBody);
+        errors.push(...result.errors);
+        if (!errors.length) {
+          nextInit = {
+            ...init,
+            body: JSON.stringify(result.value),
+            headers: withJSONContentType(init?.headers),
+          };
+        }
+      }
+      if (!errors.length && nextInit === init) {
         nextInit = {
           ...init,
-          body: JSON.stringify(result.value),
           headers: withJSONContentType(init?.headers),
         };
       }
@@ -271,6 +281,34 @@ function withJSONContentType(headers) {
     return next;
   }
   return { ...headers, "Content-Type": headerValue(headers, "content-type") || "application/json" };
+}
+
+function usesTransportOnlyBodyValidation(pathname) {
+  return pathname === "/api/auth/passkeys/register/verify" || pathname === "/api/auth/passkeys/authenticate/verify";
+}
+
+function validateTransportPayload(value, field = "body") {
+  const errors = [];
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => {
+      errors.push(...validateTransportPayload(item, `${field}[${index}]`));
+    });
+    return errors;
+  }
+  if (value && typeof value === "object") {
+    Object.entries(value).forEach(([key, child]) => {
+      const childField = field === "body" ? key : `${field}.${key}`;
+      errors.push(...validateTransportPayload(child, childField));
+    });
+    return errors;
+  }
+  if (typeof value !== "string") return errors;
+  if (value.length > SECRET_MAX_LENGTH) {
+    errors.push({ field, message: `${field} exceeds ${SECRET_MAX_LENGTH} characters.` });
+  } else if (CONTROL_RE.test(value) || /[\u0009\u000a\u000d]/.test(value)) {
+    errors.push({ field, message: `${field} cannot include control characters.` });
+  }
+  return errors;
 }
 
 function safeDecodeURIComponent(value) {

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/app/utils/inputValidation.js
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/app/utils/inputValidation.js
@@ -1,0 +1,297 @@
+const DEFAULT_MAX_LENGTH = 4096;
+const IDENTIFIER_MAX_LENGTH = 256;
+const PATH_MAX_LENGTH = 4096;
+const SECRET_MAX_LENGTH = 16 * 1024 * 1024;
+
+const FIELD_CLASS = {
+  PLAIN_SINGLE_LINE: "plain_single_line",
+  PLAIN_MULTILINE: "plain_multiline",
+  IDENTIFIER: "identifier",
+  SLUG: "slug",
+  HOST: "host",
+  URL: "url",
+  PATH: "path",
+  REGISTRY: "registry",
+  REGEX: "regex",
+  SECRET: "secret",
+  CODE: "code",
+};
+
+const IDENTIFIER_RE = /^[A-Za-z0-9][A-Za-z0-9._:@/-]*$/;
+const SLUG_RE = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/;
+const IPV4_RE = /^(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}(\/([0-9]|[1-2]\d|3[0-2]))?$/;
+const HOST_RE = /^(?=.{1,253}$)([A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)(\.([A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?))*$/;
+const CONTROL_RE = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/;
+const UNSAFE_MARKUP_RE = /<\s*\/?\s*(script|iframe|object|embed|img|svg|math|link|style|meta|base|form|input|button|textarea|select|option|video|audio|source|body|html)\b|on[a-z]+\s*=|javascript\s*:/i;
+
+export { FIELD_CLASS };
+
+export function sanitizeSingleLineInput(value) {
+  return String(value ?? "")
+    .replace(/[\u0000-\u001f\u007f]+/g, " ")
+    .trim()
+    .replace(/\s+/g, " ");
+}
+
+export function sanitizeMultilineInput(value) {
+  return String(value ?? "")
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
+    .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]+/g, " ")
+    .trim();
+}
+
+export function sanitizeNotificationMessage(value) {
+  let text = sanitizeMultilineInput(value)
+    .replaceAll("<B>", "<b>")
+    .replaceAll("</B>", "</b>")
+    .replaceAll("<b>", "\u0000BOLD_OPEN\u0000")
+    .replaceAll("</b>", "\u0000BOLD_CLOSE\u0000");
+  text = text.replaceAll("<", "").replaceAll(">", "");
+  return text
+    .replaceAll("\u0000BOLD_OPEN\u0000", "<b>")
+    .replaceAll("\u0000BOLD_CLOSE\u0000", "</b>")
+    .slice(0, DEFAULT_MAX_LENGTH);
+}
+
+export function classifyInputField(field) {
+  const key = String(field || "").toLowerCase().trim().replace(/^\[|\]$/g, "");
+  if (
+    key.includes("password") ||
+    key.includes("cipher") ||
+    key.includes("secret") ||
+    key.includes("token") ||
+    key.includes("pem") ||
+    key.includes("private_key") ||
+    key.includes("backup")
+  ) return FIELD_CLASS.SECRET;
+  if (
+    key.includes("script") ||
+    key.includes("code") ||
+    key.includes("content") ||
+    key.includes("stdout") ||
+    key.includes("stderr") ||
+    key.includes("command") ||
+    key.includes("argument") ||
+    key.includes("json") ||
+    key.includes("payload") ||
+    key === "data" ||
+    key === "value_data"
+  ) return FIELD_CLASS.CODE;
+  if (key.includes("regex")) return FIELD_CLASS.REGEX;
+  if (key.includes("registry")) return FIELD_CLASS.REGISTRY;
+  if (key === "path" || key.endsWith("_path") || key.includes("directory") || key.includes("folder")) return FIELD_CLASS.PATH;
+  if (key.includes("url") || key.includes("uri") || key.includes("endpoint")) return FIELD_CLASS.URL;
+  if (key === "hostname" || key.includes("host_name") || key.endsWith("_host") || key.includes("cidr") || key.includes("ip_address")) return FIELD_CLASS.HOST;
+  if (key.includes("slug")) return FIELD_CLASS.SLUG;
+  if (
+    key === "id" ||
+    key.endsWith("_id") ||
+    key.includes("guid") ||
+    key.includes("uuid") ||
+    key === "role" ||
+    key === "action" ||
+    key.endsWith("_action") ||
+    key === "platform" ||
+    key === "artifact" ||
+    key === "branch" ||
+    key === "service_mode"
+  ) return FIELD_CLASS.IDENTIFIER;
+  if (key.includes("description") || key.includes("notes") || key.includes("message") || key.includes("comment")) {
+    return FIELD_CLASS.PLAIN_MULTILINE;
+  }
+  return FIELD_CLASS.PLAIN_SINGLE_LINE;
+}
+
+export function validateInputValue(field, value, fieldClass = classifyInputField(field)) {
+  const text = String(value ?? "");
+  const allowNewlines = [FIELD_CLASS.PLAIN_MULTILINE, FIELD_CLASS.SECRET, FIELD_CLASS.CODE, FIELD_CLASS.REGEX].includes(fieldClass);
+  const maxLength = [FIELD_CLASS.SECRET, FIELD_CLASS.CODE].includes(fieldClass)
+    ? SECRET_MAX_LENGTH
+    : fieldClass === FIELD_CLASS.PATH || fieldClass === FIELD_CLASS.REGISTRY
+      ? PATH_MAX_LENGTH
+      : fieldClass === FIELD_CLASS.IDENTIFIER
+        ? IDENTIFIER_MAX_LENGTH
+        : DEFAULT_MAX_LENGTH;
+
+  if (text.length > maxLength) return `${field} exceeds ${maxLength} characters.`;
+  if (CONTROL_RE.test(text) || (!allowNewlines && /[\r\n\t]/.test(text))) return `${field} cannot include control characters.`;
+
+  const trimmed = text.trim();
+  if (!trimmed) return "";
+  if (![FIELD_CLASS.SECRET, FIELD_CLASS.CODE, FIELD_CLASS.PATH, FIELD_CLASS.REGISTRY, FIELD_CLASS.REGEX].includes(fieldClass) && UNSAFE_MARKUP_RE.test(trimmed)) {
+    return `${field} cannot include executable markup.`;
+  }
+
+  if (fieldClass === FIELD_CLASS.IDENTIFIER && !IDENTIFIER_RE.test(trimmed)) return `${field} must be an identifier, enum, or safe ref.`;
+  if (fieldClass === FIELD_CLASS.SLUG && !SLUG_RE.test(trimmed)) return `${field} must be a lowercase slug.`;
+  if (fieldClass === FIELD_CLASS.HOST && !isHostInput(trimmed)) return `${field} must be a hostname, IP address, or CIDR.`;
+  if (fieldClass === FIELD_CLASS.URL) {
+    try {
+      const parsed = new URL(trimmed);
+      if (!["http:", "https:", "ldap:", "ldaps:"].includes(parsed.protocol)) return `${field} uses an unsupported URL scheme.`;
+    } catch {
+      return `${field} must be an absolute URL.`;
+    }
+  }
+  if (fieldClass === FIELD_CLASS.REGISTRY && (trimmed.includes("/") || /[<>"|?*]/.test(trimmed))) {
+    return `${field} must be a Windows registry path or value name.`;
+  }
+  if (fieldClass === FIELD_CLASS.REGEX) {
+    try {
+      new RegExp(trimmed);
+    } catch {
+      return `${field} must be a valid regular expression.`;
+    }
+  }
+  return "";
+}
+
+export function sanitizePayload(value, field = "body", fieldClass = classifyInputField(field)) {
+  if (Array.isArray(value)) {
+    const errors = [];
+    const sanitized = value.map((item, index) => {
+      const result = sanitizePayload(item, `${field}[${index}]`, fieldClass);
+      errors.push(...result.errors);
+      return result.value;
+    });
+    return { value: sanitized, errors };
+  }
+
+  const fileLike = typeof File !== "undefined" && value instanceof File;
+  const blobLike = typeof Blob !== "undefined" && value instanceof Blob;
+  if (value && typeof value === "object" && !fileLike && !blobLike) {
+    const errors = [];
+    const sanitized = {};
+    for (const [key, child] of Object.entries(value)) {
+      const childClass = classifyInputField(key);
+      const result = sanitizePayload(child, key, childClass);
+      errors.push(...result.errors.map((error) => ({ ...error, field: error.field.includes(".") ? error.field : key })));
+      sanitized[key] = result.value;
+    }
+    return { value: sanitized, errors };
+  }
+
+  if (typeof value !== "string") return { value, errors: [] };
+  const error = validateInputValue(field, value, fieldClass);
+  if (error) return { value, errors: [{ field, message: error }] };
+
+  if ([FIELD_CLASS.PLAIN_SINGLE_LINE, FIELD_CLASS.IDENTIFIER, FIELD_CLASS.SLUG, FIELD_CLASS.HOST, FIELD_CLASS.URL].includes(fieldClass)) {
+    return { value: sanitizeSingleLineInput(value), errors: [] };
+  }
+  if (fieldClass === FIELD_CLASS.PLAIN_MULTILINE) {
+    return { value: sanitizeMultilineInput(value), errors: [] };
+  }
+  return { value, errors: [] };
+}
+
+export function validateBorealisFetchRequest(input, init = {}, baseOrigin = globalThis.window?.location?.origin || "http://localhost") {
+  const urlText = typeof input === "string" || input instanceof URL ? String(input) : String(input?.url || "");
+  let parsed;
+  try {
+    parsed = new URL(urlText, baseOrigin);
+  } catch {
+    return { input, init, errors: [] };
+  }
+  const base = new URL(baseOrigin);
+  if (parsed.origin !== base.origin || !parsed.pathname.startsWith("/api/") || parsed.pathname.startsWith("/api/internal/") || parsed.pathname === "/api/server/k3s/operator") {
+    return { input, init, errors: [] };
+  }
+
+  const errors = [];
+  const decodedPath = safeDecodeURIComponent(parsed.pathname);
+  if (/[\u0000-\u001f\u007f]/.test(decodedPath) || UNSAFE_MARKUP_RE.test(decodedPath)) {
+    errors.push({ field: "path", message: "path cannot include executable markup or control characters." });
+  }
+  for (const [key, value] of parsed.searchParams.entries()) {
+    const error = validateInputValue(`query.${key}`, value, classifyInputField(key));
+    if (error) errors.push({ field: `query.${key}`, message: error });
+  }
+
+  let nextInit = init;
+  const body = init?.body;
+  const contentType = headerValue(init?.headers, "content-type");
+  if (typeof body === "string" && (contentType.includes("json") || /^[\s\r\n]*[\[{]/.test(body))) {
+    try {
+      const parsedBody = JSON.parse(body);
+      const result = sanitizePayload(parsedBody);
+      errors.push(...result.errors);
+      if (!errors.length) {
+        nextInit = {
+          ...init,
+          body: JSON.stringify(result.value),
+          headers: withJSONContentType(init?.headers),
+        };
+      }
+    } catch {
+      errors.push({ field: "body", message: "Request body must be valid JSON." });
+    }
+  } else if (typeof FormData !== "undefined" && body instanceof FormData) {
+    for (const [key, value] of body.entries()) {
+      if (typeof File !== "undefined" && value instanceof File) continue;
+      const error = validateInputValue(key, value, classifyInputField(key));
+      if (error) errors.push({ field: key, message: error });
+    }
+  }
+
+  return { input, init: nextInit, errors };
+}
+
+export function installBorealisInputValidationGuard(win = globalThis.window) {
+  if (!win || win.__BorealisInputValidationGuardInstalled || typeof win.fetch !== "function") return;
+  const originalFetch = win.fetch.bind(win);
+  win.fetch = async (input, init = {}) => {
+    const result = validateBorealisFetchRequest(input, init, win.location?.origin || "http://localhost");
+    if (result.errors.length) {
+      return new Response(JSON.stringify({ error: "validation_failed", errors: result.errors }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return originalFetch(result.input, result.init);
+  };
+  Object.defineProperty(win, "__BorealisInputValidationGuardInstalled", {
+    value: true,
+    configurable: true,
+  });
+}
+
+function headerValue(headers, key) {
+  if (!headers) return "";
+  if (typeof headers.get === "function") return String(headers.get(key) || "").toLowerCase();
+  const found = Object.entries(headers).find(([name]) => name.toLowerCase() === key.toLowerCase());
+  return String(found?.[1] || "").toLowerCase();
+}
+
+function withJSONContentType(headers) {
+  if (!headers) return { "Content-Type": "application/json" };
+  if (typeof Headers !== "undefined" && headers instanceof Headers) {
+    const next = new Headers(headers);
+    if (!next.has("Content-Type")) next.set("Content-Type", "application/json");
+    return next;
+  }
+  return { ...headers, "Content-Type": headerValue(headers, "content-type") || "application/json" };
+}
+
+function safeDecodeURIComponent(value) {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function isHostInput(value) {
+  if (IPV4_RE.test(value) || HOST_RE.test(value)) return true;
+  const parts = value.split("/");
+  if (parts.length > 2) return false;
+  const [address, prefix] = parts;
+  if (prefix !== undefined && (!/^\d+$/.test(prefix) || Number(prefix) > 128)) return false;
+  if (!address.includes(":")) return false;
+  try {
+    new URL(`http://[${address}]`);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/Data/Engine/Containers/webui-frontend/data/web-interface/src/nodes/Data Analysis & Manipulation/Node_JSON_Display.jsx
+++ b/Data/Engine/Containers/webui-frontend/data/web-interface/src/nodes/Data Analysis & Manipulation/Node_JSON_Display.jsx
@@ -96,9 +96,17 @@ const JSONPrettyDisplayNode = ({ id, data }) => {
     return () => { clearInterval(iv); clearInterval(monitor); };
   }, [id, edges, setNodes]);
 
-  // Generate highlighted HTML
   const pretty = JSON.stringify(jsonData, null, 2);
-  const highlighted = Prism.highlight(pretty, Prism.languages.json, "json");
+  const highlighted = (() => {
+    try {
+      return Prism.highlight(pretty, Prism.languages.json, "json");
+    } catch {
+      return String(pretty || "")
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;");
+    }
+  })();
 
   return (
     <div

--- a/Docs/Reference/Data and Schema/api-reference.md
+++ b/Docs/Reference/Data and Schema/api-reference.md
@@ -2,6 +2,8 @@
 
 Provide a consolidated, human-readable list of Borealis Engine API endpoints grouped by domain.
 
+Public `/api/*` routes validate path/query/body input before domain work where shared validation helpers are in use. Malformed field-class input returns HTTP `400` with `error: validation_failed` and field-level `errors`; legacy endpoint-specific validation payloads remain in place where domain handlers already expose them.
+
 ??? example "Detailed Codex Breakdown"
 
     ### API endpoints

--- a/Docs/Reference/ui-and-notifications.md
+++ b/Docs/Reference/ui-and-notifications.md
@@ -17,6 +17,11 @@ Treat this document as the single source of truth for Borealis WebUI design rule
 - Alerts queue: `Data/Engine/Containers/webui-frontend/data/web-interface/src/Alerting/Active_Alerts.jsx`.
 - Page style template reference: `Data/Engine/Containers/webui-frontend/data/web-interface/src/DevTools/Page_Style_Template.jsx` (layout only).
 
+## Input Validation
+WebUI text fields and Engine APIs use field-class validation. Plain labels and descriptions are trimmed and normalized, while code, secrets, JSON, LDAP filters, regex patterns, registry data, and remote paths keep meaningful syntax and receive context-specific checks.
+
+New forms should validate before submit and expect the API to enforce the same rule again. Validation failures return `validation_failed` with field-level messages where shared helpers handle the request.
+
 ## Operator Bootstrap Gate
 - Borealis now resolves `/api/bootstrap/state` before it attempts `/api/auth/me` or renders the normal login form.
 - Bootstrap phases are:
@@ -140,6 +145,14 @@ Treat this document as the single source of truth for Borealis WebUI design rule
     - [Software Icon Overrides](software-icon-overrides.md)
     - [Software Uninstall Overrides](software-uninstall-overrides.md)
     - [Software Uninstall Blocklist](software-uninstall-blocklist.md)
+
+    ### Input validation source map
+
+    - WebUI shared helper: `Data/Engine/Containers/webui-frontend/data/web-interface/src/app/utils/inputValidation.js`.
+    - WebUI runtime guard: `Data/Engine/Containers/webui-frontend/data/web-interface/src/app/runtime/bootstrapClientRuntime.js` installs same-origin `/api/*` fetch validation before route rendering.
+    - Go API helper: `Data/Engine/Containers/api-backend/cmd/api-backend/input_validation.go` owns public request path/query validation, bounded map decoders, field-class validators, and `validation_failed` payloads.
+    - Field classes: plain single-line, plain multiline, identifier/ref, slug, host/IP/CIDR, URL, remote path, registry path/value name, regex, secret, and code/content.
+    - Preserve syntax for scripts, CodeMirror content, JSON, passwords, Aegis Cipher, private keys, LDAP DNs/filters, command arguments, registry value data, regex, and remote paths. Apply size, UTF-8, NUL/control, parse, enum, or domain-specific validation instead of generic stripping.
 
     ### Shared Conventions (Full)
     - Cross-cutting guidance that applies to both Agent and Engine work.

--- a/Docs/Reference/ui-and-notifications.md
+++ b/Docs/Reference/ui-and-notifications.md
@@ -18,7 +18,7 @@ Treat this document as the single source of truth for Borealis WebUI design rule
 - Page style template reference: `Data/Engine/Containers/webui-frontend/data/web-interface/src/DevTools/Page_Style_Template.jsx` (layout only).
 
 ## Input Validation
-WebUI text fields and Engine APIs use field-class validation. Plain labels and descriptions are trimmed and normalized, while code, secrets, JSON, LDAP filters, regex patterns, registry data, and remote paths keep meaningful syntax and receive context-specific checks.
+WebUI text fields and Engine APIs use field-class validation. Plain labels and descriptions are trimmed and normalized, while code, secrets, JSON, LDAP filters, regex patterns, registry data, remote paths, and WebAuthn passkey credential JSON keep meaningful syntax and receive context-specific checks.
 
 New forms should validate before submit and expect the API to enforce the same rule again. Validation failures return `validation_failed` with field-level messages where shared helpers handle the request.
 
@@ -152,7 +152,7 @@ New forms should validate before submit and expect the API to enforce the same r
     - WebUI runtime guard: `Data/Engine/Containers/webui-frontend/data/web-interface/src/app/runtime/bootstrapClientRuntime.js` installs same-origin `/api/*` fetch validation before route rendering.
     - Go API helper: `Data/Engine/Containers/api-backend/cmd/api-backend/input_validation.go` owns public request path/query validation, bounded map decoders, field-class validators, and `validation_failed` payloads.
     - Field classes: plain single-line, plain multiline, identifier/ref, slug, host/IP/CIDR, URL, remote path, registry path/value name, regex, secret, and code/content.
-    - Preserve syntax for scripts, CodeMirror content, JSON, passwords, Aegis Cipher, private keys, LDAP DNs/filters, command arguments, registry value data, regex, and remote paths. Apply size, UTF-8, NUL/control, parse, enum, or domain-specific validation instead of generic stripping.
+    - Preserve syntax for scripts, CodeMirror content, JSON, passwords, Aegis Cipher, private keys, LDAP DNs/filters, command arguments, registry value data, regex, remote paths, and WebAuthn/passkey credential JSON. Apply size, UTF-8, NUL/control, parse, enum, or domain-specific validation instead of generic stripping.
 
     ### Shared Conventions (Full)
     - Cross-cutting guidance that applies to both Agent and Engine work.


### PR DESCRIPTION
## Issue Goal

Closes #424.

- Expected behavior: WebUI validates and sanitizes text fields by field class while Engine public APIs reject malformed or potentially malicious payloads server-side.
- Affected subsystem: Engine Go API, WebUI request/runtime guard, API output safety, docs.
- Relevant docs: AGENTS.md, Docs/index.md, UI and Notifications, API Reference, Engine Runtime, Unit Testing, Security Whitepaper.
- Validation: Go API package tests passed; focused Engine lanes attempted; WebUI lane blocked by missing runtime cache.
- Docs/SBOM/debt impact: AGENTS.md plus UI/API docs updated; no SBOM update because no third-party dependency added.

## Implementation

- Adds shared Engine input validation for public `/api/*` path/query/body handling, excluding `/api/internal/*` and `/api/server/k3s/operator`.
- Adds field-class validators for plain text, identifiers, slugs, host/IP/CIDR, URLs, paths, registry values, regex, secrets, and code/content.
- Wires validation-aware limited JSON map decoding across public Engine handler groups, with transport-only validation for rich assembly documents, agent inventory payloads, and WebAuthn/passkey credential verify payloads.
- Adds WebUI fetch guard and validation helper, plus tests for sanitization, same-origin API blocking, host/CIDR validation, opaque passkey verify payloads, and notification bold-tag preservation.
- Escapes user-controlled Prism/highlight fallbacks before `dangerouslySetInnerHTML`.

## Validation

- PASS: `cd Data/Engine/Containers/api-backend && /opt/Borealis/Dependencies/Go/go1.25.12/bin/go test ./cmd/api-backend`
- PASS: `git diff --check`
- BLOCKED: `./Engine_Unit_Tests.sh --domain access` and `--domain files` and `--domain scheduler` because `/usr/bin/python3` has no `pytest`.
- BLOCKED: `./Engine_Unit_Tests.sh --domain devices` and `--domain watchdogs` because no matching Engine Python tests exist under `Data/Engine/Unit_Tests`.
- BLOCKED: `./Engine_Unit_Tests.sh --domain webui` because runtime unit tests are missing at `/opt/Borealis/Engine/Services/webui-frontend/cache/web-interface/Unit_Tests`. Latest rerun: `/opt/Borealis/Unit_Test_Results/engine-20260804T212902Z/engine-webui-vitest.log`.
- NOT RUN: full `./Engine_Unit_Tests.sh`; current focused lanes show local blockers that would make full lane fail before adding signal.
