### PR TITLE
issue/cluster-node-manager-token-permissions

### DIFF
--- a/Data/Engine/Containers/api-backend/cmd/borealis-node-manager/main.go
+++ b/Data/Engine/Containers/api-backend/cmd/borealis-node-manager/main.go
@@ -2018,15 +2018,7 @@ func installLocalNodeManagerService(repoRoot string) error {
 	if err := os.Chown(filepath.Dir(defaultSecretPath), 0, 0); err != nil {
 		return err
 	}
-	if _, err := os.Stat(defaultSecretPath); errors.Is(err, os.ErrNotExist) {
-		token := make([]byte, 32)
-		if _, err := rand.Read(token); err != nil {
-			return err
-		}
-		if err := os.WriteFile(defaultSecretPath, []byte(hex.EncodeToString(token)+"\n"), 0o640); err != nil {
-			return err
-		}
-	} else if err != nil {
+	if err := ensureNodeManagerToken(defaultSecretPath); err != nil {
 		return err
 	}
 	if err := os.Chown(defaultSecretPath, 0, actionRuntimeID); err != nil {
@@ -2091,6 +2083,23 @@ func replaceExecutable(destination string, content []byte) error {
 		return err
 	}
 	return os.Rename(temporaryPath, destination)
+}
+
+func ensureNodeManagerToken(path string) error {
+	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+		token := make([]byte, 32)
+		if _, err := rand.Read(token); err != nil {
+			return err
+		}
+		if err := os.WriteFile(path, []byte(hex.EncodeToString(token)+"\n"), 0o640); err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	}
+	// Creation modes are filtered by umask. Action Jobs need group read even
+	// when installation runs with umask 077 or repairs an existing token.
+	return os.Chmod(path, 0o640)
 }
 
 func ensureSecureDirectory(path string) error {

--- a/Data/Engine/Containers/api-backend/cmd/borealis-node-manager/token_permissions_linux_test.go
+++ b/Data/Engine/Containers/api-backend/cmd/borealis-node-manager/token_permissions_linux_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"encoding/hex"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func TestNodeManagerTokenPermissionsUnderRestrictiveUmask(t *testing.T) {
+	const childMarker = "BOREALIS_TEST_NODE_MANAGER_TOKEN_UMASK"
+	if os.Getenv(childMarker) != "1" {
+		// umask is process-wide; isolate it from parallel tests and the race lane.
+		cmd := exec.Command(os.Args[0], "-test.run=^TestNodeManagerTokenPermissionsUnderRestrictiveUmask$")
+		cmd.Env = append(os.Environ(), childMarker+"=1")
+		if output, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("restrictive-umask subprocess: %v\n%s", err, output)
+		}
+		return
+	}
+	oldMask := syscall.Umask(0o077)
+	defer syscall.Umask(oldMask)
+	for _, test := range []struct {
+		name string
+		mode os.FileMode
+	}{
+		{name: "new"},
+		{name: "root_only", mode: 0o600},
+		{name: "group_read", mode: 0o640},
+		{name: "world_read", mode: 0o644},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "node-manager.token")
+			var previous []byte
+			if test.mode != 0 {
+				previous = []byte(strings.Repeat("a", 64) + "\n")
+				if err := os.WriteFile(path, previous, test.mode); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Chmod(path, test.mode); err != nil {
+					t.Fatal(err)
+				}
+			}
+			for attempt := 0; attempt < 2; attempt++ {
+				if err := ensureNodeManagerToken(path); err != nil {
+					t.Fatal(err)
+				}
+				info, err := os.Stat(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if info.Mode().Perm() != 0o640 {
+					t.Fatalf("token mode = %o, want owner read/write and group read only", info.Mode().Perm())
+				}
+				current, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				decoded, err := hex.DecodeString(strings.TrimSpace(string(current)))
+				if err != nil || len(decoded) != 32 {
+					t.Fatal("token must contain 32 hex-encoded random bytes")
+				}
+				if previous != nil && !bytes.Equal(previous, current) {
+					t.Fatal("permission reconciliation rotated existing token")
+				}
+				previous = current
+			}
+		})
+	}
+}

--- a/Docs/Engine/managing-engine-clusters.md
+++ b/Docs/Engine/managing-engine-clusters.md
@@ -141,6 +141,8 @@ Optional `--k3s-server`, `--k3s-version`, and `--peer-cidrs` flags assert expect
 
 Normal `1 -> 3` expansion requires a complete pair of joining nodes.  Temporary even K3s membership during pair admission does not disable healthy existing nodes.
 
+Joining hosts may use a restrictive administrator umask. The node-manager installer preserves its existing authentication token and restores the group access required by cluster action Jobs.
+
 After approval, members remain application-drained and role-ineligible while Borealis:
 
 * Runs probe conformance pinned to each joining node
@@ -758,6 +760,7 @@ sudo k3s kubectl -n borealis create configmap borealis-aegis-trust \
 - The WebUI therefore reroutes drained-node "**Exit Maintenance Mode**" during isolation to `/hmr/exit` after an explicit warning and `EXIT HMR`; the controller restores full pinned-production placement.
 - Completion preserves `2/3` quorum degradation and remaining database degradation.  Verified three-node recovery returns Healthy only when no recorded active node remains drained.
 - The node manager accepts fixed verbs only, including persistent K3s membership fence, exact-version probe conformance, drained application preparation, and `RunSchemaPhase` limited to `expand|finalize` plus the recorded target SHA.
+- `installLocalNodeManagerService` retains the authentication token at `/etc/borealis/node-manager.token`, normalizes mode `0640` through `ensureNodeManagerToken`, and assigns owner/group `root:64646`. Explicit chmod is required because `os.WriteFile` creation mode is filtered by caller umask and does not repair existing modes. Action Jobs remain UID/GID `64646`; root-only `0600` breaks their read-only token mount. Linux filesystem regression covers fresh creation and retained tokens under umask `077`, exact group-read permissions, removal of world access, and no rotation on rerun. For an older affected lab installation, verify root ownership and group `64646`, restore mode `0640` on that file only, then retry the same failed admission through Cluster Management; do not run action Jobs as root or grant world access. Tracked in #509.
 - Preparation scales named node workloads and waits for rollouts without changing `borealis.io/application-state`.
 - Operation retry also accepts an already-active state because an earlier attempt may have completed activation before a later step failed.  Any other state still fails closed.
 - Only final activation clears drain after controller health gates.


### PR DESCRIPTION
Fresh joins launched with `umask 077` created a root-only node-manager token, so non-root cluster action Jobs failed authentication before probe conformance. Installer now normalizes mode0640 for both new and retained tokens while preserving token bytes and existing root:64646 ownership contract. Action Jobs retain UID/GID64646 and read-only token mount.

Linux filesystem regression isolates restrictive umask in a subprocess and checks fresh creation, existing0600/0640/0644 modes, removal of world access, and repeat installation without token rotation. Canonical cluster guidance records normal behavior and older-install recovery.

Validation:
- Focused restrictive-umask regression passed.
- Full `BOREALIS_GO_BIN=/opt/Borealis/Dependencies/Go/go1.25.12/bin/go bash Tests/run-engine-go.sh` passed: format, tidy, vet, tests, runtime builds, cutover and204-route policies.
- `bash Tests/run-docs.sh`, documentation references and `git diff --check` passed.
- [CI34035025784](https://github.com/bunny-lab-io/Borealis/actions/runs/34035025784) passed repository policy, full Engine Go with CGO_ENABLED=1/BOREALIS_ENGINE_GO_RACE=1, K3s, strict docs and real api-backend/borealis-operator image builds at exacteacda5021. [CodeQL34035023971](https://github.com/bunny-lab-io/Borealis/actions/runs/34035023971) passed. PostgreSQL and unrelated lanes were correctly unselected; no database code changed. Local repository policy unavailable because Node.js absent; remote policy supplies that evidence.
- Live baseline lab repair of exact file mode on engine-02/03 let retry of operation c13c7396-3e60-45e2-8223-4315a37b85d6 authenticate and execute real probe trials. Admission attempt2 stopped on separate trial6/10 conformance observation failure. One bounded diagnostic rerun of original unchanged script passed10/10; independently captured all10 transient volumes show required initial liveness failure, replacement startup failure and no early replacement liveness. Admission attempt3 now runs original controller gates. This PR does not claim admission or MVP qualification.

Fixes #509. Child of #493, discovered during H03 #466/#499 prerequisite setup; keep umbrella and H03 open. No schema, public API, dependency, or credential value change.
