### PR TITLE
issue/move-docs-site-files

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
     paths:
       - "Docs/**"
-      - "zensical.toml"
       - ".github/workflows/pages.yml"
   workflow_dispatch:
 
@@ -39,21 +38,21 @@ jobs:
 
       - name: Prune Pages artifact
         run: |
-          find site -type f \( \
+          find Docs/site -type f \( \
             -iname '*.psd' -o \
             -iname '*.psb' -o \
             -iname '*.xcf' -o \
             -iname '*.ai' -o \
             -iname '*.sketch' \
           \) -delete
-          du -sh site
-          find site -type f -printf '%s\t%p\n' | sort -nr | head -40
+          du -sh Docs/site
+          find Docs/site -type f -printf '%s\t%p\n' | sort -nr | head -40
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5
         timeout-minutes: 5
         with:
-          path: site
+          path: Docs/site
 
   deploy:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,4 @@ __pycache__
 .pytest_cache/
 Unit_Test_Results/
 Updater.log
-/site/
+/Docs/site/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,7 @@ Keep in mind that admonitions require correct indentation, otherwise they will b
 * Keep screenshots on `Docs/screenshots.md` by default.
 * Landing pages may carry one high-signal screenshot.
 * Topic pages should stay screenshot-free unless operator intentionally adds one.
-* Do not manually maintain page navigation in `zensical.toml`.  Zensical handles this automatically on its own.
+* Do not manually maintain page navigation in `Docs/zensical.toml`.  Zensical handles this automatically on its own.
 * Zensical auto-discovers Markdown folders and pages from `Docs/`; place pages in correct folder and use `index.md` for folder landing pages.
 
 ## Interacting with Codebase

--- a/Docs/index.md
+++ b/Docs/index.md
@@ -71,7 +71,7 @@ Deploy the Borealis Engine to a Linux host via the [Engine Deployment](Engine/de
     Authoring rules:
 
     - Keep new documentation inside closest domain folder.
-    - Do not manually add pages to `../zensical.toml`; Zensical discovers Markdown files from `Docs/`.
+    - Do not manually add pages to `Docs/zensical.toml`; Zensical discovers Markdown files from `Docs/`.
     - Use ASCII unless existing file already uses Unicode.
     - Avoid duplicating long source code; link to files and summarize behavior.
     - Document UI and backend components together when both change.

--- a/Docs/zensical.toml
+++ b/Docs/zensical.toml
@@ -6,7 +6,7 @@ site_url = "https://bunny-lab-io.github.io/Borealis/"
 repo_url = "https://github.com/bunny-lab-io/Borealis"
 repo_name = "bunny-lab-io/Borealis"
 edit_uri = "edit/main/Docs/"
-docs_dir = "Docs"
+docs_dir = "."
 site_dir = "site"
 extra_css = ["stylesheets/extra.css"]
 

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -18,7 +18,7 @@ Repository commands below own deterministic correctness rules. GitHub Actions se
 | `./Tests/run-docs.sh` | Pinned clean Zensical strict build | Python 3 and venv |
 | `./Tests/run-all.sh` | All normal portable lanes | Combined prerequisites above |
 
-Set `BOREALIS_DOCKER_USE_SUDO=1` where local Docker socket requires sudo. Results, virtual environments, caches, compiled output, and reports stay under ignored `Unit_Test_Results/`, temporary workspaces, or ignored `site/`.
+Set `BOREALIS_DOCKER_USE_SUDO=1` where local Docker socket requires sudo. Results, virtual environments, caches, compiled output, and reports stay under ignored `Unit_Test_Results/`, temporary workspaces, or ignored `Docs/site/`.
 
 ## Path-to-Gate Behavior
 

--- a/Tests/manifests/ci-paths.json
+++ b/Tests/manifests/ci-paths.json
@@ -84,7 +84,7 @@
   ],
   "docs": [
     "Docs/**",
-    "zensical.toml",
+    "Docs/zensical.toml",
     "Tests/run-docs.sh",
     "Tests/README.md",
     "Tests/requirements-docs.txt",

--- a/Tests/policy/check_docs_references.py
+++ b/Tests/policy/check_docs_references.py
@@ -26,7 +26,7 @@ SOURCE_SECTION = re.compile(
 NEXT_SECTION = re.compile(r"^\s*### ")
 BACKTICK = re.compile(r"`([^`]+)`")
 SOURCE_PREFIXES = ("Data/", "Tests/", ".github/")
-SOURCE_FILES = {"AGENTS.md", "Engine.sh", "Engine_Unit_Tests.sh", "zensical.toml"}
+SOURCE_FILES = {"AGENTS.md", "Engine.sh", "Engine_Unit_Tests.sh", "Docs/zensical.toml"}
 
 
 def fail(message: str, failures: list[str]) -> None:

--- a/Tests/run-docs.sh
+++ b/Tests/run-docs.sh
@@ -20,16 +20,17 @@ run_timed "${TIMEOUT_SECONDS}" "${VENV_DIR}/bin/python" -m pip install \
   >"${RESULT_DIR}/dependency-install.log" 2>&1
 
 printf '==> Strict Zensical build\n'
-run_timed "${TIMEOUT_SECONDS}" "${VENV_DIR}/bin/zensical" build --clean --strict \
+run_timed "${TIMEOUT_SECONDS}" "${VENV_DIR}/bin/zensical" build \
+  --config-file "${REPO_ROOT}/Docs/zensical.toml" --clean --strict \
   >"${RESULT_DIR}/zensical-build.log" 2>&1
 
-find "${REPO_ROOT}/site" -type f \( \
+find "${REPO_ROOT}/Docs/site" -type f \( \
   -iname '*.psd' -o -iname '*.psb' -o -iname '*.xcf' -o \
   -iname '*.ai' -o -iname '*.sketch' \
 \) -delete
 
-[[ -f "${REPO_ROOT}/site/index.html" ]] || {
-  printf 'DOCS FAIL: strict build lacks site/index.html.\n' >&2
+[[ -f "${REPO_ROOT}/Docs/site/index.html" ]] || {
+  printf 'DOCS FAIL: strict build lacks Docs/site/index.html.\n' >&2
   exit 1
 }
 printf 'Documentation validation passed. Results: %s\n' "${RESULT_DIR}"


### PR DESCRIPTION
Closes #443

## Summary
- Move `zensical.toml` from repository root to `Docs/zensical.toml`.
- Move generated site output from `site/` to ignored `Docs/site/`.
- Update GitHub Pages artifact paths, docs runner, CI path inventory, policy references, and documentation.
- Preserve Vite Dev HMR workspace/runtime behavior; no WebUI runtime source changed and no Engine redeploy ran.

## Validation
- `./Tests/run-docs.sh` — passed locally
- `python3 Tests/policy/check_data_files.py` — passed locally
- `python3 Tests/policy/check_docs_references.py` — passed locally
- `python3 -m unittest discover -s Tests/Unit_Tests -p 'test_*.py'` — 15 passed locally\n- `./Tests/run-repository-policy.sh` — local prerequisite stop: host lacks `node`; same lane passed in CI\n- PR Validation / required — passed\n- CodeQL — passed