### PR TITLE
issue/cluster-node-build-prerequisites

### DIFF
--- a/Docs/Engine/managing-engine-clusters.md
+++ b/Docs/Engine/managing-engine-clusters.md
@@ -121,7 +121,9 @@ sudo borealis-node-manager join \
   --k3s-token-file /root/borealis-k3s-server.token
 ```
 
-The endpoint must use HTTPS and must not redirect. Use `--ca-file /path/to/engine-ca.pem` when the Engine certificate uses a private CA. The node manager submits its identity and waits for approval before preparing the firewall, iSCSI, NFSv4, and K3s host prerequisites. It checks approval again before joining K3s.
+The endpoint must use HTTPS and must not redirect. Use `--ca-file /path/to/engine-ca.pem` when the Engine certificate uses a private CA. The node manager submits its identity and waits for approval before preparing the host. Preparation creates the Borealis runtime account, installs missing Python and Docker build dependencies, verifies Docker access, and prepares the firewall, iSCSI, NFSv4, and K3s prerequisites. It checks approval again before joining K3s.
+
+Preparation can take several minutes on a fresh host. If account creation, package installation, or Docker checks fail, repair the reported host prerequisite and resume the same join command. Preparation does not create a standalone Engine or database.
 
 Invitation join creates a `Pending Quorum` admission and waits for Admin approval.  AMD64 architecture, Ubuntu version, hostname, node name, management IPv4, invitation lifetime, and invitation authentication are validated before membership work begins.
 
@@ -785,6 +787,7 @@ sudo k3s kubectl -n borealis create configmap borealis-aegis-trust \
 - Initial unconsumed/pending invitation expiry remains 15 minutes; signed accepted-join access and stored creation timestamp impose a 24-hour bound for approved/admitted/recovery targets. Admin renewal swaps only the original admission's invitation binding and revokes previous access.
 - Approval and original-operation retry pin `join_config` from `cluster_state.control_plane_vip`, `config_json.k3s_version`, active member addresses and the selected admission cohort. Exactly three private IPv4 peers are required. Client flags can assert those settings but cannot override them.
 - The node manager validates settings, runs fixed `Engine.sh --cluster-prepare-node` only after approval, then rechecks approval/configuration before installing K3s. Preparation may outlast initial invitation lifetime without consuming an unapproved invitation.
+- The root-only preparation entrypoint runs `ensure_cluster_node_host_dependencies` before writing join configuration or firewall state. It reuses the normal deployment identity and dependency helpers, including UID/GID collision checks and Docker daemon verification. Required account/package changes finish before the installed node-manager service runs with `ProtectSystem=strict`; do not grant that service write access to `/etc/passwd` or package-manager paths. Existing prepared hosts retain their identity and skip unnecessary package installation. See [Engine launch mechanics](deploying-the-engine.md#launch-mechanics) for the shared deployment contract.
 - Controller reconciliation requires current lease ownership. Expired pending records release capacity only without approval, operation or non-removed member evidence. Failed/cancelled membership operations mark approved admissions `Recovery Required`; retry retains the original cohort and operation. No schema or automatic member deletion is involved.
 - Expansion-pair approval records the same authenticated approval event for both admission IDs so both waiting joiners proceed.
 - Degraded-quorum replacement records the same compatible approval event for one admission.

--- a/Engine.sh
+++ b/Engine.sh
@@ -11647,15 +11647,22 @@ PY
   ensure_cluster_controller_baseline
 }
 
+ensure_cluster_node_host_dependencies() {
+  ensure_systemctl_for_k3s
+  # Account and package changes must finish outside the node-manager sandbox.
+  ensure_engine_runtime_identity
+  ensure_engine_dependencies
+  ensure_k3s_install_dependencies
+  ensure_longhorn_node_dependencies
+}
+
 cluster_prepare_node() {
   [[ "${EUID:-$(id -u)}" -eq 0 ]] || die "Cluster node preparation requires root."
   [[ -n "${K3S_PEER_CIDRS}" ]] || die "Cluster node preparation requires BOREALIS_K3S_PEER_CIDRS covering every current and planned Engine node."
   mkdir -p "${DEPLOY_DIR}"
   touch "${BUILD_LOG}"
   validate_k3s_baseline_settings
-  ensure_systemctl_for_k3s
-  ensure_k3s_install_dependencies
-  ensure_longhorn_node_dependencies
+  ensure_cluster_node_host_dependencies
   write_k3s_borealis_config >/dev/null || true
   write_k3s_registries_config >/dev/null || true
   ensure_k3s_api_firewall

--- a/Engine.sh
+++ b/Engine.sh
@@ -11652,6 +11652,7 @@ ensure_cluster_node_host_dependencies() {
   # Account and package changes must finish outside the node-manager sandbox.
   ensure_engine_runtime_identity
   ensure_engine_dependencies
+  validate_k3s_baseline_settings
   ensure_k3s_install_dependencies
   ensure_longhorn_node_dependencies
 }
@@ -11661,7 +11662,6 @@ cluster_prepare_node() {
   [[ -n "${K3S_PEER_CIDRS}" ]] || die "Cluster node preparation requires BOREALIS_K3S_PEER_CIDRS covering every current and planned Engine node."
   mkdir -p "${DEPLOY_DIR}"
   touch "${BUILD_LOG}"
-  validate_k3s_baseline_settings
   ensure_cluster_node_host_dependencies
   write_k3s_borealis_config >/dev/null || true
   write_k3s_registries_config >/dev/null || true

--- a/Tests/Unit_Tests/test_engine_cluster_recovery.py
+++ b/Tests/Unit_Tests/test_engine_cluster_recovery.py
@@ -30,11 +30,13 @@ class EngineClusterRecoveryTests(unittest.TestCase):
         )
 
     def test_join_preparation_provisions_identity_and_build_dependencies(self):
-        for case in ("fresh", "existing", "joined_group", "uid_collision", "package_failure", "docker_unreachable"):
+        for case in ("fresh", "existing", "joined_group", "missing_python", "uid_collision", "package_failure", "docker_unreachable"):
             with self.subTest(case=case), tempfile.TemporaryDirectory() as temp_dir:
                 root = pathlib.Path(temp_dir)
                 for name in ("passwd", "group", "calls"):
                     (root / name).touch()
+                if case != "missing_python":
+                    (root / "python3").touch()
                 if case in ("existing", "joined_group"):
                     (root / "group").write_text("borealis-engine:x:64646:\n")
                 if case == "existing":
@@ -48,6 +50,7 @@ ENGINE_RUNTIME_USER=borealis-engine
 ENGINE_RUNTIME_GROUP=borealis-engine
 ENGINE_RUNTIME_UID=64646
 ENGINE_RUNTIME_GID=64646
+K3S_PEER_CIDRS=192.168.50.0/24
 getent() {
   local db="$1" name="${2:-}"
   awk -F: -v name="$name" 'name == "" || $1 == name' "$BOREALIS_TEST_STATE/$db"
@@ -65,7 +68,8 @@ run_privileged() {
 }
 command_exists() {
   case "$1" in
-    systemctl|python3) return 0 ;;
+    systemctl) return 0 ;;
+    python3) [[ -e "$BOREALIS_TEST_STATE/python3" ]] ;;
     docker) [[ -e "$BOREALIS_TEST_STATE/docker" ]] ;;
     *) return 92 ;;
   esac
@@ -75,6 +79,11 @@ install_engine_apt_dependencies() {
   printf 'INSTALL PACKAGES\n' >>"$BOREALIS_TEST_STATE/calls"
   [[ "$BOREALIS_TEST_CASE" != package_failure ]] || return 73
   : >"$BOREALIS_TEST_STATE/docker"
+  : >"$BOREALIS_TEST_STATE/python3"
+}
+python3() {
+  [[ -e "$BOREALIS_TEST_STATE/python3" ]] || return 127
+  command python3 "$@"
 }
 docker() {
   [[ "$1" == info && -e "$BOREALIS_TEST_STATE/docker" && "$BOREALIS_TEST_CASE" != docker_unreachable ]]
@@ -88,7 +97,7 @@ printf 'HOST READY\n'
                     extra_env={"BOREALIS_TEST_STATE": str(root), "BOREALIS_TEST_CASE": case},
                 )
                 calls = (root / "calls").read_text()
-                if case in ("fresh", "existing", "joined_group"):
+                if case in ("fresh", "existing", "joined_group", "missing_python"):
                     self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
                     self.assertIn("HOST READY", result.stdout)
                     self.assertIn("borealis-engine:x:64646:64646:", (root / "passwd").read_text())

--- a/Tests/Unit_Tests/test_engine_cluster_recovery.py
+++ b/Tests/Unit_Tests/test_engine_cluster_recovery.py
@@ -29,6 +29,92 @@ class EngineClusterRecoveryTests(unittest.TestCase):
             check=False,
         )
 
+    def test_join_preparation_provisions_identity_and_build_dependencies(self):
+        for case in ("fresh", "existing", "joined_group", "uid_collision", "package_failure", "docker_unreachable"):
+            with self.subTest(case=case), tempfile.TemporaryDirectory() as temp_dir:
+                root = pathlib.Path(temp_dir)
+                for name in ("passwd", "group", "calls"):
+                    (root / name).touch()
+                if case in ("existing", "joined_group"):
+                    (root / "group").write_text("borealis-engine:x:64646:\n")
+                if case == "existing":
+                    (root / "passwd").write_text("borealis-engine:x:64646:64646::/nonexistent:/usr/sbin/nologin\n")
+                    (root / "docker").touch()
+                if case == "uid_collision":
+                    (root / "passwd").write_text("foreign-user:x:64646:1000::/home/foreign:/bin/bash\n")
+                result = self.run_engine_library(
+                    r'''
+ENGINE_RUNTIME_USER=borealis-engine
+ENGINE_RUNTIME_GROUP=borealis-engine
+ENGINE_RUNTIME_UID=64646
+ENGINE_RUNTIME_GID=64646
+getent() {
+  local db="$1" name="${2:-}"
+  awk -F: -v name="$name" 'name == "" || $1 == name' "$BOREALIS_TEST_STATE/$db"
+}
+groupadd() { printf '%s\n' '--key'; }
+useradd() { printf '%s\n' '--key'; }
+run_privileged() {
+  printf '%s\n' "$*" >>"$BOREALIS_TEST_STATE/calls"
+  case "$1" in
+    groupadd) printf 'borealis-engine:x:64646:\n' >>"$BOREALIS_TEST_STATE/group" ;;
+    useradd) printf 'borealis-engine:x:64646:64646::/nonexistent:/usr/sbin/nologin\n' >>"$BOREALIS_TEST_STATE/passwd" ;;
+    systemctl) return 0 ;;
+    *) return 91 ;;
+  esac
+}
+command_exists() {
+  case "$1" in
+    systemctl|python3) return 0 ;;
+    docker) [[ -e "$BOREALIS_TEST_STATE/docker" ]] ;;
+    *) return 92 ;;
+  esac
+}
+detect_distro() { DISTRO_ID=ubuntu; }
+install_engine_apt_dependencies() {
+  printf 'INSTALL PACKAGES\n' >>"$BOREALIS_TEST_STATE/calls"
+  [[ "$BOREALIS_TEST_CASE" != package_failure ]] || return 73
+  : >"$BOREALIS_TEST_STATE/docker"
+}
+docker() {
+  [[ "$1" == info && -e "$BOREALIS_TEST_STATE/docker" && "$BOREALIS_TEST_CASE" != docker_unreachable ]]
+}
+systemctl() { return 1; }
+ensure_k3s_install_dependencies() { printf 'K3S PREREQUISITES\n'; }
+ensure_longhorn_node_dependencies() { printf 'STORAGE PREREQUISITES\n'; }
+ensure_cluster_node_host_dependencies
+printf 'HOST READY\n'
+''',
+                    extra_env={"BOREALIS_TEST_STATE": str(root), "BOREALIS_TEST_CASE": case},
+                )
+                calls = (root / "calls").read_text()
+                if case in ("fresh", "existing", "joined_group"):
+                    self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                    self.assertIn("HOST READY", result.stdout)
+                    self.assertIn("borealis-engine:x:64646:64646:", (root / "passwd").read_text())
+                    if case == "existing":
+                        self.assertNotIn("useradd", calls)
+                        self.assertNotIn("groupadd", calls)
+                        self.assertNotIn("INSTALL PACKAGES", calls)
+                    else:
+                        self.assertIn("--no-create-home", calls)
+                        self.assertIn("INSTALL PACKAGES", calls)
+                        if case == "joined_group":
+                            self.assertNotIn("groupadd", calls)
+                else:
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertNotIn("HOST READY", result.stdout)
+                    self.assertNotIn("K3S PREREQUISITES", result.stdout)
+                    self.assertNotIn("STORAGE PREREQUISITES", result.stdout)
+                    if case == "uid_collision":
+                        self.assertIn("already belongs to foreign-user", result.stderr)
+                        self.assertNotIn("useradd", calls)
+                        self.assertNotIn("INSTALL PACKAGES", calls)
+                    elif case == "package_failure":
+                        self.assertEqual(result.returncode, 73)
+                    else:
+                        self.assertIn("Docker daemon unreachable", result.stderr)
+
     def test_engine_redeploy_preserves_newer_installed_k3s(self):
         result = self.run_engine_library(
             r'''

--- a/Tests/policy/check_k3s_manifests.py
+++ b/Tests/policy/check_k3s_manifests.py
@@ -767,6 +767,7 @@ def validate_k3s_peer_allowlist_contract() -> None:
         'Cluster runtime environment is missing BOREALIS_K3S_PEER_CIDRS.': "fail-closed cluster node redeploy",
         'networks.append(str(network))': "canonical private CIDR normalization",
         'cluster_prepare_node()': "fixed blank-node preparation entrypoint",
+        '  touch "${BUILD_LOG}"\n  ensure_cluster_node_host_dependencies': "dependency bootstrap before Python-backed CIDR validation",
         '  ensure_cluster_node_host_dependencies\n  write_k3s_borealis_config >/dev/null || true\n  write_k3s_registries_config >/dev/null || true\n  ensure_k3s_api_firewall\n  printf \'Cluster node host preparation complete.': "blank-node dependencies, Spegel, and firewall preparation",
         'Engine.sh --cluster-prepare-node': "documented fixed node preparation command",
     }

--- a/Tests/policy/check_k3s_manifests.py
+++ b/Tests/policy/check_k3s_manifests.py
@@ -767,7 +767,7 @@ def validate_k3s_peer_allowlist_contract() -> None:
         'Cluster runtime environment is missing BOREALIS_K3S_PEER_CIDRS.': "fail-closed cluster node redeploy",
         'networks.append(str(network))': "canonical private CIDR normalization",
         'cluster_prepare_node()': "fixed blank-node preparation entrypoint",
-        '  ensure_longhorn_node_dependencies\n  write_k3s_borealis_config >/dev/null || true\n  write_k3s_registries_config >/dev/null || true\n  ensure_k3s_api_firewall\n  printf \'Cluster node host preparation complete.': "blank-node Longhorn, Spegel, and firewall preparation",
+        '  ensure_cluster_node_host_dependencies\n  write_k3s_borealis_config >/dev/null || true\n  write_k3s_registries_config >/dev/null || true\n  ensure_k3s_api_firewall\n  printf \'Cluster node host preparation complete.': "blank-node dependencies, Spegel, and firewall preparation",
         'Engine.sh --cluster-prepare-node': "documented fixed node preparation command",
     }
     for marker, description in required.items():


### PR DESCRIPTION
Fresh joining hosts reached sandboxed candidate deployment without Borealis runtime user or Docker, so first deployment failed trying to write `/etc/passwd`. Fixed root-only host preparation now provisions runtime identity and Engine build dependencies before K3s admission. Existing UID/GID collision checks and Docker verification remain enforced; node-manager keeps its filesystem sandbox.

Closes #511. F02 child of #493, discovered during H03 #466/#499 live prerequisites. Umbrella remains open.

Validation:
- Focused preparation regression covers fresh host, existing host, preexisting join group, UID collision, package failure and unreachable Docker; all pass. Repository Python suite:93 tests passed.
- Shell policy:34 files passed. Strict documentation, reference and SBOM policies passed. K3s policy passed. Final CI/CodeQL passed on f3534fc7c; review completed2026-09-06T17:27:11Z with no further findings. Python-bootstrap review thread addressed and resolved.
- Authorized lab recovery invoked the same existing identity/dependency helpers outside service sandbox on02/03; both completed0. Verified UID/GID64646, functioning Docker and Buildx, clean pinned checkouts. Admission retry4 passed both conformance gates and progressed past account creation, then exposed separate missing runtime configuration tracked in #513/#516. Completed Engine admission is not claimed.
- Full local repository policy unavailable because node is absent from PATH; required CI must pass before merge.

Canonical join guidance updated. No new dependency, schema migration or public API contract. Runtime remains pinned to older baseline; live helper repair does not claim deployment of this commit.

Review correction: Python-dependent peer validation now follows dependency installation; missing-Python regression exercises real CIDR parser after simulated installation. F02 scope passes; separate F03 configuration blocker remains open. Standing operator approval authorizes merge.
